### PR TITLE
Refactor init-container secrets

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/__init__.py
@@ -21,7 +21,7 @@ import pinject as pinject
 from .datadog import DataDog
 from .deployer import DeploymentDeployer
 from .prometheus import Prometheus
-from .secrets import Secrets, KubernetesSecrets, GenericInitSecrets, StrongboxSecrets
+from .secrets import Secrets, KubernetesSecrets, GenericInitSecrets
 
 
 class DeploymentBindings(pinject.BindingSpec):
@@ -30,6 +30,5 @@ class DeploymentBindings(pinject.BindingSpec):
         bind("prometheus", to_class=Prometheus)
         bind("kubernetes_secrets", to_class=KubernetesSecrets)
         bind("generic_init_secrets", to_class=GenericInitSecrets)
-        bind("strongbox_secrets", to_class=StrongboxSecrets)
         bind("deployment_secrets", to_class=Secrets)
         bind("deployment_deployer", to_class=DeploymentDeployer)

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/secrets.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/secrets.py
@@ -20,26 +20,44 @@ from k8s.models.pod import EnvFromSource, SecretEnvSource, EnvVar, Container, Co
     EmptyDirVolumeSource, ConfigMapVolumeSource, SecretVolumeSource
 
 from fiaas_deploy_daemon.tools import merge_dicts
+from fiaas_deploy_daemon.specs.models import SecretsSpec
 
 LOG = logging.getLogger(__name__)
 
 
 class Secrets(object):
-    def __init__(self, config, kubernetes_secrets, generic_init_secrets, strongbox_secrets):
-        self._secrets_image_set = config.secrets_init_container_image is not None
-        self._strongbox_image_set = config.strongbox_init_container_image is not None
+    def __init__(self, config, kubernetes_secrets, generic_init_secrets):
         self._kubernetes = kubernetes_secrets
         self._generic_init = generic_init_secrets
-        self._strongbox = strongbox_secrets
 
-    def _uses_strongbox_init_container(self, app_spec):
-        return self._strongbox_image_set and app_spec.strongbox.enabled
+    def _legacy_strongbox_secrets_spec(self, app_spec):
+        strongbox_params = {
+            "AWS_REGION": app_spec.strongbox.aws_region,
+            "SECRET_GROUPS": ",".join(app_spec.strongbox.groups),
+        }
+        strongbox_annotations = {
+            "iam.amazonaws.com/role": app_spec.strongbox.iam_role
+        }
+        return SecretsSpec(type="strongbox",
+                           parameters=strongbox_params,
+                           annotations=strongbox_annotations)
+
+    def _default_init_secret(self):
+        return SecretsSpec(type="default",
+                           parameters={},
+                           annotations={})
 
     def apply(self, deployment, app_spec):
-        if self._secrets_image_set:
-            self._generic_init.apply(deployment, app_spec)
-        elif self._uses_strongbox_init_container(app_spec):
-            self._strongbox.apply(deployment, app_spec)
+        secret_specs = []
+        if not secret_specs:
+            if self._generic_init.supports("strongbox") and app_spec.strongbox.enabled:
+                secret_specs = [self._legacy_strongbox_secrets_spec(app_spec)]
+            elif self._generic_init.supports("default"):
+                secret_specs = [self._default_init_secret()]
+
+        if secret_specs:
+            for secret_spec in secret_specs:
+                self._generic_init.apply(deployment, app_spec, secret_spec)
         else:
             self._kubernetes.apply(deployment, app_spec)
 
@@ -89,26 +107,44 @@ class GenericInitSecrets(KubernetesSecrets):
     SECRETS_INIT_CONTAINER_NAME = "fiaas-secrets-init-container"
 
     def __init__(self, config):
-        self._secrets_init_container_image = config.secrets_init_container_image
-        self._secrets_service_account_name = config.secrets_service_account_name
+        self._available_secrets_containers = {}
+        if config.strongbox_init_container_image is not None:
+            self._available_secrets_containers.setdefault("strongbox", config.strongbox_init_container_image)
+
+        if config.secrets_init_container_image is not None:
+            self._secrets_service_account_name = config.secrets_service_account_name
+            self._automount_service_account_token = True
+            self._available_secrets_containers.setdefault("default", config.secrets_init_container_image)
+
         self._use_in_memory_emptydirs = config.use_in_memory_emptydirs
 
