### PR TITLE
Refactor lifecycle signals

### DIFF
--- a/fiaas_deploy_daemon/deployer/__init__.py
+++ b/fiaas_deploy_daemon/deployer/__init__.py
@@ -35,4 +35,4 @@ class DeployerBindings(pinject.BindingSpec):
         bind("deployer", to_class=Deployer)
 
 
-DeployerEvent = namedtuple('DeployerEvent', ['action', 'app_spec'])
+DeployerEvent = namedtuple('DeployerEvent', ['action', 'app_spec', 'lifecycle_subject'])

--- a/fiaas_deploy_daemon/deployer/deploy.py
+++ b/fiaas_deploy_daemon/deployer/deploy.py
@@ -45,42 +45,26 @@ class Deployer(DaemonThread):
             set_extras(event.app_spec)
             LOG.info("Received %r for %s", event.app_spec, event.action)
             if event.action == "UPDATE":
-                self._update(event.app_spec)
+                self._update(event.app_spec, event.lifecycle_subject)
             elif event.action == "DELETE":
                 self._delete(event.app_spec)
             else:
                 raise ValueError("Unknown DeployerEvent action {}".format(event.action))
 
-    def _update(self, app_spec):
-        repository = _repository(app_spec)
+    def _update(self, app_spec, lifecycle_subject):
         try:
-            self._lifecycle.start(app_name=app_spec.name,
-                                  namespace=app_spec.namespace,
-                                  deployment_id=app_spec.deployment_id,
-                                  repository=repository,
-                                  labels=app_spec.labels.status,
-                                  annotations=app_spec.annotations.status)
+            self._lifecycle.start(lifecycle_subject)
             with self._bookkeeper.time(app_spec):
                 self._adapter.deploy(app_spec)
             if app_spec.name != "fiaas-deploy-daemon":
-                self._scheduler.add(ReadyCheck(app_spec, self._bookkeeper, self._lifecycle))
+                self._scheduler.add(ReadyCheck(app_spec, self._bookkeeper, self._lifecycle, lifecycle_subject))
             else:
-                self._lifecycle.success(app_name=app_spec.name,
-                                        namespace=app_spec.namespace,
-                                        deployment_id=app_spec.deployment_id,
-                                        repository=repository,
-                                        labels=app_spec.labels.status,
-                                        annotations=app_spec.annotations.status)
+                self._lifecycle.success(lifecycle_subject)
                 self._bookkeeper.success(app_spec)
             LOG.info("Completed deployment of %r", app_spec)
         except Exception:
             LOG.exception("Error while deploying %s: ", app_spec.name)
-            self._lifecycle.failed(app_name=app_spec.name,
-                                   namespace=app_spec.namespace,
-                                   deployment_id=app_spec.deployment_id,
-                                   repository=repository,
-                                   labels=app_spec.labels.status,
-                                   annotations=app_spec.annotations.status)
+            self._lifecycle.failed(lifecycle_subject)
             self._bookkeeper.failed(app_spec)
 
     def _delete(self, app_spec):
@@ -91,10 +75,3 @@ class Deployer(DaemonThread):
 def _make_gen(func):
     while True:
         yield func()
-
-
-def _repository(app_spec):
-    try:
-        return app_spec.annotations.deployment["fiaas/source-repository"]
-    except (TypeError, KeyError, AttributeError):
-        pass

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -27,33 +27,23 @@ FAIL_LIMIT_MULTIPLIER = 10
 
 
 class ReadyCheck(object):
-    def __init__(self, app_spec, bookkeeper, lifecycle):
+    def __init__(self, app_spec, bookkeeper, lifecycle, lifecycle_subject):
         self._app_spec = app_spec
         self._bookkeeper = bookkeeper
         self._lifecycle = lifecycle
+        self._lifecycle_subject = lifecycle_subject
         self._fail_after_seconds = FAIL_LIMIT_MULTIPLIER * app_spec.replicas * app_spec.health_checks.readiness.initial_delay_seconds
         self._fail_after = time_monotonic() + self._fail_after_seconds
 
     def __call__(self):
-        repository = _repository(self._app_spec)
         if self._ready():
-            self._lifecycle.success(app_name=self._app_spec.name,
-                                    namespace=self._app_spec.namespace,
-                                    deployment_id=self._app_spec.deployment_id,
-                                    repository=repository,
-                                    labels=self._app_spec.labels.status,
-                                    annotations=self._app_spec.annotations.status)
+            self._lifecycle.success(self._lifecycle_subject)
             self._bookkeeper.success(self._app_spec)
             return False
         if time_monotonic() >= self._fail_after:
             LOG.error("Timed out after %d seconds waiting for %s to become ready",
                       self._fail_after_seconds, self._app_spec.name)
