### PR TITLE
Allow datadog container memory to be set via config

### DIFF
--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -165,6 +165,8 @@ class Configuration(Namespace):
                             help="The service account that is passed to secrets init containers", default=None)
         parser.add_argument("--datadog-container-image",
                             help="Use specified docker image as datadog sidecar for apps", default=None)
+        parser.add_argument("--datadog-container-memory",
+                            help="The amount of memory (request and limit) for the datadog sidecar", default="2Gi")
         parser.add_argument("--pre-stop-delay", type=int,
                             help="Add a pre-stop hook that sleeps for this amount of seconds  (default: %(default)s)",
                             default=0)

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -22,6 +22,7 @@ class DataDog(object):
 
     def __init__(self, config):
         self._datadog_container_image = config.datadog_container_image
+        self._datadog_container_memory = config.datadog_container_memory
 
     def apply(self, deployment, app_spec, besteffort_qos_is_required):
         if app_spec.datadog.enabled:
@@ -38,8 +39,8 @@ class DataDog(object):
         if besteffort_qos_is_required:
             resource_requirements = ResourceRequirements()
         else:
-            resource_requirements = ResourceRequirements(limits={"cpu": "400m", "memory": "2Gi"},
-                                                         requests={"cpu": "200m", "memory": "2Gi"})
+            resource_requirements = ResourceRequirements(limits={"cpu": "400m", "memory": self._datadog_container_memory},
+                                                         requests={"cpu": "200m", "memory": self._datadog_container_memory})
 
         tags = app_spec.datadog.tags
         tags["app"] = app_spec.name

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_datadog.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_datadog.py
@@ -32,6 +32,7 @@ class TestDataDog(object):
     def config(self):
         config = mock.create_autospec(Configuration([]), spec_set=True)
         config.datadog_container_image = CONTAINER_IMAGE
+        config.datadog_container_memory = "2Gi"
         return config
 
     @pytest.fixture(scope="module")


### PR DESCRIPTION
We're seeing that the sidecar is using a lot less than 2Gi of memory,
(with a maximum of 220Mi)
and across the cluster this adds up to a lot of reserved, unused resources.
This makes the amount configurable, so that we can experiment with what
a reasonable value will be.

Fixes #75