### PR TITLE
Dump related logs from kind container at test completion

### DIFF
--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -34,20 +34,20 @@ from k8s.models.common import ObjectMeta
 from k8s.models.deployment import Deployment
 from k8s.models.ingress import Ingress
 from k8s.models.service import Service
+from utils import wait_until, crd_available, crd_supported, \
+    skip_if_crd_not_supported, read_yml, sanitize_resource_name, assert_k8s_resource_matches, get_unbound_port, \
+    KindWrapper
 
 from fiaas_deploy_daemon.crd.status import create_name
 from fiaas_deploy_daemon.crd.types import FiaasApplication, FiaasApplicationStatus, FiaasApplicationSpec, \
     AdditionalLabelsOrAnnotations
 from fiaas_deploy_daemon.tools import merge_dicts
-from utils import wait_until, crd_available, crd_supported, \
-    skip_if_crd_not_supported, read_yml, sanitize_resource_name, assert_k8s_resource_matches, get_unbound_port, \
-    KindWrapper
 
 IMAGE1 = u"finntech/application-name:123"
 IMAGE2 = u"finntech/application-name:321"
 DEPLOYMENT_ID1 = u"deployment_id_1"
 DEPLOYMENT_ID2 = u"deployment_id_2"
-PATIENCE = 30
+PATIENCE = 40
 TIMEOUT = 5
 
 


### PR DESCRIPTION
This will print logs from the kind container to stdout in two different scenarios:

If there is an exception when starting the kind container, we dump the full logs from the container. This should hopefully provide information about why kind failed to start.

In the tests, I have introduced a context manager, which notes the time it was entered, and at exit will dump the logs from the kind container that has occured in the interval between start and now. This should be all logs relevant for the current test item. Most of the time, this seems to be empty.

This should provide much needed information about what is going on inside the kind container during the tests. However, I have now experienced the "Connection reset by peer" failure mentioned in #33 locally, after these changes were present in my code, and I got no logs at all. I will write a comment on that issue with some observations.

I still think this change is useful, but it's not going to help solve #33 :disappointed: 
