### PR TITLE
ARM support, using docker buildx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -129,4 +129,9 @@ Temporary Items
 
 *.swp
 
-.wheel_cache
+# Misc files
+
+bin
+.semaphore
+docs
+tests

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -29,6 +29,8 @@ blocks:
         commands:
           # Check codestyle + run unit tests
           - checkout
+          - sudo apt-get install -y qemu-user
+          - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           - export PATH="$PATH:$HOME/.local/bin"
           - pip install --user .[ci]
           - tox -e codestyle,test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -30,7 +30,7 @@ blocks:
           # Check codestyle + run unit tests
           - checkout
           - sudo apt-get install -y qemu-user
-          - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          - docker run --rm --privileged multiarch/qemu-user-static:4.2.0-7 --reset -p yes
           - export PATH="$PATH:$HOME/.local/bin"
           - pip install --user .[ci]
           - tox -e codestyle,test

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN apk --no-cache add \
     yaml-dev
 
 COPY . /fiaas-deploy-daemon
+COPY .wheel_cache/*.whl /links/
 WORKDIR /fiaas-deploy-daemon
-RUN pip wheel . --wheel-dir=/wheels/
+RUN pip wheel . --no-cache-dir --wheel-dir=/wheels/ --find-links=/links/
 
 FROM common as production
 # Get rid of all build dependencies, install application using only pre-built binary wheels

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_CLI_EXPERIMENTAL=enabled
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 VERSION="$(date +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
 IMAGE="fiaas/fiaas-deploy-daemon"
 IMAGE_VERSION_TAG="${IMAGE}:$VERSION"

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -42,10 +42,16 @@ fi
 
 # Run multi-arch build and push it
 docker buildx build --pull \
-  --tag "${IMAGE_LATEST_TAG}" \
   --tag "${IMAGE_VERSION_TAG}" \
   --platform "${PLATFORMS}" \
   --output "${OUTPUT}" .
+
+# And again to load into docker if not already done
+if [[ "${OUTPUT}" != "type=docker" ]]; then
+  docker buuldx build \
+    --tag "${IMAGE_LATEST_TAG}" \
+    --output type=docker .
+fi
 
 # Once more to get the wheels
 docker buildx build \

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -1,16 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+DOCKER_CLI_EXPERIMENTAL=enabled
 VERSION="$(date +%Y%m%d%H%M%S)-$(git rev-parse --short HEAD)"
 IMAGE="fiaas/fiaas-deploy-daemon"
 IMAGE_VERSION_TAG="${IMAGE}:$VERSION"
 IMAGE_LATEST_TAG="${IMAGE}:latest"
+TARBALL=build/fiaas-deploy-daemon.tar
+CACHE_DIR=${PIP_CACHE_DIR:-~/.cache/pip}
 
-docker build --tag "${IMAGE_VERSION_TAG}" --tag "$IMAGE_LATEST_TAG" .
-
-if [[ "${CI:-false}" == "true" && "${SEMAPHORE_GIT_BRANCH}" == "master" && -z "${SEMAPHORE_GIT_PR_BRANCH:-}" ]]; then
-  docker push "${IMAGE_VERSION_TAG}"
-
-  echo "$VERSION" > version
-  echo "Stored $VERSION in ./version"
+if [[ "${CI:-false}" == "true" ]]; then
+  PLATFORMS=linux/arm,linux/arm64,linux/amd64
+  if [[ "${SEMAPHORE_GIT_BRANCH}" == "master" && -z "${SEMAPHORE_GIT_PR_BRANCH:-}" ]]; then
+    OUTPUT=type=image,push=true
+    echo "$VERSION" > version
+    echo "Stored $VERSION in ./version"
+  else
+    OUTPUT=type=image,push=false
+  fi
+else
+  PLATFORMS=linux/amd64
+  OUTPUT=type=docker
 fi
+echo "Building ${OUTPUT} for ${PLATFORMS}"
+
+# Put cached wheels into the docker context so we can use it in our Dockerfile
+mkdir -p .wheel_cache
+mkdir -p build
+mkdir -p "${CACHE_DIR}/wheels"
+find "${CACHE_DIR}/wheels" -name "*.whl" -execdir cp "{}" "${PWD}/.wheel_cache" \;
+
+# Create a multi-arch buildx builder if needed
+if docker buildx ls | grep docker-container | grep multi-arch &> /dev/null; then
+  echo "Using existing multi-arch builder"
+  docker buildx use multi-arch
+else
+  echo "Creating new multi-arch builder"
+  docker buildx create --name multi-arch --driver docker-container --use --platform "${PLATFORMS}"
+fi
+
+# Run multi-arch build and push it
+docker buildx build --pull \
+  --tag "${IMAGE_LATEST_TAG}" \
+  --tag "${IMAGE_VERSION_TAG}" \
+  --platform "${PLATFORMS}" \
+  --output "${OUTPUT}" .
+
+# Once more to get the wheels
+docker buildx build \
+  --platform "${PLATFORMS}" \
+  --output type=tar,dest="${TARBALL}" .
+
+# Grab the wheels out of the tarball and stuff them in the pip cache directory
+tar -v -C "${CACHE_DIR}/wheels" --wildcards -x "*/wheels/*.whl" -x "wheels/*.whl" -f "${TARBALL}" 2>/dev/null || true
+
+# Clean up some wheels we don't want to cache
+find "${CACHE_DIR}/wheels" -name "fiaas*.whl" -delete

--- a/bin/docker_build
+++ b/bin/docker_build
@@ -48,7 +48,7 @@ docker buildx build --pull \
 
 # And again to load into docker if not already done
 if [[ "${OUTPUT}" != "type=docker" ]]; then
-  docker buuldx build \
+  docker buildx build \
     --tag "${IMAGE_LATEST_TAG}" \
     --output type=docker .
 fi

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -286,7 +286,7 @@ class TestE2E(object):
                 status = FiaasApplicationStatus.get(create_name(name, DEPLOYMENT_ID1))
                 assert status.result == u"RUNNING"
                 assert len(status.logs) > 0
-                assert any("Saving result RUNNING for default/{}".format(name) in l for l in status.logs)
+                assert any("Saving result RUNNING for default/{}".format(name) in line for line in status.logs)
 
             wait_until(_assert_status, patience=PATIENCE)
 


### PR DESCRIPTION
This is basically the same approach I tried for Skipper, except on Semaphore CI it works (I've tested using the really neat "debug ssh session" feature Semaphore has).

It also uses the wheel cache trick from Skipper, to avoid having to build all wheels every time.