### PR TITLE
Fix missing repository from usage-reporting

### DIFF
--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -139,6 +139,6 @@ class CrdWatcher(DaemonThread):
 
 def _repository(application):
     try:
-        return application.metadata.annotations["deployment"]["fiaas/source-repository"]
+        return application.spec.config["annotations"]["deployment"]["fiaas/source-repository"]
     except (TypeError, KeyError, AttributeError):
         pass

--- a/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
@@ -48,7 +48,8 @@ ADD_EVENT = {
             "config": {
                 "version": 2,
                 "host": "example.com",
-                "namespace": "default"
+                "namespace": "default",
+                "annotations": {}
             },
             "image": "example/app"
         }
@@ -162,7 +163,7 @@ class TestWatcher(object):
     ])
     def test_deploy(self, crd_watcher, deploy_queue, spec_factory, watcher, app_spec, event, deployer_event_type,
                     lifecycle, annotations, repository):
-        event["object"]["metadata"]["annotations"] = annotations
+        event["object"]["spec"]["config"]["annotations"] = annotations
         watcher.watch.return_value = [WatchEvent(event, FiaasApplication)]
 
         spec = event["object"]["spec"]


### PR DESCRIPTION
This fixes the issue introduced by #48 that resulted in 'repository'
being missing from the usage-reporting events.