### PR TITLE
Add a config flag to disable the pipeline consumer

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -135,7 +135,7 @@ def main():
             K8sAdapterBindings(),
             WebBindings(),
             SpecBindings(),
-            PipelineBindings() if cfg.has_service("kafka_pipeline") else FakeConsumerBindings(),
+            PipelineBindings() if not cfg.disable_pipeline_consumer and cfg.has_service("kafka_pipeline") else FakeConsumerBindings(),
             CustomResourceDefinitionBindings() if cfg.enable_crd_support else DisabledCustomResourceDefinitionBindings(),
             UsageReportingBindings(),
         ]

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -97,6 +97,9 @@ When using extensions.tls, add a separate TLS entry for each host in addition to
 application containing all hosts. This feature is deprecated and will soon be removed.
 """
 
+DISABLE_PIPELINE_CONSUMER_HELP = """disable pipeline consumer. this flag only exists to ease removing the pipeline
+consumer completely, and will be removed as soon as the pipeline consumer code is removed, do not use this flag"""
+
 EPILOG = """
 Args that start with '--' (eg. --log-format) can also be set in a config file
 ({} or specified via -c). The config file uses YAML syntax and must represent
@@ -187,6 +190,8 @@ class Configuration(Namespace):
         parser.add_argument("--ready-check-timeout-multiplier", type=int,
                             help="Multiply default ready check timeout (replicas * initialDelaySeconds) with this " +
                                  "number of seconds  (default: %(default)s)", default=10)
+        parser.add_argument("--disable-pipeline-consumer", help=DISABLE_PIPELINE_CONSUMER_HELP,
+                            action="store_true")
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)
         usage_reporting_parser.add_argument("--usage-reporting-cluster-name",
                                             help="Name of the cluster where the fiaas-deploy-daemon instance resides")


### PR DESCRIPTION
This flag will only exists temporarily to make it easier to do a controlled rollout of the system that replaces this code, don't use the flag