### PR TITLE
Bump versions of dependencies, including changes in watch timeouts.

### DIFF
--- a/fiaas_deploy_daemon/crd/types.py
+++ b/fiaas_deploy_daemon/crd/types.py
@@ -22,7 +22,7 @@ class FiaasApplication(Model):
         watch_list_url_template = "/apis/fiaas.schibsted.io/v1/watch/namespaces/{namespace}/applications"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")
+    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")  # NOQA
     kind = Field(six.text_type, "Application")
 
     metadata = Field(ObjectMeta)
@@ -37,7 +37,7 @@ class FiaasApplicationStatus(Model):
         watch_list_url_template = "/apis/fiaas.schibsted.io/v1/watch/namespaces/{namespace}/application-statuses"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")
+    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")  # NOQA
     kind = Field(six.text_type, "ApplicationStatus")
 
     metadata = Field(ObjectMeta)

--- a/fiaas_deploy_daemon/tpr/types.py
+++ b/fiaas_deploy_daemon/tpr/types.py
@@ -22,7 +22,7 @@ class PaasbetaApplication(Model):
         watch_list_url_template = "/apis/schibsted.io/v1beta/watch/namespaces/{namespace}/paasbetaapplications"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "schibsted.io/v1beta")
+    apiVersion = Field(six.text_type, "schibsted.io/v1beta")  # NOQA
     kind = Field(six.text_type, "PaasbetaApplication")
 
     metadata = Field(ObjectMeta)
@@ -37,7 +37,7 @@ class PaasbetaStatus(Model):
         watch_list_url_template = "/apis/schibsted.io/v1beta/watch/namespaces/{namespace}/paasbetastatuses"
 
     # Workaround for https://github.com/kubernetes/kubernetes/issues/44182
-    apiVersion = Field(six.text_type, "schibsted.io/v1beta")
+    apiVersion = Field(six.text_type, "schibsted.io/v1beta")  # NOQA
     kind = Field(six.text_type, "PaasbetaStatus")
 
     metadata = Field(ObjectMeta)

--- a/setup.py
+++ b/setup.py
@@ -12,23 +12,23 @@ def read(filename):
 
 
 GENERIC_REQ = [
-    "ConfigArgParse == 0.12.0",
-    "prometheus_client == 0.3.1",
-    "PyYAML == 3.12",
-    "pyaml == 16.12.2",
-    "pinject == 0.10.2",
-    "six == 1.10.0",
-    "dnspython == 1.15.0",
-    "k8s == 0.11.0",
-    "monotonic == 1.3",
+    "ConfigArgParse == 0.14.0",
+    "prometheus_client == 0.7.1",
+    "PyYAML == 5.1.2",
+    "pyaml == 19.4.1",
+    "pinject == 0.14.1",
+    "six == 1.12.0",
+    "dnspython == 1.16.0",
+    "k8s == 0.12.0",
+    "monotonic == 1.5",
     "appdirs == 1.4.3",
-    "requests-toolbelt == 0.8.0",
-    "backoff == 1.6",
+    "requests-toolbelt == 0.9.1",
+    "backoff == 1.8.0",
 ]
 
 WEB_REQ = [
-    "Flask == 0.12",
-    "flask-talisman==0.5.1",
+    "Flask == 1.1.1",
+    "flask-talisman==0.7.0",
     "blinker == 1.4",
 ]
 
@@ -38,37 +38,33 @@ PIPELINE_REQ = [
 ]
 
 DEPLOY_REQ = [
-    "requests == 2.13.0",
-    "ipaddress == 1.0.18"  # Required by requests for resolving IP address in SSL cert
+    "requests == 2.22.0",
+    "ipaddress == 1.0.22"  # Required by requests for resolving IP address in SSL cert
 ]
 
 FLAKE8_REQ = [
     'flake8-print == 3.1.0',
     'flake8-comprehensions == 1.4.1',
-    'pep8-naming == 0.7.0',
-    'flake8 == 3.6.0'
+    'pep8-naming == 0.8.2',
+    'flake8 == 3.7.8'
 ]
 
 TESTS_REQ = [
-    'mock == 2.0.0',
-    'pytest-xdist == 1.25.0',
+    'mock == 3.0.5',
+    'pytest-xdist == 1.27.0',
     'pytest-sugar == 0.9.2',
-    'pytest-html == 1.19.0',
-    'pytest-cov == 2.6.0',
-    'pytest-helpers-namespace == 2017.11.11',
+    'pytest-html == 1.22.0',
+    'pytest-cov == 2.7.1',
+    'pytest-helpers-namespace == 2019.1.8',
     'pytest == 3.10.1',
     'requests-file == 1.4.3',
     'callee == 0.3',
 ]
 
 DEV_TOOLS = [
-    "tox==3.6.1",
+    "tox==3.13.2",
 ]
 
-# Transient dependencies that needs to be pinned for various reasons
-TRANSIENT_PINNED_TEST_REQ = [
-    "coverage==4.5.1",  # For some reason we end up pulling a buggy pre-release version without this
-]
 
 if __name__ == "__main__":
     setup(
@@ -84,7 +80,7 @@ if __name__ == "__main__":
         install_requires=GENERIC_REQ + WEB_REQ + PIPELINE_REQ + DEPLOY_REQ,
         setup_requires=['pytest-runner', 'wheel', 'setuptools_git >= 0.3'],
         extras_require={
-            "dev": TESTS_REQ + TRANSIENT_PINNED_TEST_REQ + FLAKE8_REQ + DEV_TOOLS
+            "dev": TESTS_REQ + FLAKE8_REQ + DEV_TOOLS
         },
 
         # Metadata

--- a/tests/fiaas_deploy_daemon/pipeline/test_consumer.py
+++ b/tests/fiaas_deploy_daemon/pipeline/test_consumer.py
@@ -17,7 +17,6 @@ from fiaas_deploy_daemon.pipeline.reporter import Reporter
 from fiaas_deploy_daemon.specs.app_config_downloader import AppConfigDownloader
 from fiaas_deploy_daemon.specs.factory import InvalidConfiguration
 
-
 DummyMessage = namedtuple("DummyMessage", ("value",))
 EVENT = {
     u'action': u'deploy',
@@ -128,7 +127,7 @@ class TestConsumer(object):
 
         result = queue.get_nowait()
         assert app_spec is result.app_spec
-        assert result.action is "UPDATE"
+        assert result.action == "UPDATE"
 
     def test_skip_message_if_wrong_cluster(self, monkeypatch, kafka_consumer, consumer, queue):
         kafka_consumer.__iter__.return_value = [MESSAGE]
@@ -161,7 +160,7 @@ class TestConsumer(object):
         consumer()
         result = queue.get_nowait()
         assert app_spec is result.app_spec
-        assert result.action is "UPDATE"
+        assert result.action == "UPDATE"
 
     def test_should_not_deploy_apps_in_blacklist(self, monkeypatch, kafka_consumer, factory, queue, consumer, app_spec):
         kafka_consumer.__iter__.return_value = [MESSAGE]


### PR DESCRIPTION
Mostly just updated to latest version of dependencies with a few exceptions around pytest (pytest-xdist requires pytest 4.4, and pytest 4 has major changes and requires a larger effort).

Also includes fiaas/k8s#56, which might fix or at least mitigate the problem described in #19.
