### PR TITLE
Add marker for latest version of k8s in e2e tests

### DIFF
--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -187,6 +187,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.4", "v1.16.3"))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.4", pytest.param("v1.16.3", marks=pytest.mark.e2e_latest)))
 def k8s_version(request):
     yield request.param


### PR DESCRIPTION
This allows the e2e tests for just the latest version of k8s to
be run by passing `-m e2e_latest` to py.test, allowing for it
to run more quickly in situations where you don't expect version
differences to be relevant.