### PR TITLE
Use long option for BSD/GNU compatibility

### DIFF
--- a/bin/run_fdd_against_kind
+++ b/bin/run_fdd_against_kind
@@ -18,9 +18,9 @@ __cleanup() {
 }
 trap __cleanup EXIT
 
-jq -r ".clusters[] | select(.name == \"kind-${CLUSTER_NAME}\") | .cluster.\"certificate-authority-data\"" <<< "$KUBECONFIG_JSON" | base64 -D > "$APISERVER_CERT"
-jq -r ".users[] | select(.name == \"kind-${CLUSTER_NAME}\") | .user.\"client-certificate-data\"" <<< "$KUBECONFIG_JSON" | base64 -D > "$CLIENT_CERT"
-jq -r ".users[] | select(.name == \"kind-${CLUSTER_NAME}\") | .user.\"client-key-data\"" <<< "$KUBECONFIG_JSON" | base64 -D > "$CLIENT_KEY"
+jq -r ".clusters[] | select(.name == \"kind-${CLUSTER_NAME}\") | .cluster.\"certificate-authority-data\"" <<< "$KUBECONFIG_JSON" | base64 --decode > "$APISERVER_CERT"
+jq -r ".users[] | select(.name == \"kind-${CLUSTER_NAME}\") | .user.\"client-certificate-data\"" <<< "$KUBECONFIG_JSON" | base64 --decode > "$CLIENT_CERT"
+jq -r ".users[] | select(.name == \"kind-${CLUSTER_NAME}\") | .user.\"client-key-data\"" <<< "$KUBECONFIG_JSON" | base64 --decode > "$CLIENT_KEY"
 
 ARGS=(
 '--debug'


### PR DESCRIPTION
BSD (default on OSX) uses -D, but GNU uses -d. Both accept --decode