### PR TITLE
Add script to run local fiaas-deploy-daemon against a kind Kubernetes cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,23 @@ Useful resources:
 - http://www.voidspace.org.uk/python/mock
 - http://flask.pocoo.org/
 
-Running fiaas-deploy-daemon with `minikube`
+Running fiaas-deploy-daemon against a local `minikube` or `kind` backed Kubernetes cluster
 -------------------------------------------
 
-To run fiaas-deploy-daemon locally and connect it to a minikube cluster, do the following.
+This workflow is intended for manual testing of fiaas-deploy-daemon against a live Kubernetes cluster while
+developing.
+
+To run fiaas-deploy-daemon locally and connect it to a local cluster, do the following:
 
 * Set up development environment and install fiaas-deploy-daemon (`$ pip install -r requirements.txt`)
+
+With kind:
+* (See https://kind.sigs.k8s.io/docs/user/quick-start/#installation for how to install and configure kind)
+* Start kind: `$ kind create cluster --image kindest/node:v1.15.6`
+* Run `$ bin/run_fdd_against_kind`
+
+With minikube:
+* (See https://minikube.sigs.k8s.io/docs/start/ for how to install and configure minikube)
 * Start minikube: `$ minikube start`
 * Run `$ bin/run_fdd_against_minikube`
 

--- a/bin/run_fdd_against_kind
+++ b/bin/run_fdd_against_kind
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+export CLUSTER_NAME="${1:-kind}"
+echo "Using kind cluster: $CLUSTER_NAME"
+export NAMESPACE="${NAMESPACE:-default}"
+
+KUBECONFIG_JSON="$(kubectl config view --output json --raw)"
+API_SERVER="$(jq -r ".clusters[] | select(.name == \"kind-"${CLUSTER_NAME}"\") | .cluster.server" <<< "$KUBECONFIG_JSON")"
+APISERVER_CERT=$(mktemp)
+CLIENT_CERT=$(mktemp)
+CLIENT_KEY=$(mktemp)
+__cleanup() {
+    rm -f "$APISERVER_CERT"
+    rm -f "$CLIENT_CERT"
+    rm -f "$CLIENT_KEY"
+}
+trap __cleanup EXIT
+
+jq -r ".clusters[] | select(.name == \"kind-${CLUSTER_NAME}\") | .cluster.\"certificate-authority-data\"" <<< "$KUBECONFIG_JSON" | base64 -D > "$APISERVER_CERT"
+jq -r ".users[] | select(.name == \"kind-${CLUSTER_NAME}\") | .user.\"client-certificate-data\"" <<< "$KUBECONFIG_JSON" | base64 -D > "$CLIENT_CERT"
+jq -r ".users[] | select(.name == \"kind-${CLUSTER_NAME}\") | .user.\"client-key-data\"" <<< "$KUBECONFIG_JSON" | base64 -D > "$CLIENT_KEY"
+
+ARGS=(
+'--debug'
+'--api-server' "$API_SERVER"
+'--api-cert' "$APISERVER_CERT"
+'--client-cert' "$CLIENT_CERT"
+'--client-key' "$CLIENT_KEY"
+'--service-type' 'ClusterIP'
+'--environment' 'test'
+'--datadog-container-image' 'datadog/docker-dd-agent:12.2.5172-alpine'
+'--enable-crd-support'
+)
+
+(set -ux; fiaas-deploy-daemon "${ARGS[@]}")

--- a/bin/run_fdd_against_minikube
+++ b/bin/run_fdd_against_minikube
@@ -2,20 +2,12 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-kubernetes_minor_version() {
-    local regex='v[0-9]\.([0-9]+)\.[0-9]+'
-    local git_version
-    git_version="$(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
-    [[ $git_version =~ $regex ]] && echo "${BASH_REMATCH[1]}"
-}
-
 export NAMESPACE="${NAMESPACE:-default}"
 KUBECONFIG_JSON="$(kubectl config view -o json)"
 export KUBECONFIG_JSON
 API_SERVER="$(jq -r '.clusters[] | select(.name == "minikube") | .cluster.server' <<< "$KUBECONFIG_JSON")"
 CLIENT_CERT="$(jq -r '.users[] | select(.name == "minikube") | .user."client-certificate"' <<< "$KUBECONFIG_JSON")"
 CLIENT_KEY="$(jq -r '.users[] | select(.name == "minikube") | .user."client-key"' <<< "$KUBECONFIG_JSON")"
-SERVER_MINOR_VERSION="$(kubernetes_minor_version)"
 ARGS=(
 '--debug'
 '--api-server' "$API_SERVER"
@@ -25,11 +17,7 @@ ARGS=(
 '--ingress-suffix' "$(minikube ip).xip.io"
 '--environment' 'test'
 '--datadog-container-image' 'datadog/docker-dd-agent:12.2.5172-alpine'
+'--enable-crd-support'
 )
-
-if [[ "$SERVER_MINOR_VERSION" -gt 6 ]]
-then
-    ARGS=("${ARGS[@]}" '--enable-crd-support')
-fi
 
 (set -x; fiaas-deploy-daemon "${ARGS[@]}")


### PR DESCRIPTION
Works with the latest version of https://github.com/kubernetes-sigs/kind

- add run_fdd_against_kind
- remove remains of ThirdPartyResource support from run_fdd_against_minikube