### PR TITLE
FIAAS deployment fails when replicas.min = replicas.max = 0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ TESTS_REQ = [
 ]
 
 DEV_TOOLS = [
-    "tox==3.13.2",
+    "tox==3.14.5",
 ]
 
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -17,7 +17,6 @@
 
 import mock
 import pytest
-from k8s.models.deployment import Deployment
 from monotonic import monotonic as time_monotonic
 
 from fiaas_deploy_daemon.deployer.bookkeeper import Bookkeeper
@@ -45,14 +44,6 @@ class TestReadyCheck(object):
     @pytest.fixture
     def config(self):
         return Configuration([])
-
-    @pytest.fixture
-    def deployment(self):
-        with mock.patch("k8s.models.deployment.Deployment.get") as m:
-            deployment = mock.create_autospec(Deployment(), spec_set=True)
-            deployment.spec.replicas.return_value = REPLICAS
-            m.return_value = deployment
-            return deployment
 
     @pytest.mark.parametrize("generation,observed_generation", (
             (0, 0),
@@ -111,6 +102,17 @@ class TestReadyCheck(object):
         lifecycle.success.assert_not_called()
         lifecycle.failed.assert_called_with(lifecycle_subject)
 
+    def test_deployment_complete_deactivated(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+
+        self._create_response_zero_replicas(get)
+        not_ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+
+        assert not_ready() is False
+        bookkeeper.success.assert_called_with(app_spec)
+        bookkeeper.failed.assert_not_called()
+        lifecycle.success.assert_called_with(lifecycle_subject)
+        lifecycle.failed.assert_not_called()
+
     @staticmethod
     def _create_response(get, requested=REPLICAS, replicas=REPLICAS, available=REPLICAS, updated=REPLICAS,
                          generation=0, observed_generation=0):
@@ -138,5 +140,30 @@ class TestReadyCheck(object):
                 'unavailableReplicas': replicas - available,
                 'updatedReplicas': updated,
                 'observedGeneration': observed_generation,
+            }
+        }
+
+    @staticmethod
+    def _create_response_zero_replicas(get):
+        get.side_effect = None
+        resp = mock.MagicMock()
+        get.return_value = resp
+        resp.json.return_value = {
+            'metadata': pytest.helpers.create_metadata('testapp', generation=0),
+            'spec': {
+                'selector': {'matchLabels': {'app': 'testapp'}},
+                'template': {
+                    'spec': {
+                        'containers': [{
+                            'name': 'testapp',
+                            'image': 'finntech/testimage:version',
+                        }]
+                    },
+                    'metadata': pytest.helpers.create_metadata('testapp')
+                },
+                'replicas': 0
+            },
+            'status': {
+                'observedGeneration': 0,
             }
         }

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -105,9 +105,9 @@ class TestReadyCheck(object):
     def test_deployment_complete_deactivated(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
 
         self._create_response_zero_replicas(get)
-        not_ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
 
-        assert not_ready() is False
+        assert ready() is False
         bookkeeper.success.assert_called_with(app_spec)
         bookkeeper.failed.assert_not_called()
         lifecycle.success.assert_called_with(lifecycle_subject)


### PR DESCRIPTION
We are making this fix because when a user wants to deactivate an application, they would change the replicas to zero and the deploy will fail due to the fact that the 'fail_after_seconds' is zero as well.

In the code of the ReadyCheck's constructor, the fail_after timer depends on the number of replicas. In this case, the number of replicas is 0, hence the timer will be set to 0 and as a consequence the deployment will fail immediately.