### PR TITLE
Make Kind e2e tests run on Docker for mac

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session")
 def use_docker_for_e2e(request):
-    def dockerize(test_request, cert_path, service_type, k8s_version, port):
+    def dockerize(test_request, cert_path, service_type, k8s_version, port, apiserver_ip):
         container_name = "fdd_{}_{}".format(service_type, k8s_version)
         test_request.addfinalizer(lambda: subprocess.call(["docker", "stop", container_name]))
         args = [
@@ -165,6 +165,8 @@ def use_docker_for_e2e(request):
             "--name", container_name,
             "--publish", "{port}:{port}".format(port=port),
             "--mount", "type=bind,src={},dst={},ro".format(cert_path, cert_path),
+            # make `kubernetes` resolve to the apiserver's IP to make it possible to validate its TLS cert
+            "--add-host", "kubernetes:{}".format(apiserver_ip),
         ]
         if not _is_macos():
             # Linux needs host networking to make the fiaas-deploy-daemon port available on localhost when running it

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -247,7 +247,9 @@ class KindWrapper(object):
     def __init__(self, k8s_version, name):
         self.k8s_version = k8s_version
         self.name = name
-        self._workdir = tempfile.mkdtemp(prefix="kind-{}-".format(name))
+        # on Docker for mac, directories under $TMPDIR can't be mounted by default. use /tmp, which works
+        tmp_dir = '/tmp' if _is_macos() else None
+        self._workdir = tempfile.mkdtemp(prefix="kind-{}-".format(name), dir=tmp_dir)
         self._client = docker.from_env()
         self._container = None
 
@@ -305,3 +307,6 @@ class KindWrapper(object):
         with open(path, "wb") as fobj:
             fobj.write(raw_data)
         return path
+
+def _is_macos():
+    return os.uname()[0] == 'Darwin'

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -71,8 +71,8 @@ def wait_until(action, description=None, exception_class=AssertionError, patienc
 
 
 def crd_available(kubernetes, timeout=5):
-    app_url = urljoin(kubernetes["server"], FiaasApplication._meta.url_template.format(namespace="default", name=""))
-    status_url = urljoin(kubernetes["server"],
+    app_url = urljoin(kubernetes["host-to-container-server"], FiaasApplication._meta.url_template.format(namespace="default", name=""))
+    status_url = urljoin(kubernetes["host-to-container-server"],
                          FiaasApplicationStatus._meta.url_template.format(namespace="default", name=""))
     session = requests.Session()
     session.verify = kubernetes["api-cert"]
@@ -256,7 +256,7 @@ class KindWrapper(object):
     def start(self):
         try:
             self._start()
-            api_port, config_port = self._get_ports()
+            in_container_server_ip, api_port, config_port = self._get_ports()
             wait_until(self._endpoint_ready(config_port, "config"), "config available")
             resp = requests.get("http://localhost:{}/config".format(config_port))
             resp.raise_for_status()
@@ -265,10 +265,17 @@ class KindWrapper(object):
             client_cert = self._save_to_file("client_cert", config["users"][-1]["user"]["client-certificate-data"])
             client_key = self._save_to_file("client_key", config["users"][-1]["user"]["client-key-data"])
             result = {
-                "server": "https://localhost:{}".format(api_port),
+                # "server": "https://kubernetes:8443",
+                # the apiserver's IP. We need to map this to `kubernetes` in the fdd container to be able to validate
+                # the TLS cert of the apiserver
+                "container-to-container-server-ip": in_container_server_ip,
+                # apiserver endpoint when running fdd as a container
+                "container-to-container-server": "https://kubernetes:8443",
+                # apiserver endpoint for k8s client in tests, or when running fdd locally
+                "host-to-container-server": "https://localhost:{}".format(api_port),
                 "client-cert": client_cert,
                 "client-key": client_key,
-                "api-cert": api_cert
+                "api-cert": api_cert,
             }
             wait_until(self._endpoint_ready(config_port, "kubernetes-ready"), "kubernetes ready", patience=180)
             return result
@@ -297,10 +304,11 @@ class KindWrapper(object):
 
     def _get_ports(self):
         self._container.reload()
+        ip = self._container.attrs["NetworkSettings"]["IPAddress"]
         ports = self._container.attrs["NetworkSettings"]["Ports"]
         config_port = ports["10080/tcp"][-1]["HostPort"]
         api_port = ports["8443/tcp"][-1]["HostPort"]
-        return api_port, config_port
+        return ip, api_port, config_port
 
     def _save_to_file(self, name, data):
         raw_data = base64.b64decode(data)
@@ -308,6 +316,7 @@ class KindWrapper(object):
         with open(path, "wb") as fobj:
             fobj.write(raw_data)
         return path
+
 
 def _is_macos():
     return os.uname()[0] == 'Darwin'

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -277,7 +277,8 @@ class KindWrapper(object):
             raise
 
     def delete(self):
-        self._container.stop()
+        if self._container:
+            self._container.stop()
 
     def _endpoint_ready(self, port, endpoint):
         url = "http://localhost:{}/{}".format(port, endpoint)

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -285,7 +285,10 @@ class KindWrapper(object):
 
     def delete(self):
         if self._container:
-            self._container.stop()
+            try:
+                self._container.stop()
+            except docker.errors.NotFound:
+                pass  # container has already stopped
 
     def _endpoint_ready(self, port, endpoint):
         url = "http://localhost:{}/{}".format(port, endpoint)

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -265,7 +265,6 @@ class KindWrapper(object):
             client_cert = self._save_to_file("client_cert", config["users"][-1]["user"]["client-certificate-data"])
             client_key = self._save_to_file("client_key", config["users"][-1]["user"]["client-key-data"])
             result = {
-                # "server": "https://kubernetes:8443",
                 # the apiserver's IP. We need to map this to `kubernetes` in the fdd container to be able to validate
                 # the TLS cert of the apiserver
                 "container-to-container-server-ip": in_container_server_ip,


### PR DESCRIPTION
~Builds on #26~

- Always use /tmp for temporary test data when running e2e tests on macOS, as discussed in #26.
- Due to network differences on Docker for mac vs. native Docker on Linux, some more changes were necessary to make the tests run: 

We are running Kind in a container, and need to be able to connect to its apiserver from fiaas-deploy-daemon either running in a container or on the host, and from the tests themselves, which always runs on the host. Kind exposes the apiserver on port 8443 in the container it runs, and we also map this to `localhost:$RANDOM_PORT` on the host that runs the container.

On Linux, we can run Docker with host networking. This runs all containers on the hosts network, meaning we can connect to ports bound on localhost whether we're running inside a container (fiaas-deploy-daemon) or not (the tests themselves), and it will work fine. On macOS with Docker for mac, it is not possible to use host networking, so we have to use different endpoints when connecting to the apiserver running in one container from the host and from fiaas-deploy-daemon running in another container. This commit changes the kubernetes['server'] endpoint into kubernetes['container-to-container-server'] for connecting from fiaas-deploy-daemon running in a container, and kuberentes['host-to-container-server'] for connecting from fiaas-deploy-daemon running on the host, and for connecting from the tests themselves.

The TLS certificate Kind uses is pre-generated, and has `localhost` and `kubernetes` among others as valid SANs. To make sure we can validate the cert when connecting from fiaas-deploy-daemon in a container, we use `--add-host` to map `kubernetes` to the Kind container's IP in the fiaas-deploy-daemon container's hosts file.