-            self._lifecycle.failed(app_name=self._app_spec.name,
-                                   namespace=self._app_spec.namespace,
-                                   deployment_id=self._app_spec.deployment_id,
-                                   repository=repository,
-                                   labels=self._app_spec.labels.status,
-                                   annotations=self._app_spec.annotations.status)
+            self._lifecycle.failed(self._lifecycle_subject)
             self._bookkeeper.failed(self._app_spec)
             return False
         return True
@@ -71,10 +61,3 @@ class ReadyCheck(object):
     def __eq__(self, other):
         return other._app_spec == self._app_spec and other._bookkeeper == self._bookkeeper \
                and other._lifecycle == self._lifecycle
-
-
-def _repository(app_spec):
-    try:
-        return app_spec.annotations.deployment["fiaas/source-repository"]
-    except (TypeError, KeyError, AttributeError):
-        pass

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -22,7 +22,7 @@ from monotonic import monotonic as time_monotonic
 
 from fiaas_deploy_daemon.deployer.bookkeeper import Bookkeeper
 from fiaas_deploy_daemon.deployer.kubernetes.ready_check import ReadyCheck
-from fiaas_deploy_daemon.lifecycle import Lifecycle
+from fiaas_deploy_daemon.lifecycle import Lifecycle, Subject
 from fiaas_deploy_daemon.specs.models import LabelAndAnnotationSpec
 
 REPLICAS = 2
@@ -38,6 +38,10 @@ class TestReadyCheck(object):
         return mock.create_autospec(Lifecycle, spec_set=True)
 
     @pytest.fixture
+    def lifecycle_subject(self, app_spec):
+        return Subject(app_spec.name, app_spec.namespace, app_spec.deployment_id, None, app_spec.labels.status, app_spec.annotations.status)
+
+    @pytest.fixture
     def deployment(self):
         with mock.patch("k8s.models.deployment.Deployment.get") as m:
             deployment = mock.create_autospec(Deployment(), spec_set=True)
@@ -49,14 +53,15 @@ class TestReadyCheck(object):
             (0, 0),
             (0, 1)
     ))
-    def test_deployment_complete(self, get, app_spec, bookkeeper, generation, observed_generation, lifecycle):
+    def test_deployment_complete(self, get, app_spec, bookkeeper, generation, observed_generation, lifecycle, lifecycle_subject):
         self._create_response(get, generation=generation, observed_generation=observed_generation)
-
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject)
 
         assert ready() is False
         bookkeeper.success.assert_called_with(app_spec)
         bookkeeper.failed.assert_not_called()
+        lifecycle.success.assert_called_with(lifecycle_subject)
+        lifecycle.failed.assert_not_called()
 
     @pytest.mark.parametrize("requested,replicas,available,updated,generation,observed_generation", (
             (8, 9, 7, 2, 0, 0),
@@ -67,10 +72,9 @@ class TestReadyCheck(object):
             (2, 2, 2, 2, 1, 0),
     ))
     def test_deployment_incomplete(self, get, app_spec, bookkeeper, requested, replicas, available, updated,
-                                   generation, observed_generation, lifecycle):
+                                   generation, observed_generation, lifecycle, lifecycle_subject):
         self._create_response(get, requested, replicas, available, updated, generation, observed_generation)
-
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject)
 
         assert ready() is True
         bookkeeper.success.assert_not_called()
@@ -86,22 +90,20 @@ class TestReadyCheck(object):
             (2, 1, 1, 1, {"fiaas/source-repository": "xyz"}, "xyz"),
     ))
     def test_deployment_failed(self, get, app_spec, bookkeeper, requested, replicas, available, updated,
-                               lifecycle, annotations, repository):
+                               lifecycle, lifecycle_subject, annotations, repository):
         if annotations:
             app_spec = app_spec._replace(annotations=LabelAndAnnotationSpec(*[annotations] * 6))
 
         self._create_response(get, requested, replicas, available, updated)
 
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject)
         ready._fail_after = time_monotonic()
 
         assert ready() is False
         bookkeeper.success.assert_not_called()
         bookkeeper.failed.assert_called_with(app_spec)
         lifecycle.success.assert_not_called()
-        lifecycle.failed.assert_called_with(app_name=app_spec.name, namespace=app_spec.namespace,
-                                            deployment_id=app_spec.deployment_id, repository=repository,
-                                            labels=app_spec.labels.status, annotations=app_spec.annotations.status)
+        lifecycle.failed.assert_called_with(lifecycle_subject)
 
     @staticmethod
     def _create_response(get, requested=REPLICAS, replicas=REPLICAS, available=REPLICAS, updated=REPLICAS,


### PR DESCRIPTION
The list of parameters to the signals has grown quite long, and each
received the same set of parameters, and the handlers essentially handled
each in the same way. This switches to use a single signal, and replaces
the list of parameters with a 'Subject' that wraps them, along with a status.

Fixes #34