### PR TITLE
Set uid=None when processing events in 'consumer' workflow

### DIFF
--- a/fiaas_deploy_daemon/pipeline/consumer.py
+++ b/fiaas_deploy_daemon/pipeline/consumer.py
@@ -127,7 +127,7 @@ class Consumer(DaemonThread):
 
         app_config = self._app_config_downloader.get(fiaas_url)
 
-        return self._spec_factory(name, image, app_config, teams, tags, deployment_id,
+        return self._spec_factory(None, name, image, app_config, teams, tags, deployment_id,
                                   DEFAULT_NAMESPACE, None, None)
 
     def _artifacts(self, event):

--- a/tests/fiaas_deploy_daemon/pipeline/test_consumer.py
+++ b/tests/fiaas_deploy_daemon/pipeline/test_consumer.py
@@ -111,7 +111,7 @@ class TestConsumer(object):
         assert app_config_downloader.get.call_count == 1
 
         image = EVENT[u"artifacts_by_type"][u"docker"]
-        factory.assert_called_once_with(EVENT[u"project_name"], image, app_config, EVENT[u"teams"], EVENT[u"tags"],
+        factory.assert_called_once_with(None, EVENT[u"project_name"], image, app_config, EVENT[u"teams"], EVENT[u"tags"],
                                         image.split(":")[-1], pipeline_consumer.DEFAULT_NAMESPACE, None, None)
 
     def test_fail_if_no_docker_image(self, consumer):


### PR DESCRIPTION
Here there is no Application CRD to take an ID from; when we come to
set the ownerReference, it will have to be omitted for this mode of
operation, and we can use uid=None to indicate that.