-    def apply(self, deployment, app_spec):
+    def supports(self, secrets_type):
+        return secrets_type in self._available_secrets_containers
+
+    def apply(self, deployment, app_spec, secret_spec):
         deployment_spec = deployment.spec
         pod_template_spec = deployment_spec.template
         pod_spec = pod_template_spec.spec
         main_container = pod_spec.containers[0]
+        image = self._available_secrets_containers.get(secret_spec.type)
+        if image is None:
+            LOG.warning("No init-container registered for secrets with type=%s", secret_spec.type)
+            return
 
         if app_spec.secrets_in_environment:
             LOG.warning("%s is attempting to use 'secrets_in_environment', which is not supported.", app_spec.name)
 
         self._apply_mounts(app_spec, main_container)
 
-        init_container = self._make_secrets_init_container(app_spec, self._secrets_init_container_image)
+        init_container = self._make_secrets_init_container(app_spec, image, env_vars=secret_spec.parameters)
         pod_spec.initContainers.append(init_container)
         if self._secrets_service_account_name:
             pod_spec.serviceAccountName = self._secrets_service_account_name
-        pod_spec.automountServiceAccountToken = True
+        if self._automount_service_account_token:
+            pod_spec.automountServiceAccountToken = True
+
+        pod_metadata = pod_template_spec.metadata
+        pod_metadata.annotations = merge_dicts(pod_metadata.annotations, secret_spec.annotations)
 
         self._apply_volumes(app_spec, pod_spec)
 
@@ -151,43 +187,3 @@ class GenericInitSecrets(KubernetesSecrets):
                               ],
                               volumeMounts=self._make_volume_mounts(app_spec, is_init_container=True))
         return container
-
-
-class StrongboxSecrets(GenericInitSecrets):
-    def __init__(self, config):
-        super(StrongboxSecrets, self).__init__(config)
-        self._strongbox_init_container_image = config.strongbox_init_container_image
-
-    def apply(self, deployment, app_spec):
-        deployment_spec = deployment.spec
-        pod_template_spec = deployment_spec.template
-        pod_spec = pod_template_spec.spec
-        main_container = pod_spec.containers[0]
-
-        if app_spec.secrets_in_environment:
-            LOG.warning("%s is attempting to use 'secrets_in_environment' and strongbox at the same time,"
-                        " which is not supported.", app_spec.name)
-
-        self._apply_mounts(app_spec, main_container)
-
-        strongbox_env = {
-            "AWS_REGION": app_spec.strongbox.aws_region,
-            "SECRET_GROUPS": ",".join(app_spec.strongbox.groups),
-        }
-        init_container = self._make_secrets_init_container(app_spec, self._strongbox_init_container_image,
-                                                           env_vars=strongbox_env)
-        pod_spec.initContainers.append(init_container)
-
-        self._apply_volumes(app_spec, pod_spec)
-
-        strongbox_annotations = self._make_strongbox_annotations(app_spec) if self._uses_strongbox_init_container(
-            app_spec) else {}
-        pod_metadata = pod_template_spec.metadata
-        pod_metadata.annotations = merge_dicts(pod_metadata.annotations, strongbox_annotations)
-
-    def _uses_strongbox_init_container(self, app_spec):
-        return self._strongbox_init_container_image is not None and app_spec.strongbox.enabled
-
-    @staticmethod
-    def _make_strongbox_annotations(app_spec):
-        return {"iam.amazonaws.com/role": app_spec.strongbox.iam_role}

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/secrets.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/secrets.py
@@ -108,6 +108,8 @@ class GenericInitSecrets(KubernetesSecrets):
 
     def __init__(self, config):
         self._available_secrets_containers = {}
+        self._secrets_service_account_name = None
+        self._automount_service_account_token = False
         if config.strongbox_init_container_image is not None:
             self._available_secrets_containers.setdefault("strongbox", config.strongbox_init_container_image)
 

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -131,6 +131,12 @@ StrongboxSpec = namedtuple("StrongboxSpec", [
     "groups",
 ])
 
