### PR TITLE
Fix scale up issue when autoscaler is enabled and application downscaled

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -98,9 +98,11 @@ class DeploymentDeployer(object):
         if should_have_autoscaler(app_spec):
             try:
                 deployment = Deployment.get(app_spec.name, app_spec.namespace)
-                replicas = deployment.spec.replicas
-                LOG.info("Configured replica size (%d) for deployment is being ignored, as current running replica size"
-                         " is different (%d) for %s", app_spec.replicas, deployment.spec.replicas, app_spec.name)
+                # the autoscaler won't scale up the deployment if the current number of replicas is 0
+                if deployment.spec.replicas > 0:
+                    replicas = deployment.spec.replicas
+                    LOG.info("Configured replica size (%d) for deployment is being ignored, as current running replica size"
+                             " is different (%d) for %s", app_spec.replicas, deployment.spec.replicas, app_spec.name)
             except NotFound:
                 pass
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -189,6 +189,7 @@ class TestDeploymentDeployer(object):
     @pytest.mark.parametrize("previous_replicas,max_replicas,min_replicas,cpu_request,expected_replicas", (
             (5, 3, 2, None, 3),
             (5, 3, 2, "1", 5),
+            (0, 3, 2, "1", 3),
     ))
     def test_replicas_when_autoscaler_enabled(self, previous_replicas, max_replicas, min_replicas, cpu_request,
                                               expected_replicas, config, app_spec, get, put, post, datadog, prometheus,


### PR DESCRIPTION
This fix aims to set the number of replicas to replicas.maximum when the
current deployment has 0 replica set. Otherwise, the number of replicas stays
to 0 and the application is never upscaled (the HPA is disabled with this
state: "scaling is disabled since the replica count of the target is zero").