### PR TITLE
Change datadog imagePullPolicy for "latest"

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -49,10 +49,14 @@ class DataDog(object):
         # output is predictable
         dd_tags = ",".join("{}:{}".format(k, tags[k]) for k in sorted(tags))
 
+        image_pull_policy = "IfNotPresent"
+        if ":" not in self._datadog_container_image or ":latest" in self._datadog_container_image:
+            image_pull_policy = "Always"
+
         return Container(
             name=self.DATADOG_CONTAINER_NAME,
             image=self._datadog_container_image,
-            imagePullPolicy="IfNotPresent",
+            imagePullPolicy=image_pull_policy,
             env=[
                 EnvVar(name="DD_TAGS", value=dd_tags),
                 EnvVar(name="DD_API_KEY",

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
@@ -195,7 +195,7 @@ spec:
         - name: DD_CMD_PORT
           value: "42623"
         envFrom: []
-        image: DATADOG_IMAGE
+        image: DATADOG_IMAGE:tag
         volumeMounts: []
         imagePullPolicy: IfNotPresent
         name: fiaas-datadog-container

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -111,7 +111,7 @@ class TestE2E(object):
             "--service-type", service_type,
             "--ingress-suffix", "svc.test.example.com",
             "--environment", "test",
-            "--datadog-container-image", "DATADOG_IMAGE",
+            "--datadog-container-image", "DATADOG_IMAGE:tag",
             "--strongbox-init-container-image", "STRONGBOX_IMAGE",
             "--use-ingress-tls", "default_off",
         ]


### PR DESCRIPTION
This changes the imagePullPolicy for the datadog sidecar, based
on the tag of the image so that "latest" or no tag will result in
"Always". This makes it consistent with the setting applied for the
main container.