### PR TITLE
Add 'uid' to AppSpec

### DIFF
--- a/fiaas_deploy_daemon/bootstrap/bootstrapper.py
+++ b/fiaas_deploy_daemon/bootstrap/bootstrapper.py
@@ -105,6 +105,7 @@ class Bootstrapper(object):
 
         try:
             app_spec = self._spec_factory(
+                application.metadata.uid,
                 name=application.spec.application,
                 image=application.spec.image,
                 app_config=application.spec.config,

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -108,6 +108,7 @@ class CrdWatcher(DaemonThread):
                                                      annotations=application.spec.additional_annotations.status)
         try:
             app_spec = self._spec_factory(
+                uid=application.metadata.uid,
                 name=app_name,
                 image=application.spec.image,
                 app_config=application.spec.config,
@@ -127,6 +128,7 @@ class CrdWatcher(DaemonThread):
 
     def _delete(self, application):
         app_spec = self._spec_factory(
+            uid=application.metadata.uid,
             name=application.spec.application,
             image=application.spec.image,
             app_config=application.spec.config,

--- a/fiaas_deploy_daemon/specs/factory.py
+++ b/fiaas_deploy_daemon/specs/factory.py
@@ -31,7 +31,7 @@ class SpecFactory(object):
         self._supported_versions = [factory.version] + transformers.keys()
         self._fiaas_counter = Counter("fiaas_yml_version", "The version of fiaas.yml used", ["version", "app_name"])
 
-    def __call__(self, name, image, app_config, teams, tags, deployment_id, namespace,
+    def __call__(self, uid, name, image, app_config, teams, tags, deployment_id, namespace,
                  additional_labels, additional_annotations):
         """Create an app_spec from app_config"""
         fiaas_version = app_config.get(u"version", 1)
@@ -39,7 +39,7 @@ class SpecFactory(object):
         LOG.info("Attempting to create app_spec for %s from fiaas.yml version %s", name, fiaas_version)
         try:
             app_config = self.transform(app_config)
-            app_spec = self._factory(name, image, teams, tags, app_config, deployment_id, namespace,
+            app_spec = self._factory(uid, name, image, teams, tags, app_config, deployment_id, namespace,
                                      additional_labels, additional_annotations)
         except InvalidConfiguration:
             raise

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -18,6 +18,7 @@ from collections import namedtuple
 
 
 class AppSpec(namedtuple("AppSpec", [
+    "uid",
     "namespace",
     "name",
     "image",

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -37,13 +37,14 @@ class Factory(BaseFactory):
         # Overwrite default value based on config flag for ingress_tls
         self._defaults["extensions"]["tls"]["enabled"] = config and config.use_ingress_tls == "default_on"
 
-    def __call__(self, name, image, teams, tags, app_config, deployment_id, namespace,
+    def __call__(self, uid, name, image, teams, tags, app_config, deployment_id, namespace,
                  additional_labels, additional_annotations):
         if app_config.get("extensions") and app_config["extensions"].get("tls") and type(
                 app_config["extensions"]["tls"]) == bool:
             app_config["extensions"]["tls"] = {u"enabled": app_config["extensions"]["tls"]}
         lookup = LookupMapping(config=app_config, defaults=self._defaults)
         app_spec = AppSpec(
+            uid=uid,
             namespace=namespace,
             name=name,
             image=image,

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -37,6 +37,7 @@ EMPTY_RESOURCE_SPEC = ResourcesSpec(requests=ResourceRequirementSpec(cpu=None, m
 @pytest.fixture
 def app_spec():
     return AppSpec(
+        uid="c1f34517-6f54-11ea-8eaf-0ad3d9992c8c",
         name="testapp",
         namespace="default",
         image="finntech/testimage:version",

--- a/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
@@ -41,7 +41,8 @@ ADD_EVENT = {
                 "fiaas/deployment_id": "deployment_id"
             },
             "name": "example",
-            "namespace": "the-namespace"
+            "namespace": "the-namespace",
+            "uid": "c1f34517-6f54-11ea-8eaf-0ad3d9992c8c"
         },
         "spec": {
             "application": "example",
@@ -196,7 +197,8 @@ class TestWatcher(object):
         app_config = spec["config"]
         additional_labels = AdditionalLabelsOrAnnotations()
         additional_annotations = AdditionalLabelsOrAnnotations()
-        spec_factory.assert_called_once_with(name=app_name, image=spec["image"], app_config=app_config,
+        spec_factory.assert_called_once_with(uid="c1f34517-6f54-11ea-8eaf-0ad3d9992c8c",
+                                             name=app_name, image=spec["image"], app_config=app_config,
                                              teams=[], tags=[],
                                              deployment_id=deployment_id,
                                              namespace=namespace,

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -34,6 +34,7 @@ INGRESSES_URI = '/apis/extensions/v1beta1/namespaces/default/ingresses/'
 
 def app_spec(**kwargs):
     default_app_spec = AppSpec(
+        uid="c1f34517-6f54-11ea-8eaf-0ad3d9992c8c",
         name="testapp",
         namespace="default",
         image="finntech/testimage:version",

--- a/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
+++ b/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
@@ -26,6 +26,7 @@ TEAMS = "IO"
 TAGS = "Foo"
 DEPLOYMENT_ID = "deployment_id"
 NAMESPACE = "namespace"
+UID = "c1f34517-6f54-11ea-8eaf-0ad3d9992c8c"
 
 
 class TestSpecFactory(object):
@@ -64,31 +65,31 @@ class TestSpecFactory(object):
         minimal_config = {}
         if version:
             minimal_config["version"] = version
-        factory(NAME, IMAGE, minimal_config, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+        factory(UID, NAME, IMAGE, minimal_config, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
         mock_factory = request.getfuncargvalue(mock_to_call)
         mock_factory.assert_called_with(minimal_config, strip_defaults=False)
 
     @pytest.mark.parametrize("version", [1, 2, 3])
     def test_parsed_by_current_version(self, factory, version, v3):
-        factory(NAME, IMAGE, {"version": version}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
-        v3.assert_called_with(NAME, IMAGE, TEAMS, TAGS, ANY, DEPLOYMENT_ID, NAMESPACE, None, None)
+        factory(UID, NAME, IMAGE, {"version": version}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+        v3.assert_called_with(UID, NAME, IMAGE, TEAMS, TAGS, ANY, DEPLOYMENT_ID, NAMESPACE, None, None)
 
     def test_raise_invalid_config_if_version_not_supported(self, factory):
         with pytest.raises(InvalidConfiguration):
-            factory(NAME, IMAGE, {"version": 999}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+            factory(UID, NAME, IMAGE, {"version": 999}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
 
     def test_raise_invalid_config_if_datadog_undefined_and_requested(self, factory, v3, app_spec):
         datadog_spec = app_spec.datadog._replace(enabled=True, tags={})
         v3.return_value = app_spec._replace(datadog=datadog_spec)
         with pytest.raises(InvalidConfiguration):
-            factory(NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+            factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
 
     def test_accept_config_if_datadog_defined_and_requested(self, factory, v3, app_spec, config):
         config.datadog_container_image = "datadog"
         datadog_spec = app_spec.datadog._replace(enabled=True, tags={})
         expected = app_spec._replace(datadog=datadog_spec)
         v3.return_value = expected
-        actual = factory(NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+        actual = factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
         assert actual == expected
 
     @pytest.mark.parametrize("exception", (
@@ -102,4 +103,4 @@ class TestSpecFactory(object):
     def test_parse_errors_raises_invalid_config(self, factory, v3, exception):
         v3.side_effect = exception
         with pytest.raises(InvalidConfiguration):
-            factory(NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+            factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)

--- a/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
+++ b/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
@@ -28,9 +28,11 @@ from fiaas_deploy_daemon.specs.v3.factory import Factory
 IMAGE = "finntech/docker-image:some-version"
 NAME = "application-name"
 NAMESPACE = "namespace-value"
+UID = "23840085-8ab6-11ea-b4f9-02a852666faa"
 
 TEST_DATA = {
     "v3minimal": {
+        "uid": UID,
         "namespace": NAMESPACE,
         "replicas": 5,
         "autoscaler.enabled": True,
@@ -365,7 +367,7 @@ class TestFactory(object):
             "v3minimal",
     ))
     def test_name_and_image(self, load_app_config_testdata, factory, filename):
-        app_spec = factory(NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
+        app_spec = factory(UID, NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
                            None, None)
         assert app_spec.name == NAME
         assert app_spec.image == IMAGE
@@ -378,7 +380,7 @@ class TestFactory(object):
     ))
     def test_invalid_configuration(self, load_app_config_testdata, factory, filename):
         with pytest.raises(InvalidConfiguration):
-            factory(NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
+            factory(UID, NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
                     None, None)
 
     @pytest.mark.parametrize("filename,attribute,value", (
@@ -416,7 +418,7 @@ class TestFactory(object):
             pod={"pod/annotation": "true", "z": "override"},
             status={"status/annotation": "true"},
         )
-        app_spec = factory(NAME, IMAGE, load_app_config_testdata(filename), [], [], "deployment_id", NAMESPACE,
+        app_spec = factory(UID, NAME, IMAGE, load_app_config_testdata(filename), [], [], "deployment_id", NAMESPACE,
                            additional_labels, additional_annotations)
         assert app_spec is not None
         code = "app_spec.%s" % attribute
@@ -425,7 +427,7 @@ class TestFactory(object):
         assert actual == value
 
     def test(self, load_app_config_testdata, factory, filename, attribute, value):
-        app_spec = factory(NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
+        app_spec = factory(UID, NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
                            None, None)
         assert app_spec is not None
         code = "app_spec.%s" % attribute


### PR DESCRIPTION
Include the Application's metadata.uid in the app-spec, so it can be
used as the referent when setting ownerReferences