### PR TITLE
Update to support kubernetes 1.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ GENERIC_REQ = [
     "pinject == 0.14.1",
     "six == 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.13.0",
+    "k8s == 0.14.0",
     "monotonic == 1.5",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -187,6 +187,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.10.12", "v1.12.10", "v1.14.4"))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.10.12", "v1.12.10", "v1.14.4", "v1.16.3"))
 def k8s_version(request):
     yield request.param

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -187,6 +187,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.10.12", "v1.12.10", "v1.14.4", "v1.16.3"))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.4", "v1.16.3"))
 def k8s_version(request):
     yield request.param

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -31,7 +31,7 @@ from fiaas_deploy_daemon.tools import merge_dicts
 
 SELECTOR = {'app': 'testapp'}
 LABELS = {"deployment_deployer": "pass through", "global_label": "impossible to override"}
-DEPLOYMENTS_URI = '/apis/extensions/v1beta1/namespaces/default/deployments/'
+DEPLOYMENTS_URI = '/apis/apps/v1/namespaces/default/deployments/'
 
 
 def test_make_http_probe():


### PR DESCRIPTION
Updates the version of k8s to the latest, which has the changes
to support the new API URLs for Deployments. Also includes 1.16
as a version in the end-to-end tests.

Fixes #39