### PR TITLE
Log to inform users if the deployment will not proceed 

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -85,8 +85,8 @@ class DeploymentDeployer(object):
             try:
                 deployment = Deployment.get(app_spec.name, app_spec.namespace)
                 replicas = deployment.spec.replicas
-                LOG.warn("configured replica size (%d) for deployment is being ignored, as current running replica size"
-                         " is different (%d) for %s", deployment.spec.replicas, app_spec.replicas, app_spec.name)
+                LOG.info("Configured replica size (%d) for deployment is being ignored, as current running replica size"
+                         " is different (%d) for %s", app_spec.replicas, deployment.spec.replicas, app_spec.name)
             except NotFound:
                 pass
 

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -86,6 +86,8 @@ class DeploymentDeployer(object):
                 deployment = Deployment.get(app_spec.name, app_spec.namespace)
                 replicas = deployment.spec.replicas
             except NotFound:
+                LOG.warn("deployment not being scaled as autoscaler has been manually set to another value " +
+                         "for %s", app_spec.name)
                 pass
 
         deployment_strategy = DeploymentStrategy(

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -85,9 +85,9 @@ class DeploymentDeployer(object):
             try:
                 deployment = Deployment.get(app_spec.name, app_spec.namespace)
                 replicas = deployment.spec.replicas
+                LOG.warn("configured replica size (%d) for deployment is being ignored, as current running replica size"
+                         " is different (%d) for %s", deployment.spec.replicas, app_spec.replicas, app_spec.name)
             except NotFound:
-                LOG.warn("deployment not being scaled as autoscaler has been manually set to another value " +
-                         "for %s", app_spec.name)
                 pass
 
         deployment_strategy = DeploymentStrategy(


### PR DESCRIPTION
because auto-scaling was manually changed in the currently running application.

Please check that it does in fact log in the correct place, and that the message is clear enough.

Thanks!