### PR TITLE
Renamed datadog env var from 'API_KEY' to 'DD_API_KEY'

### DIFF
--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -190,7 +190,7 @@ In order to use DataDog in a namespace, a secret named `datadog` needs to be pro
 The container will get these environment variables set:
 
 * `DD_TAGS=app:<application name>,k8s_namespace:<kubernetes namespace>`
-* `API_KEY=<the "apikey" value from the "datadog" secret>`
+* `DD_API_KEY=<the "apikey" value from the "datadog" secret>`
 * `NON_LOCAL_TRAFFIC=false`
 * `DD_LOGS_STDOUT=yes`
 

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -40,7 +40,7 @@ class DataDog(object):
             imagePullPolicy="IfNotPresent",
             env=[
                 EnvVar(name="DD_TAGS", value=dd_tags),
-                EnvVar(name="API_KEY",
+                EnvVar(name="DD_API_KEY",
                        valueFrom=EnvVarSource(secretKeyRef=SecretKeySelector(name="datadog", key="apikey"))),
                 EnvVar(name="NON_LOCAL_TRAFFIC", value="false"),
                 EnvVar(name="DD_LOGS_STDOUT", value="yes"),

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_datadog.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_datadog.py
@@ -76,7 +76,7 @@ class TestDataDog(object):
                     'name': 'DD_TAGS',
                     'value': "a:1,app:{},b:2,k8s_namespace:{}".format(app_spec.name, app_spec.namespace)
                 },
-                {'name': 'API_KEY', 'valueFrom': {'secretKeyRef': {'name': 'datadog', 'key': 'apikey'}}},
+                {'name': 'DD_API_KEY', 'valueFrom': {'secretKeyRef': {'name': 'datadog', 'key': 'apikey'}}},
                 {'name': 'NON_LOCAL_TRAFFIC', 'value': 'false'},
                 {'name': 'DD_LOGS_STDOUT', 'value': 'yes'},
                 {'name': 'DD_EXPVAR_PORT', 'value': '42622'},

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
@@ -163,7 +163,7 @@ spec:
         env:
         - name: DD_TAGS
           value: app:v3-data-examples-full,k8s_namespace:default,tag1:value1,tag2:value2
-        - name: API_KEY
+        - name: DD_API_KEY
           valueFrom:
             secretKeyRef:
               name: datadog


### PR DESCRIPTION
Changed API Key format to enable compatiblity with Datadog v6 Agent. Should fix #20  as Datadog v5 agent can use both "old" and "new" name of env var for the API key.