### PR TITLE
Consumer needs to send additional labels and annotations too

### DIFF
--- a/fiaas_deploy_daemon/pipeline/consumer.py
+++ b/fiaas_deploy_daemon/pipeline/consumer.py
@@ -126,7 +126,7 @@ class Consumer(DaemonThread):
         app_config = self._app_config_downloader.get(fiaas_url)
 
         return self._spec_factory(name, image, app_config, teams, tags, deployment_id,
-                                  DEFAULT_NAMESPACE)
+                                  DEFAULT_NAMESPACE, None, None)
 
     def _artifacts(self, event):
         artifacts = event[u"artifacts_by_type"]

--- a/tests/fiaas_deploy_daemon/pipeline/test_consumer.py
+++ b/tests/fiaas_deploy_daemon/pipeline/test_consumer.py
@@ -112,7 +112,7 @@ class TestConsumer(object):
 
         image = EVENT[u"artifacts_by_type"][u"docker"]
         factory.assert_called_once_with(EVENT[u"project_name"], image, app_config, EVENT[u"teams"], EVENT[u"tags"],
-                                        image.split(":")[-1], pipeline_consumer.DEFAULT_NAMESPACE)
+                                        image.split(":")[-1], pipeline_consumer.DEFAULT_NAMESPACE, None, None)
 
     def test_fail_if_no_docker_image(self, consumer):
         event = deepcopy(EVENT)


### PR DESCRIPTION
When implementing #29, we forgot to test the consumer code (the part that is FINN specific, and doesn't have e2e tests).

This solves that issue by setting the parameters to `None`.