### PR TITLE
Write some documentation on using CRDs for deployment

### DIFF
--- a/docs/crd/examples/fiaas-deploy-daemon.yaml
+++ b/docs/crd/examples/fiaas-deploy-daemon.yaml
@@ -12,29 +12,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: "fiaas.schibsted.io/v1"
+apiVersion: fiaas.schibsted.io/v1
 kind: Application
 metadata:
-  name: fiaas-deploy-daemon
-  annotations:
-    fiaas/artifact_id: 20180313140557-9af2ccf
   labels:
-    fiaas/deployment_id: 20180313140557-9af2ccf
+    app: fiaas-deploy-daemon
+    fiaas/deployment_id: 59677ef9-7bc6-4cec-bbd5-fc4f5a4d1933
+  name: fiaas-deploy-daemon
 spec:
   application: fiaas-deploy-daemon
-  image: registry:5000/fiaas-deploy-daemon:20180313140557-9af2ccf
+  image: fiaas/fiaas-deploy-daemon:20190812124040-967aba3
   config:
-    version: 2
+    version: 3
     admin_access: true
-    replicas: 1
+    replicas:
+      maximum: 1
+      minimum: 1
     resources:
       requests:
-        memory: 128m
+        memory: 128Mi
     ports:
       - target_port: 5000
     healthchecks:
       liveness:
         http:
           path: /healthz
-    config:
-      volume: true
+    metrics:
+      prometheus:
+        path: /internal-backstage/prometheus

--- a/docs/crd/examples/nginx.yaml
+++ b/docs/crd/examples/nginx.yaml
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: "fiaas.schibsted.io/v1"
+apiVersion: fiaas.schibsted.io/v1
 kind: Application
 metadata:
   name: nginx-example
@@ -24,11 +24,13 @@ spec:
   application: nginx-example
   image: docker.io/nginx:1.13.0
   config:
-    version: 2
-    replicas: 2
+    version: 3
+    replicas:
+      maximum: 2
+      minimum: 1
     resources:
       requests:
-        memory: 128m
+        memory: 128Mi
     ports:
       - target_port: 80
     healthchecks:

--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -28,7 +28,7 @@ The Basics
 
 In order for FIAAS to function in a cluster, some basics needs to be in place
 
-* Autoscaling based on CPU metrics requires Heapster, deployed in the kube-system namespace
+* Autoscaling based on CPU metrics requires the metrics API (provided by Heapster or metrics-server), deployed in the kube-system namespace
 * Applications expect DNS to work, so kube-dns, coredns or an equivalent substitute should be installed
 * Log aggregation, so that stdout and stderr from applications are collected and aggregated and collected somewhere it can be found. Typically Fluentd collecting and sending to a suitable storage.
 * An ingress controller capable of handling all the required features