+SecretsSpec = namedtuple("SecretsSpec", [
+    "type",
+    "parameters",
+    "annotations"
+])
+
 IngressTlsSpec = namedtuple("IngressTlsSpec", [
     "enabled",
     "certificate_issuer",

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_secrets.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_secrets.py
@@ -21,9 +21,9 @@ from k8s.models.deployment import Deployment, DeploymentSpec
 from k8s.models.pod import Container, PodSpec, PodTemplateSpec, EnvVar
 
 from fiaas_deploy_daemon import Configuration
-from fiaas_deploy_daemon.deployer.kubernetes.deployment import StrongboxSecrets, GenericInitSecrets, KubernetesSecrets, \
+from fiaas_deploy_daemon.deployer.kubernetes.deployment import GenericInitSecrets, KubernetesSecrets, \
     Secrets
-from fiaas_deploy_daemon.specs.models import StrongboxSpec
+from fiaas_deploy_daemon.specs.models import StrongboxSpec, SecretsSpec
 
 CANARY_NAME = "DUMMY"
 CANARY_VALUE = "CANARY"
@@ -54,7 +54,7 @@ class TestSecrets(object):
         (True, True, False, "generic_init_secrets"),
         (True, False, True, "generic_init_secrets"),
         (True, False, False, "generic_init_secrets"),
-        (False, True, True, "strongbox_secrets"),
+        (False, True, True, "generic_init_secrets"),
         (False, True, False, "kubernetes_secrets"),
         (False, False, True, "kubernetes_secrets"),
         (False, False, False, "kubernetes_secrets"),
@@ -80,19 +80,31 @@ class TestSecrets(object):
         return mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
 
     @pytest.fixture
-    def strongbox_secrets(self, config):
-        return mock.create_autospec(StrongboxSecrets(config), spec_set=True, instance=True)
+    def secrets(self, config, kubernetes_secrets, generic_init_secrets):
+        return Secrets(config, kubernetes_secrets, generic_init_secrets)
 
-    @pytest.fixture
-    def secrets(self, config, kubernetes_secrets, generic_init_secrets, strongbox_secrets):
-        return Secrets(config, kubernetes_secrets, generic_init_secrets, strongbox_secrets)
+    @staticmethod
+    def mock_supports(generic_enabled, strongbox_enabled):
+        def wrapped(_type):
+            if _type == "strongbox" and strongbox_enabled:
+                return True
+            if _type == "default" and generic_enabled:
+                return True
+            return False
+
+        return wrapped
 
     def test_secret_selection(self, request, secrets_mode, secrets, deployment, app_spec,
-                              kubernetes_secrets, generic_init_secrets, strongbox_secrets):
+                              kubernetes_secrets, generic_init_secrets, config):
         generic_enabled, strongbox_enabled, app_strongbox_enabled, wanted_mock_name = secrets_mode
 
+        generic_init_secrets.supports.side_effect = self.mock_supports(generic_enabled, strongbox_enabled)
+
+        if not generic_enabled:
+            assert config.secrets_init_container_image is None
+
         if app_strongbox_enabled:
-            strongbox = StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1"])
+            strongbox = StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"])
         else:
             strongbox = StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None)
         app_spec = app_spec._replace(strongbox=strongbox)
@@ -100,10 +112,51 @@ class TestSecrets(object):
         secrets.apply(deployment, app_spec)
 
         wanted_mock = request.getfixturevalue(wanted_mock_name)
