### PR TITLE
Update deployment status check

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -63,8 +63,10 @@ class ReadyCheck(object):
             dep = Deployment.get(self._app_spec.name, self._app_spec.namespace)
         except NotFound:
             return False
-        return (dep.status.updatedReplicas >= dep.spec.replicas and
-                dep.status.availableReplicas >= dep.spec.replicas)
+        return (dep.status.updatedReplicas == dep.spec.replicas and
+                dep.status.replicas == dep.spec.replicas and
+                dep.status.availableReplicas == dep.spec.replicas and
+                dep.status.observedGeneration >= dep.metadata.generation)
 
     def __eq__(self, other):
         return other._app_spec == self._app_spec and other._bookkeeper == self._bookkeeper \

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
@@ -18,7 +18,7 @@ import pytest
 
 
 @pytest.helpers.register
-def create_metadata(app_name, namespace='default', labels=None, external=None, annotations=None):
+def create_metadata(app_name, namespace='default', labels=None, external=None, annotations=None, generation=None):
     if not labels:
         labels = {
             'app': app_name,
@@ -38,4 +38,7 @@ def create_metadata(app_name, namespace='default', labels=None, external=None, a
     if external is not None:
         expose_annotations = {'fiaas/expose': str(external).lower()}
         metadata.setdefault('annotations', {}).update(expose_annotations)
+
+    if generation is not None:
+        metadata['generation'] = generation
     return metadata


### PR DESCRIPTION
This change is inspired by the check that kubernetes does to know the state of
a Deployment
(https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/deployment/util/deployment_util.go#L736).
Moreover, it  aims to fix the deployment status on corner case described in #44.