@@ -153,6 +153,30 @@ See the Kubernetes documentation about [emptyDir](https://kubernetes.io/docs/con
 
 Used to configure [Usage Reporting](#usage-reporting).
 
+
+Deploying an application
+------------------------
+
+To deploy an application with FIAAS, you need three things:
+
+- A name for your application (Should follow the [Kubernetes conventions for names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names))
+- A docker image reference
+- A fiaas configuration for your application (commonly referred to as `fiaas.yml`)
+
+To deploy an application, create an Application object describing your application. A JSON schema describing the various objects FIAAS uses is in [schema.json](schema.json). 
+
+When you create or update your Application object, and at various intervals in between, fiaas-deploy-daemon will load the description of your application and create or update all relevant objects to match what is described in your Application. A requirement is that you also set a label on the Application named `fiaas/deployment_id` (the Deployment ID). This should reflect a particular deployment that is to be considered distinct from previous or later deployments. Typically this will change when you either change your image or your fiaas config. 
+
+When you want to deploy a new version, you can in the simplest case update the `image` field and the Deployment ID label, and FIAAS will ensure a rolling deploy to the new image is performed. Making changes to the other fields in Application will likewise update the deployment.
+
+When a deployment is running, fiaas-deploy-daemon will update a ApplicationStatus object that is specific for the specified Deployment ID. The status object indicates the current state of the deployment, as well as collect some relevant information.
+
+Mast is an application you can install in your cluster, that provides a REST interface for creating Application objects. It does not currently support all features of the Application object, but we hope to expand it in the future. Mast also has a view for showing the status object related to a deployment, and can be a good starting point for those that want to create their own flow.
+
+Two example Application definitions are included in the docs:
+
+- [fiaas-deploy-daemon](crd/examples/fiaas-deploy-daemon.yaml)
+- [nginx](crd/examples/nginx.yaml)
 
 Secrets
 -------

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "FIAAS object schema",
+  "$comment": "TODO: Use a version of this schema in the actual CRD object",
+  "definitions": {
+    "io.schibsted.fiaas.v1.Application": {
+      "$id": "#Application",
+      "description": "Top level object describing your application",
+      "type": "object",
+      "required": [
+        "spec"
+      ],
+      "properties": {
+        "metadata": {
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$comment": "Regular ObjectMeta from the k8s API"
+        },
+        "spec": {
+          "$ref": "#ApplicationSpec"
+        }
+      }
+    },
+    "io.schibsted.fiaas.v1.ApplicationSpec": {
+      "$id": "#ApplicationSpec",
+      "description": "A description of your application",
+      "type": "object",
+      "required": [
+        "application",
+        "image",
+        "config"
+      ],
+      "properties": {
+        "application": {
+          "type": "string",
+          "description": "Name of your application"
+        },
+        "image": {
+          "type": "string",
+          "description": "Reference to docker image (including version)"
+        },
+        "config": {
+          "type": "object",
+          "description": "Your fiaas configuration (contents of fiaas.yml in the general case)"
+        },
+        "additional_labels": {
+          "$ref": "#AdditionalLabelsOrAnnotations",
+          "description": "Additional labels to apply to objects created"
+        },
+        "additional_annotations": {
+          "$ref": "#AdditionalLabelsOrAnnotations",
+          "description": "Additional annotations to apply to objects created"
+        }
+      }
+    },
+    "io.schibsted.fiaas.v1.AdditionalLabelsOrAnnotations": {
+      "$id": "#AdditionalLabelsOrAnnotations",
+      "type": "object",
+      "description": "A set of labels or annotations to apply",
+      "properties": {
+        "global": {
+          "type": "object",
+          "description": "These are applied to all objects created"
+        },
+        "deployment": {
+          "type": "object",
+          "description": "Applied to Deployment object"
+        },
+        "horizontal_pod_autoscaler": {
+          "type": "object",
+          "description": "Applied to HPA object"
+        },
+        "ingress": {
+          "type": "object",
+          "description": "Applied to Ingress object"
+        },
+        "service": {
+          "type": "object",
+          "description": "Applied to Service object"
+        },
+        "pod": {
+          "type": "object",
+          "description": "Applied to Pod objects (via Deployment template)"
+        },
+        "status": {
+          "type": "object",
+          "description": "Applied to the ApplicationStatus object related to this deployment"
+        }
+      }
+    },
+    "io.schibsted.fiaas.v1.ApplicationStatus": {
+      "$id": "#ApplicationStatus",
+      "type": "object",
+      "description": "An object describing the status of a particular deployment",
+      "properties": {
+        "metadata": {
+          "$ref": "https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/openapi-spec/swagger.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+          "$comment": "Regular ObjectMeta from the k8s API"
+        },
+        "result": {
+          "type": "string",
+          "description": "String describing the current state",
+          "enum": [
+            "INITIATED",
+            "RUNNING",
+            "FAILED",
+            "SUCCESS"
+          ]
+        },
+        "logs": {
+          "type": "array",
+          "description": "A list of log-lines related to this deployment",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I have written a short section on how to use CRDs for deployment, since that's the primary method and we don't actually document how that works. During this I found that I needed to describe the objects, and instead of referring to Python code, or inventing my own schema description I just used JSON Schema.

CRDs have an optional field for describing the object using JSON Schema, so we should consider moving this file to somewhere we can refer to it, and attach it to the CRDs when creating them. We also should have a more structured approach to the definition and creation of our CRDs.

It might be natural to start thinking about moving some of this documentation to the github pages repository, creating a proper documentation site.