-        wanted_mock.apply.assert_called_once_with(deployment, app_spec)
-        for m in (kubernetes_secrets, generic_init_secrets, strongbox_secrets):
-            if m != wanted_mock:
-                m.apply.assert_not_called()
+
+        if wanted_mock == generic_init_secrets:
+            kubernetes_secrets.apply.assert_not_called()
+            generic_init_secrets.apply.assert_called_once()
+        else:
+            generic_init_secrets.apply.assert_not_called()
+            kubernetes_secrets.apply.assert_called_once()
+
+    def test_default_generic_secrets(self, deployment, app_spec):
+        config = mock.create_autospec(Configuration([]), spec_set=True)
+        config.secrets_init_container_image = SECRET_IMAGE
+        config.secrets_service_account_name = "secretsmanager"
+
+        generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
+        generic_init_secrets.supports.side_effect = lambda _type: _type == 'default'
+
+        secrets = Secrets(config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets)
+
+        expected_spec = SecretsSpec(type="default",
+                                    parameters={},
+                                    annotations={})
+
+        secrets.apply(deployment, app_spec)
+
+        generic_init_secrets.apply.assert_called_once_with(deployment, app_spec, expected_spec)
+
+    def test_legacy_strongbox_secrets(self, deployment, app_spec):
+        config = mock.create_autospec(Configuration([]), spec_set=True)
+        config.strongbox_init_container_image = STRONGBOX_IMAGE
+
+        app_spec = app_spec._replace(strongbox=StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"]))
+
+        generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
+        generic_init_secrets.supports.side_effect = lambda _type: _type == 'strongbox'
+
+        secrets = Secrets(config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets)
+
+        expected_spec = SecretsSpec(type="strongbox",
+                                    parameters={"AWS_REGION": "eu-west-1", "SECRET_GROUPS": "group1,group2"},
+                                    annotations={"iam.amazonaws.com/role": "iam_role"})
+
+        secrets.apply(deployment, app_spec)
+
+        generic_init_secrets.apply.assert_called_once_with(deployment, app_spec, expected_spec)
+
 
 
 class TestKubernetesSecrets(object):
@@ -137,10 +190,18 @@ class TestGenericInitSecrets(object):
     def generic_init_secrets(self, use_in_memory_emptydirs):
         config = mock.create_autospec(Configuration([]), spec_set=True)
         config.use_in_memory_emptydirs = use_in_memory_emptydirs
+        config.secrets_init_container_image = "some-image"
         return GenericInitSecrets(config)
 
-    def test_main_container_volumes(self, deployment, app_spec, generic_init_secrets, use_in_memory_emptydirs):
-        generic_init_secrets.apply(deployment, app_spec)
+    @pytest.fixture
+    def secrets_spec(self):
+        return SecretsSpec(type="default",
+                           parameters={},
+                           annotations={})
+
+    def test_main_container_volumes(self, deployment, app_spec, generic_init_secrets, use_in_memory_emptydirs, secrets_spec):
+        assert generic_init_secrets.supports("default")
+        generic_init_secrets.apply(deployment, app_spec, secrets_spec)
 
         secret_volume = deployment.spec.template.spec.volumes[0]
         assert secret_volume.emptyDir is not None
@@ -155,8 +216,8 @@ class TestGenericInitSecrets(object):
         assert secret_mount.mountPath == "/var/run/secrets/fiaas/"
         assert secret_mount.readOnly is True
 
-    def test_init_container(self, deployment, app_spec, generic_init_secrets):
-        generic_init_secrets.apply(deployment, app_spec)
+    def test_init_container(self, deployment, app_spec, generic_init_secrets, secrets_spec):
+        generic_init_secrets.apply(deployment, app_spec, secrets_spec)
 
         init_container = deployment.spec.template.spec.initContainers[0]
         assert init_container is not None
@@ -164,8 +225,8 @@ class TestGenericInitSecrets(object):
         assert "K8S_DEPLOYMENT" == init_container.env[-1].name
         assert app_spec.name == init_container.env[-1].value
 
-    def test_init_container_mounts(self, deployment, app_spec, generic_init_secrets):
-        generic_init_secrets.apply(deployment, app_spec)
+    def test_init_container_mounts(self, deployment, app_spec, generic_init_secrets, secrets_spec):
+        generic_init_secrets.apply(deployment, app_spec, secrets_spec)
 
         mounts = deployment.spec.template.spec.initContainers[0].volumeMounts
         assert mounts[0].name == "{}-secret".format(app_spec.name)
@@ -177,20 +238,23 @@ class TestGenericInitSecrets(object):
 class TestStrongboxSecrets(object):
     IAM_ROLE = "arn:aws:iam::12345678:role/the-role-name"
     AWS_REGION = "eu-west-1"
-    GROUPS = ["foo", "bar"]
+    GROUPS = "foo,bar"
 
     @pytest.fixture
     def strongbox_secrets(self):
         config = mock.create_autospec(Configuration([]), spec_set=True)
-        return StrongboxSecrets(config)
+        config.strongbox_init_container_image = "some-strongbox-image"
+        return GenericInitSecrets(config)
 
     @pytest.fixture
-    def app_spec(self, app_spec):
-        strongbox = StrongboxSpec(enabled=True, iam_role=self.IAM_ROLE, aws_region=self.AWS_REGION, groups=self.GROUPS)
-        return app_spec._replace(strongbox=strongbox)
+    def secrets_spec(self, app_spec):
+        return SecretsSpec(type="strongbox",
+                           parameters={"AWS_REGION": self.AWS_REGION, "SECRET_GROUPS": self.GROUPS},
+                           annotations={"iam.amazonaws.com/role": self.IAM_ROLE})
 
-    def test_environment(self, deployment, app_spec, strongbox_secrets):
-        strongbox_secrets.apply(deployment, app_spec)
+    def test_environment(self, deployment, app_spec, strongbox_secrets, secrets_spec):
+        assert strongbox_secrets.supports("strongbox")
+        strongbox_secrets.apply(deployment, app_spec, secrets_spec)
 
         assert 1 == len(deployment.spec.template.spec.initContainers)
         init_container = deployment.spec.template.spec.initContainers[0]
@@ -199,10 +263,10 @@ class TestStrongboxSecrets(object):
         assert 3 == len(init_container.env)
         self._assert_env_var(init_container.env[0], "K8S_DEPLOYMENT", app_spec.name)
         self._assert_env_var(init_container.env[1], "AWS_REGION", self.AWS_REGION)
-        self._assert_env_var(init_container.env[2], "SECRET_GROUPS", ",".join(self.GROUPS))
+        self._assert_env_var(init_container.env[2], "SECRET_GROUPS", self.GROUPS)
 
-    def test_annotations(self, deployment, app_spec, strongbox_secrets):
-        strongbox_secrets.apply(deployment, app_spec)
+    def test_annotations(self, deployment, app_spec, strongbox_secrets, secrets_spec):
+        strongbox_secrets.apply(deployment, app_spec, secrets_spec)
 
         pod_metadata = deployment.spec.template.metadata
         assert pod_metadata.annotations == {

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_secrets.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_secrets.py
@@ -142,7 +142,8 @@ class TestSecrets(object):
         config = mock.create_autospec(Configuration([]), spec_set=True)
         config.strongbox_init_container_image = STRONGBOX_IMAGE
 
-        app_spec = app_spec._replace(strongbox=StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"]))
+        app_spec = app_spec._replace(
+            strongbox=StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"]))
 
         generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
         generic_init_secrets.supports.side_effect = lambda _type: _type == 'strongbox'
@@ -156,7 +157,6 @@ class TestSecrets(object):
         secrets.apply(deployment, app_spec)
 
         generic_init_secrets.apply.assert_called_once_with(deployment, app_spec, expected_spec)
-
 
 
 class TestKubernetesSecrets(object):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -145,7 +145,7 @@ class TestDeploymentDeployer(object):
 
     @pytest.fixture
     def secrets(self, config):
-        return mock.create_autospec(Secrets(config, None, None, None), spec_set=True, instance=True)
+        return mock.create_autospec(Secrets(config, None, None), spec_set=True, instance=True)
 
     @pytest.mark.usefixtures("get")
     def test_deploy_new_deployment(self, post, config, app_spec, datadog, prometheus, secrets):


### PR DESCRIPTION
This rewrites the processing of the default init-container,
and the strongbox version, to be based on the same implementation
that will be re-usable for the new functionality proposed in #71.

The initialisation of an empty list of `secret_specs` in Secrets.apply will be
replaced by the secrets specified in the app-spec, and the map of
`_available_secrets_containers` in GenericInitSecrets will be replaced
by a value taken from the deploy-daemon config.