### PR TITLE
Support multiple secret-init-containers

### DIFF
--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -219,7 +219,7 @@ they wish to use, specify environment variables, and attach annotations to the p
 The images should be registered with a 'type', e.g. `--secret-init-containers foosecrets=fiaas/some-foo-image:latest`, and this can
 then be used by applications by specifying `extensions.secrets.foosecrets` in their configuration.
 
-Any environment variables specified as `extensions.secrets.foosecrets.paramters` will be available, and any annotations
+Any environment variables specified as `extensions.secrets.foosecrets.parameters` will be available, and any annotations
 specified as `extensions.secrets.foosecrets.parameters` will be added to the pod.
 
 Using the special value 'default' for the 'type' will mean the image will be attached when an application doesn't

--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -79,7 +79,7 @@ Service objects can have a number of types in Kubernetes. This option decides wh
 
 This is currently only used for FINN, and will go away soon.
 
-### secrets-init-container-image, secrets-service-account-name and strongbox-init-container-image
+### secret-init-containers, secrets-init-container-image, secrets-service-account-name and strongbox-init-container-image
 
 Used to implement an init-container that will get secrets from some backend and make them available to the application. Read the section about [Secrets](#secrets)
 
@@ -184,7 +184,7 @@ Two example Application definitions are included in the docs:
 Secrets
 -------
 
-FIAAS supports three different sources of secrets. All three options will provide access to secrets in a pre-defined location, currently `/var/run/secrets/fiaas/`. This allows applications to assume their secrets are located at that path, regardless of where the secrets are sourced from.
+FIAAS supports different sources of secrets. All options will provide access to secrets in a pre-defined location, currently `/var/run/secrets/fiaas/`. This allows applications to assume their secrets are located at that path, regardless of where the secrets are sourced from.
 
 ### Kubernetes Secret
 
@@ -192,23 +192,44 @@ The default source is Kubernetes Secret objects. If a Secret with the same name 
 
 When using Kubernetes as a source of secrets it is possible to set the key `secrets_in_environment` in the application configuration to `true`, and each key-value pair in the Secret will be exposed as environment variables to your application. This flag is ignored for by other sources because of technical limitations.
 
-### Secrets init container
+### Using init-containers
 
-Since Kubernetes Secrets are somewhat insecure, operators might want to use other options for storing secrets. The option `secrets-init-container-image` allows selecting an image that will be run as an init-container before the application starts, in order to allow fetching secrets from a different location.
+Since Kubernetes Secrets are somewhat insecure, operators might want to use other options for storing secrets. There are 3 options to
+allow images to be made available to application developers which will be run as an init-container before the application starts, in
+order to allow for fetching secrets from a different location.
 
-The container will be responsible for getting the application secrets from whatever backend is used, and writing them to disk. The path `/var/run/secrets/fiaas` will be an "EmptyDir" with read/write permissions, which is then mounted with read-only permissions in the application container.
-
-If `secrets-service-account-name` is specified, the named service account will be mounted in the init container.
+In all cases, the container will be responsible for getting the application secrets from whatever backend is used, and writing them to disk. The path `/var/run/secrets/fiaas` will be an "EmptyDir" with read/write permissions, which is then mounted with read-only permissions in the application container.
 
 In the init container, the environment variable `K8S_DEPLOYMENT` will be the name of the application. In addition, any variables specified in a ConfigMap named `fiaas-secrets-init-container` will be exposed as environment variables.
 
 The ConfigMap will also be mounted at `/var/run/config/fiaas-secrets-init-container/`. If there exists a ConfigMap for the application then it will be mounted at `/var/run/config/fiaas/`. 
 
-### Strongbox
+#### Secrets init container (--secrets-init-container-image)
 
-In AWS you have the option of using [Strongbox](https://schibsted.github.io/strongbox/) for your secrets. If you wish to use Strongbox, the configuration option `strongbox-init-container-image` should be set to an image that can get secrets from Strongbox. This option is very similar to the previous variant, except that Strongbox gets a few more pieces of information from the application configuration. The application must specify an IAM role, and can select AWS region and a list of secret groups to get secrets from.
+This allows for a single image to be configured per-namespace, that will be attached to applications without them
+having to configure anything.
 
-The Strongbox init container is treated much the same as the previous variant, with two extra environment variables:
+If `secrets-service-account-name` is specified, the named service account will be mounted in the init container.
+
+### Configurable secrets init containers (--secret-init-containers)
+
+This allows for multiple images to be configured per-namespaces, and application developers can choose which
+they wish to use, specify environment variables, and attach annotations to the pod.
+
+The images should be registered with a 'type', e.g. `--secret-init-containers foosecrets=fiaas/some-foo-image:latest`, and this can
+then be used by applications by specifying `extensions.secrets.foosecrets` in their configuration.
+
+Any environment variables specified as `extensions.secrets.foosecrets.paramters` will be available, and any annotations
+specified as `extensions.secrets.foosecrets.parameters` will be added to the pod.
+
+Using the special value 'default' for the 'type' will mean the image will be attached when an application doesn't
+specify any other secrets configuration.
+
+#### Strongbox
+
+In AWS you have the option of using [Strongbox](https://https://github.com/schibsted/strongbox) for your secrets. If you wish to use Strongbox, the configuration option `strongbox-init-container-image` should be set to an image that can get secrets from Strongbox. This option is very similar to the previous variant, except that Strongbox gets a few more pieces of information from the application configuration. The application must specify an IAM role, and can select AWS region and a list of secret groups to get secrets from.
+
+The Strongbox init container is treated much the same as the previous variants, with two extra environment variables:
 
 * `SECRET_GROUPS` is a comma separated list of secret groups from the application config
 * `AWS_REGION` is the AWS region from the application config.

--- a/docs/v3_spec.md
+++ b/docs/v3_spec.md
@@ -635,6 +635,36 @@ admin_access: False
 
 ## extensions
 
+### secrets
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Configuration for pulling secrets from arbitrary sources before application startup. The keys of this
+object should be the 'type' of secret init-container that has been registered in the cluster
+(using `--secret-init-containers`).
+The init-container can be configured using 'parameters', which will be available inside the container as
+Environment Variables; and/or 'annotations', which will be added to the annotations present in the pod.
+
+If no value is provided here, and a 'default' init-container is registered in the cluster it will be used
+for the application.
+
+The init-container should make secrets available as files under `/var/run/secrets/fiaas`. Any additional structure
+or convention will depend on the init-container being used.
+
+Example:
+```yaml
+extensions:
+  secrets:
+    parameter-store:
+      parameters:
+        AWS_REGION: eu-west-1
+        SECRET_ID: somesecret
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::12345678:role/the-role-name
+```
+
 ### strongbox
 
 | **Type** | **Required** |

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -123,6 +123,15 @@ Regardless of how a variable is passed in (option, environment variable or in
 a config file), it must be specified as `<key>=<value>`.
 """
 
+SECRET_CONTAINERS_LONG_HELP = """
+You can register container-images that can be used as secret init-containers
+by applications. Specify as `type=image`, and then reference this in the
+application config as `extensions.secrets.<type>`.
+
+Using 'default' as the 'type' will mean the container will be attached automatically,
+if the application doesn't specify any.
+"""
+
 
 class Configuration(Namespace):
     VALID_LOG_FORMAT = ("plain", "json")
@@ -241,9 +250,16 @@ class Configuration(Namespace):
         list_group = list_parser.add_mutually_exclusive_group()
         list_group.add_argument("--blacklist", help="Do not deploy this application", action="append", default=[])
         list_group.add_argument("--whitelist", help="Only deploy this application", action="append", default=[])
+        secret_init_containers_parser = parser.add_argument_group("Secret init-containers", SECRET_CONTAINERS_LONG_HELP)
+        secret_init_containers_parser.add_argument("--secret-init-containers", default=[],
+                                                   env_var="FIAAS_SECRET_INIT_CONTAINERS",
+                                                   help="Images to use for secret init-containers by key",
+                                                   action="append", type=KeyValue, dest="secret_init_containers")
+
         parser.parse_args(args, namespace=self)
         self.global_env = {env_var.key: env_var.value for env_var in self.global_env}
         self.datadog_global_tags = {tag.key: tag.value for tag in self.datadog_global_tags}
+        self.secret_init_containers = {provider.key: provider.value for provider in self.secret_init_containers}
 
     def _resolve_api_config(self):
         token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -39,6 +39,7 @@ class AppSpec(namedtuple("AppSpec", [
     "strongbox",
     "singleton",
     "ingress_tls",
+    "secrets"
 ])):
     __slots__ = ()
 

--- a/fiaas_deploy_daemon/specs/v3/defaults.yml
+++ b/fiaas_deploy_daemon/specs/v3/defaults.yml
@@ -98,3 +98,4 @@ extensions:
   tls: # TLS is only enabled if fiaas-deploy-daemon is run with a value for --use-ingress-tls other than `disabled`
     enabled: false # This is dynamically set based on the value for --use-ingress-tls passed to the instance
     certificate_issuer: # the name of certificate-issuer cert-manager should use
+  secrets: {}

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -24,7 +24,7 @@ from ..factory import BaseFactory, InvalidConfiguration
 from ..lookup import LookupMapping
 from ..models import AppSpec, PrometheusSpec, DatadogSpec, ResourcesSpec, ResourceRequirementSpec, PortSpec, \
     HealthCheckSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, ExecCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTlsSpec
+    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTlsSpec, SecretsSpec
 from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK
 from ...tools import merge_dicts
 
@@ -66,6 +66,7 @@ class Factory(BaseFactory):
             singleton=lookup["replicas"]["singleton"],
             ingress_tls=IngressTlsSpec(enabled=lookup["extensions"]["tls"]["enabled"],
                                        certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]),
+            secrets=self._secrets_specs(lookup["extensions"]["secrets"]),
         )
         return app_spec
 
@@ -226,6 +227,12 @@ class Factory(BaseFactory):
         return StrongboxSpec(enabled=enabled, iam_role=iam_role,
                              aws_region=strongbox_lookup["aws_region"],
                              groups=groups)
+
+    @staticmethod
+    def _secrets_specs(secrets_lookup):
+        return [SecretsSpec(type=k,
+                            parameters=v["parameters"],
+                            annotations=v["annotations"]) for (k, v) in secrets_lookup.iteritems()]
 
 
 def _get_value(key, overrides):

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -64,7 +64,8 @@ def app_spec():
         ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)])],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
-        ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)
+        ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),
+        secrets=[]
     )
 
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -62,7 +62,8 @@ def app_spec(**kwargs):
         ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)])],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
-        ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)
+        ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),
+        secrets=[]
     )
 
     return default_app_spec._replace(**kwargs)

--- a/tests/fiaas_deploy_daemon/e2e_expected/secrets-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/secrets-deployment.yml
@@ -1,0 +1,208 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app: v3-data-examples-secrets
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-secrets
+  namespace: default
+  ownerReferences: []
+  finalizers: []
+spec:
+  replicas: 5
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: v3-data-examples-secrets
+  strategy:
+    rollingUpdate:
+      maxSurge: "25%"
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /_/metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
+        iam.amazonaws.com/role: "arn:aws:iam::12345678:role/the-role-name"
+        some.other/annotation: annotation-value
+      labels:
+        app: v3-data-examples-secrets
+        fiaas/deployed_by: ""
+        fiaas/deployment_id: DEPLOYMENT_ID
+        fiaas/status: active
+        fiaas/version: VERSION
+      name: v3-data-examples-secrets
+      namespace: default
+      ownerReferences: []
+      finalizers: []
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command: []
+        env:
+        - name: ARTIFACT_NAME
+          value: v3-data-examples-secrets
+        - name: CONSTRETTO_TAGS
+          value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ENVIRONMENT
+          value: test
+        - name: FIAAS_INFRASTRUCTURE
+          value: diy
+        - name: FIAAS_LIMITS_CPU
+          valueFrom:
+            resourceFieldRef:
+              containerName: v3-data-examples-secrets
+              resource: limits.cpu
+              divisor: "1"
+        - name: FIAAS_LIMITS_MEMORY
+          valueFrom:
+            resourceFieldRef:
+              containerName: v3-data-examples-secrets
+              resource: limits.memory
+              divisor: "1"
+        - name: FIAAS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+              apiVersion: "v1"
+        - name: FIAAS_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+              apiVersion: "v1"
+        - name: FIAAS_REQUESTS_CPU
+          valueFrom:
+            resourceFieldRef:
+              containerName: v3-data-examples-secrets
+              resource: requests.cpu
+              divisor: "1"
+        - name: FIAAS_REQUESTS_MEMORY
+          valueFrom:
+            resourceFieldRef:
+              containerName: v3-data-examples-secrets
+              resource: requests.memory
+              divisor: "1"
+        - name: FINN_ENV
+          value: test
+        - name: IMAGE
+          value: IMAGE
+        - name: LOG_FORMAT
+          value: plain
+        - name: LOG_STDOUT
+          value: "true"
+        - name: VERSION
+          value: VERSION
+        envFrom:
+        - configMapRef:
+            name: v3-data-examples-secrets
+            optional: true
+        image: IMAGE
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /_/health
+            port: http
+            scheme: HTTP
+            httpHeaders: []
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: v3-data-examples-secrets
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /_/ready
+            port: http
+            scheme: HTTP
+            httpHeaders: []
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 400m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /var/run/secrets/fiaas/
+          name: v3-data-examples-secrets-secret
+          readOnly: true
+        - mountPath: /var/run/config/fiaas/
+          name: v3-data-examples-secrets-config
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: v3-data-examples-secrets-secret
+      - name: fiaas-secrets-init-container-config
+        configMap:
+          optional: true
+          name: fiaas-secrets-init-container
+          defaultMode: 420
+      - name: v3-data-examples-secrets-config
+        configMap:
+          optional: true
+          name: v3-data-examples-secrets
+          defaultMode: 420
+      - name: tmp
+      initContainers:
+      - name: 'fiaas-secrets-init-container'
+        envFrom:
+        - configMapRef:
+            optional: true
+            name: 'fiaas-secrets-init-container'
+        image: 'PARAM_STORE_IMAGE'
+        volumeMounts:
+        - mountPath: '/var/run/secrets/fiaas/'
+          name: 'v3-data-examples-secrets-secret'
+        - readOnly: true
+          mountPath: '/var/run/config/fiaas-secrets-init-container/'
+          name: 'fiaas-secrets-init-container-config'
+        - readOnly: true
+          mountPath: '/var/run/config/fiaas/'
+          name: 'v3-data-examples-secrets-config'
+        - mountPath: '/tmp'
+          name: 'tmp'
+        command: []
+        env:
+        - name: 'K8S_DEPLOYMENT'
+          value: 'v3-data-examples-secrets'
+        - name: 'AWS_REGION'
+          value: 'eu-central-1'
+        - name: 'SECRET_PATH'
+          value: 'some-param'
+        imagePullPolicy: 'IfNotPresent'
+        ports: []
+      imagePullSecrets: []

--- a/tests/fiaas_deploy_daemon/specs/v3/data/examples/secrets.yml
+++ b/tests/fiaas_deploy_daemon/specs/v3/data/examples/secrets.yml
@@ -1,0 +1,26 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 3
+extensions:
+  secrets:
+    parameter-store:
+      parameters:
+        AWS_REGION: eu-central-1
+        SECRET_PATH: some-param
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::12345678:role/the-role-name
+        some.other/annotation: annotation-value
+    

--- a/tests/fiaas_deploy_daemon/specs/v3/data/examples/secrets_strongbox.yml
+++ b/tests/fiaas_deploy_daemon/specs/v3/data/examples/secrets_strongbox.yml
@@ -1,0 +1,25 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 3
+extensions:
+  secrets:
+    strongbox:
+      parameters:
+        AWS_REGION: eu-central-1
+        SECRET_GROUPS: secretgroup1,secretgroup2,secretgroup3
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::12345678:role/the-role-name
+    

--- a/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
+++ b/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
@@ -318,6 +318,27 @@ TEST_DATA = {
     "tls_enabled_cert_issuer": {
         "ingress_tls.enabled": True,
         "ingress_tls.certificate_issuer": "myissuer"
+    },
+    "secrets": {
+        "secrets[0].type": "parameter-store",
+        "secrets[0].parameters": {
+            "AWS_REGION": "eu-central-1",
+            "SECRET_PATH": "some-param"
+        },
+        "secrets[0].annotations": {
+            "iam.amazonaws.com/role": "arn:aws:iam::12345678:role/the-role-name",
+            "some.other/annotation": "annotation-value"
+        }
+    },
+    "secrets_strongbox": {
+        "secrets[0].type": "strongbox",
+        "secrets[0].parameters": {
+            "AWS_REGION": "eu-central-1",
+            "SECRET_GROUPS": "secretgroup1,secretgroup2,secretgroup3"
+        },
+        "secrets[0].annotations": {
+            "iam.amazonaws.com/role": "arn:aws:iam::12345678:role/the-role-name"
+        }
     }
 }
 
@@ -408,6 +429,7 @@ class TestFactory(object):
                            None, None)
         assert app_spec is not None
         code = "app_spec.%s" % attribute
+        assert app_spec.secrets is not None
         actual = eval(code)
         assert isinstance(actual, _Lookup) is False  # _Lookup objects should not leak to AppSpec
         assert actual == value

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -113,6 +113,7 @@ class TestE2E(object):
             "--environment", "test",
             "--datadog-container-image", "DATADOG_IMAGE:tag",
             "--strongbox-init-container-image", "STRONGBOX_IMAGE",
+            "--secret-init-containers", "parameter-store=PARAM_STORE_IMAGE",
             "--use-ingress-tls", "default_off",
         ]
         if crd_supported(k8s_version):
@@ -204,6 +205,9 @@ class TestE2E(object):
                 Deployment: "e2e_expected/strongbox-deployment.yml",
                 Ingress: "e2e_expected/strongbox-ingress.yml",
                 HorizontalPodAutoscaler: "e2e_expected/strongbox-hpa.yml",
+            }),
+            ("v3/data/examples/secrets.yml", {
+                Deployment: "e2e_expected/secrets-deployment.yml",
             }),
             ("v3/data/examples/single-replica-singleton.yml", {
                 Deployment: "e2e_expected/single-replica-singleton.yml",


### PR DESCRIPTION
Fixes #71

This change allows FIAAS operators to register multiple
images that can be used by app-developers as init-containers
for pulling secrets that are made available to the app.

Operators provide a mapping between a 'type' and an image, e.g.
`aws-parameter-store=fiaas/parameter-store-secrets`
And then app developers specify that they wish to use this in their
paas.yml:
```yaml
extensions:
  secrets:
    aws-parameter-store:
      parameters:
        AWS_REGION: eu-west-1
        SECRET_NAME: somesecret
      annotations:
        iam.amazonaws.com/role: arn:123:role/some-role
```

The 'parameters' will be set as ENV vars in the container, while
'annotations' will be added to the pod.

If an operator registers an image with 'type' set to 'default',
then this image will be attached automatically, iff the app config
doesn't specify anything.