### PR TITLE
Make ReadyCheck timeout multiplier configurable

### DIFF
--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -184,6 +184,9 @@ class Configuration(Namespace):
                             default="0", type=_int_or_unicode)
         parser.add_argument("--enable-deprecated-tls-entry-per-host", help=TLS_ENTRY_PER_HOST_HELP,
                             action="store_true")
+        parser.add_argument("--ready-check-timeout-multiplier", type=int,
+                            help="Multiply default ready check timeout (replicas * initialDelaySeconds) with this " +
+                                 "number of seconds  (default: %(default)s)", default=10)
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)
         usage_reporting_parser.add_argument("--usage-reporting-cluster-name",
                                             help="Name of the cluster where the fiaas-deploy-daemon instance resides")

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -23,16 +23,18 @@ from monotonic import monotonic as time_monotonic
 
 LOG = logging.getLogger(__name__)
 
-FAIL_LIMIT_MULTIPLIER = 10
-
 
 class ReadyCheck(object):
-    def __init__(self, app_spec, bookkeeper, lifecycle, lifecycle_subject):
+    def __init__(self, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
         self._app_spec = app_spec
         self._bookkeeper = bookkeeper
         self._lifecycle = lifecycle
         self._lifecycle_subject = lifecycle_subject
-        self._fail_after_seconds = FAIL_LIMIT_MULTIPLIER * app_spec.replicas * app_spec.health_checks.readiness.initial_delay_seconds
+        self._fail_after_seconds = (
+            config.ready_check_timeout_multiplier *
+            app_spec.replicas *
+            app_spec.health_checks.readiness.initial_delay_seconds
+        )
         self._fail_after = time_monotonic() + self._fail_after_seconds
 
     def __call__(self):


### PR DESCRIPTION
With the latest version of fiaas-deploy-daemon we're seing a increase of failed deployments because of ReadyCheck timeouts. At FINN we're deploying with `maxSurge: 50%` so I suspect that the increase might be because the ReadyCheck since 075f6106468fa5ef87acea8e64969e494e1062cf also waits for the scaling down and termination of the old replicas that are running after the final updated replicas become ready. To work around that I thought a solution might be to add a flag to configure the constant multiplier that is used to calculate the timeout of the ReadyCheck so that we can increase it and see if we get fewer timeouts.