### PR TITLE
Print thread dump on signal

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -6,6 +6,7 @@ import logging
 from Queue import Queue
 import sys
 import signal
+import threading
 import traceback
 
 import pinject
@@ -101,8 +102,9 @@ def init_k8s_client(config):
 def thread_dump_logger(log):
     def _dump_threads(signum, frame):
         log.info("Received signal %s, dumping thread stacks", signum)
-        for thread, frame in sys._current_frames().items():
-            log.info("Thread 0x%x" % thread)
+        thread_names = {t.ident: t.name for t in threading.enumerate()}
+        for thread_ident, frame in sys._current_frames().items():
+            log.info("Thread ident=0x%x name=%s", thread_ident, thread_names.get(thread_ident, "unknown"))
             log.info("".join(traceback.format_stack(frame)))
 
     return _dump_threads


### PR DESCRIPTION
I think this could be useful to troubleshoot issues where fiaas-deploy-daemon gets stuck. 
I just picked one of the user defined signals to trigger the thread dump, I'm not sure if it is the best one.