### PR TITLE
Send datadog global tags

### DIFF
--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -115,6 +115,14 @@ override environment variables which override config file values which
 override defaults.
 """.format(DEFAULT_CONFIG_FILE)
 
+DATADOG_GLOBAL_TAGS_LONG_HELP = """
+If you wish to send certain tags to datadog in every application
+in your cluster, define them here.
+
+Regardless of how a variable is passed in (option, environment variable or in
+a config file), it must be specified as `<key>=<value>`.
+"""
+
 
 class Configuration(Namespace):
     VALID_LOG_FORMAT = ("plain", "json")
@@ -167,6 +175,11 @@ class Configuration(Namespace):
                             help="Use specified docker image as datadog sidecar for apps", default=None)
         parser.add_argument("--datadog-container-memory",
                             help="The amount of memory (request and limit) for the datadog sidecar", default="2Gi")
+        datadog_global_tags_parser = parser.add_argument_group("Datadog Global tags", DATADOG_GLOBAL_TAGS_LONG_HELP)
+        datadog_global_tags_parser.add_argument("--datadog-global-tags", default=[],
+                                                env_var="FIAAS_DATADOG_GLOBAL_TAGS",
+                                                help="Various non-essential global tags to send to datadog for all applications",
+                                                action="append", type=KeyValue, dest="datadog_global_tags")
         parser.add_argument("--pre-stop-delay", type=int,
                             help="Add a pre-stop hook that sleeps for this amount of seconds  (default: %(default)s)",
                             default=0)
@@ -230,6 +243,7 @@ class Configuration(Namespace):
         list_group.add_argument("--whitelist", help="Only deploy this application", action="append", default=[])
         parser.parse_args(args, namespace=self)
         self.global_env = {env_var.key: env_var.value for env_var in self.global_env}
+        self.datadog_global_tags = {tag.key: tag.value for tag in self.datadog_global_tags}
 
     def _resolve_api_config(self):
         token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -23,6 +23,7 @@ class DataDog(object):
     def __init__(self, config):
         self._datadog_container_image = config.datadog_container_image
         self._datadog_container_memory = config.datadog_container_memory
+        self._datadog_global_tags = config.datadog_global_tags
 
     def apply(self, deployment, app_spec, besteffort_qos_is_required):
         if app_spec.datadog.enabled:
@@ -42,7 +43,11 @@ class DataDog(object):
             resource_requirements = ResourceRequirements(limits={"cpu": "400m", "memory": self._datadog_container_memory},
                                                          requests={"cpu": "200m", "memory": self._datadog_container_memory})
 
-        tags = app_spec.datadog.tags
+        tags = {}
+        if self._datadog_global_tags:
+            tags.update(self._datadog_global_tags)
+
+        tags.update(app_spec.datadog.tags)
         tags["app"] = app_spec.name
         tags["k8s_namespace"] = app_spec.namespace
         # Use an alphabetical order based on keys to ensure that the

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -246,6 +246,11 @@ class TestConfig(object):
         with pytest.raises(AttributeError):
             config.undefined_configuration_parameter
 
+    def test_datadog_global_tags_keyvalue(self):
+        args = ("pattern=value", "FIAAS_DD_tag=test")
+        config = Configuration(["--datadog-global-tags=%s" % arg for arg in args])
+        assert config.datadog_global_tags == {KeyValue(arg).key: KeyValue(arg).value for arg in args}
+
 
 class TestHostRewriteRule(object):
     def test_equality(self):


### PR DESCRIPTION
This change accepts the new parameter datadog-global-tags, which adds the given key:value to the Datadog tags for all the containers.
For example, if you want to send in which cluster or region the container is, you can deploy fiaas-deploy-daemon with this information instead of changing every service to send it to Datadog.