### PR TITLE
Set ownerReferences

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
@@ -23,6 +23,7 @@ from .autoscaler import AutoscalerDeployer
 from .deployment import DeploymentBindings
 from .ingress import IngressDeployer, IngressTls
 from .service import ServiceDeployer
+from .owner_references import OwnerReferences
 
 
 class K8sAdapterBindings(pinject.BindingSpec):
@@ -32,6 +33,7 @@ class K8sAdapterBindings(pinject.BindingSpec):
         bind("ingress_deployer", to_class=IngressDeployer)
         bind("autoscaler", to_class=AutoscalerDeployer)
         bind("ingress_tls", to_class=IngressTls)
+        bind("owner_references", to_class=OwnerReferences)
 
     def dependencies(self):
         return [DeploymentBindings()]

--- a/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
@@ -29,8 +29,9 @@ LOG = logging.getLogger(__name__)
 
 
 class AutoscalerDeployer(object):
-    def __init__(self):
+    def __init__(self, owner_references):
         self.name = "autoscaler"
+        self._owner_references = owner_references
 
     @retry_on_upsert_conflict
     def deploy(self, app_spec, labels):
@@ -45,6 +46,7 @@ class AutoscalerDeployer(object):
                                                maxReplicas=app_spec.replicas,
                                                targetCPUUtilizationPercentage=app_spec.autoscaler.cpu_threshold_percentage)
             autoscaler = HorizontalPodAutoscaler.get_or_create(metadata=metadata, spec=spec)
+            self._owner_references.apply(autoscaler, app_spec)
             autoscaler.save()
         else:
             try:

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -36,10 +36,11 @@ LOG = logging.getLogger(__name__)
 class DeploymentDeployer(object):
     MINIMUM_GRACE_PERIOD = 30
 
-    def __init__(self, config, datadog, prometheus, deployment_secrets):
+    def __init__(self, config, datadog, prometheus, deployment_secrets, owner_references):
         self._datadog = datadog
         self._prometheus = prometheus
         self._secrets = deployment_secrets
+        self._owner_references = owner_references
         self._fiaas_env = _build_fiaas_env(config)
         self._global_env = config.global_env
         self._lifecycle = None
@@ -120,6 +121,7 @@ class DeploymentDeployer(object):
         self._datadog.apply(deployment, app_spec, besteffort_qos_is_required)
         self._prometheus.apply(deployment, app_spec)
         self._secrets.apply(deployment, app_spec)
+        self._owner_references.apply(deployment, app_spec)
         deployment.save()
 
     def delete(self, app_spec):

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -33,10 +33,11 @@ LOG = logging.getLogger(__name__)
 
 
 class IngressDeployer(object):
-    def __init__(self, config, ingress_tls):
+    def __init__(self, config, ingress_tls, owner_references):
         self._ingress_suffixes = config.ingress_suffixes
         self._host_rewrite_rules = config.host_rewrite_rules
         self._ingress_tls = ingress_tls
+        self._owner_references = owner_references
 
     def deploy(self, app_spec, labels):
         if self._should_have_ingress(app_spec):
@@ -75,6 +76,7 @@ class IngressDeployer(object):
 
         ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
         self._ingress_tls.apply(ingress, app_spec, self._get_hosts(app_spec))
+        self._owner_references.apply(ingress, app_spec)
         ingress.save()
 
     def _generate_default_hosts(self, name):

--- a/fiaas_deploy_daemon/deployer/kubernetes/owner_references.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/owner_references.py
@@ -1,0 +1,15 @@
+from k8s.models.common import OwnerReference
+
+
+class OwnerReferences(object):
+
+    def apply(self, k8s_model, app_spec):
+        if app_spec.uid:
+            owner_reference = OwnerReference(apiVersion="fiaas.schibsted.io/v1",
+                                             blockOwnerDeletion=True,
+                                             controller=True,
+                                             kind="Application",
+                                             name=app_spec.name,
+                                             uid=app_spec.uid)
+
+            k8s_model.metadata.ownerReferences = [owner_reference]

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-deployment.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v2-data-examples-v2bootstrap
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v2-data-examples-v2bootstrap
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-ingress.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v2-data-examples-v2bootstrap
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v2-data-examples-v2bootstrap
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-service.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v2-data-examples-v2bootstrap
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v2-data-examples-v2bootstrap
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-deployment.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v3-data-examples-v3bootstrap
   namespace: kube-system
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v3-data-examples-v3bootstrap
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-hpa.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-hpa.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v3-data-examples-v3bootstrap
   namespace: kube-system
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v3-data-examples-v3bootstrap
   finalizers: []
 spec:
   maxReplicas: 5

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-ingress.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v3-data-examples-v3bootstrap
   namespace: kube-system
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v3-data-examples-v3bootstrap
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-service.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: 1.13.9-alpine
   name: specs-v3-data-examples-v3bootstrap
   namespace: kube-system
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: specs-v3-data-examples-v3bootstrap
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
+import mock
+
+from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
 
 
 @pytest.helpers.register
@@ -42,3 +45,8 @@ def create_metadata(app_name, namespace='default', labels=None, external=None, a
     if generation is not None:
         metadata['generation'] = generation
     return metadata
+
+
+@pytest.fixture
+def owner_references():
+    return mock.create_autospec(OwnerReferences(), spec_set=True, instance=True)

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -29,6 +29,8 @@ from fiaas_deploy_daemon.specs.models import CheckSpec, HttpCheckSpec, TcpCheckS
     ResourceRequirementSpec, ResourcesSpec, ExecCheckSpec, HealthCheckSpec, LabelAndAnnotationSpec
 from fiaas_deploy_daemon.tools import merge_dicts
 
+from utils import TypeMatcher
+
 SELECTOR = {'app': 'testapp'}
 LABELS = {"deployment_deployer": "pass through", "global_label": "impossible to override"}
 DEPLOYMENTS_URI = '/apis/apps/v1/namespaces/default/deployments/'
@@ -148,22 +150,23 @@ class TestDeploymentDeployer(object):
         return mock.create_autospec(Secrets(config, None, None), spec_set=True, instance=True)
 
     @pytest.mark.usefixtures("get")
-    def test_deploy_new_deployment(self, post, config, app_spec, datadog, prometheus, secrets):
+    def test_deploy_new_deployment(self, post, config, app_spec, datadog, prometheus, secrets, owner_references):
         expected_deployment = create_expected_deployment(config, app_spec)
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_deployment
         post.side_effect = None
         post.return_value = mock_response
 
-        deployer = DeploymentDeployer(config, datadog, prometheus, secrets)
+        deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references)
         deployer.deploy(app_spec, SELECTOR, LABELS, False)
 
         pytest.helpers.assert_any_call(post, DEPLOYMENTS_URI, expected_deployment)
-        datadog.apply.assert_called_once_with(DeploymentMatcher(), app_spec, False)
-        prometheus.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
-        secrets.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
+        datadog.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec, False)
+        prometheus.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
+        secrets.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
+        owner_references.apply.assert_called_with(TypeMatcher(Deployment), app_spec)
 
-    def test_deploy_clears_alpha_beta_annotations(self, put, get, config, app_spec, datadog, prometheus, secrets):
+    def test_deploy_clears_alpha_beta_annotations(self, put, get, config, app_spec, datadog, prometheus, secrets, owner_references):
         old_strongbox_spec = app_spec.strongbox._replace(enabled=True, groups=["group1", "group2"])
         old_app_spec = app_spec._replace(replicas=10, strongbox=old_strongbox_spec)
         old_deployment = create_expected_deployment(config, old_app_spec, add_init_container_annotations=True)
@@ -178,7 +181,7 @@ class TestDeploymentDeployer(object):
         put.side_effect = None
         put.return_value = put_mock_response
 
-        deployer = DeploymentDeployer(config, datadog, prometheus, secrets)
+        deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references)
         deployer.deploy(app_spec, SELECTOR, LABELS, False)
 
         pytest.helpers.assert_any_call(put, DEPLOYMENTS_URI + "testapp", expected_deployment)
@@ -193,8 +196,8 @@ class TestDeploymentDeployer(object):
     ))
     def test_replicas_when_autoscaler_enabled(self, previous_replicas, max_replicas, min_replicas, cpu_request,
                                               expected_replicas, config, app_spec, get, put, post, datadog, prometheus,
-                                              secrets):
-        deployer = DeploymentDeployer(config, datadog, prometheus, secrets)
+                                              secrets, owner_references):
+        deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references)
 
         image = "finntech/testimage:version2"
         version = "version2"

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_owner_references.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_owner_references.py
@@ -1,0 +1,38 @@
+import pytest
+
+from k8s.models.common import ObjectMeta, OwnerReference
+from k8s.models.ingress import Ingress
+
+from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
+
+
+class TestOwnerReferences(object):
+
+    @pytest.fixture
+    def owner_references(self):
+        return OwnerReferences()
+
+    @pytest.fixture
+    def expected(self, app_spec):
+        expected = OwnerReference(apiVersion="fiaas.schibsted.io/v1",
+                                  kind="Application",
+                                  controller=True,
+                                  blockOwnerDeletion=True,
+                                  name=app_spec.name,
+                                  uid=app_spec.uid)
+        return expected
+
+    def test_apply(self, app_spec, owner_references, expected):
+        ingress = Ingress(metadata=ObjectMeta())
+
+        owner_references.apply(ingress, app_spec)
+
+        assert ingress.metadata.ownerReferences == [expected]
+
+    def test_apply_with_no_uid(self, app_spec, owner_references):
+        ingress = Ingress(metadata=ObjectMeta())
+        app_spec = app_spec._replace(uid=None)
+
+        owner_references.apply(ingress, app_spec)
+
+        assert ingress.metadata.ownerReferences == []

--- a/tests/fiaas_deploy_daemon/e2e_expected/exec-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/exec-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-exec-config
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-exec-config
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/exec-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/exec-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-exec-config
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-exec-config
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/exec-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/exec-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-exec-config
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-exec-config
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/host-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/host-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-host
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-host
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/host-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/host-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-host
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-host
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/host-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/host-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-host
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-host
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-multiple-hosts-multiple-paths
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-hosts-multiple-paths
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-hpa.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-multiple-hosts-multiple-paths
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-hosts-multiple-paths
   finalizers: []
 spec:
   maxReplicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-multiple-hosts-multiple-paths
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-hosts-multiple-paths
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-multiple-hosts-multiple-paths
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-hosts-multiple-paths
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ports-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ports-deployment.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-multiple-ports
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-multiple-ports
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ports-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ports-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-multiple-ports
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-multiple-ports
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-partial-override
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-partial-override
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-hpa.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-partial-override
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-partial-override
   finalizers: []
 spec:
   maxReplicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-partial-override
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-partial-override
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-partial-override
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-partial-override
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/secrets-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/secrets-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-secrets
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-secrets
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/single-replica-not-singleton.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single-replica-not-singleton.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-single-replica-not-singleton
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-single-replica-not-singleton
   finalizers: []
 spec:
   replicas: 1

--- a/tests/fiaas_deploy_daemon/e2e_expected/single-replica-singleton.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single-replica-singleton.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-single-replica-singleton
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-single-replica-singleton
   finalizers: []
 spec:
   replicas: 1

--- a/tests/fiaas_deploy_daemon/e2e_expected/single_tcp_port-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single_tcp_port-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-single-tcp-port
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-single-tcp-port
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/single_tcp_port-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single_tcp_port-service.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-single-tcp-port
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-single-tcp-port
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-strongbox
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-strongbox
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-hpa.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-strongbox
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-strongbox
   finalizers: []
 spec:
   maxReplicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-strongbox
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-strongbox
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-strongbox
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-strongbox
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/tcp_ports-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tcp_ports-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-tcp-ports
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-tcp-ports
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/tcp_ports-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tcp_ports-service.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: v2-data-examples-tcp-ports
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v2-data-examples-tcp-ports
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment-cert-issuer.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled-cert-issuer
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled-cert-issuer
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa-cert-issuer.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled-cert-issuer
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled-cert-issuer
   finalizers: []
 spec:
   maxReplicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled
   finalizers: []
 spec:
   maxReplicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-cert-issuer.yml
@@ -25,7 +25,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled-cert-issuer
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled-cert-issuer
   finalizers: []
 spec:
   tls:

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-multiple.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-multiple.yml
@@ -11,7 +11,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled-multiple
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled-multiple
   finalizers: []
 spec:
   tls:

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress.yml
@@ -25,7 +25,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled
   finalizers: []
 spec:
   tls:

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-service-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-service-cert-issuer.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled-cert-issuer
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled-cert-issuer
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: v3-data-examples-tls-enabled
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-deployment.yml
@@ -23,7 +23,12 @@ metadata:
     fiaas/version: VERSION
   name: data-v2minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: data-v2minimal
   finalizers: []
 spec:
   replicas: 2

--- a/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-ingress.yml
@@ -24,7 +24,12 @@ metadata:
     fiaas/version: VERSION
   name: data-v2minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: data-v2minimal
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-service.yml
@@ -22,7 +22,12 @@ metadata:
     fiaas/version: VERSION
   name: data-v2minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: data-v2minimal
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
@@ -29,7 +29,12 @@ metadata:
     deployment/label: "true"
   name: v3-data-examples-full
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-full
   finalizers: []
 spec:
   replicas: 20

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-hpa.yml
@@ -29,7 +29,12 @@ metadata:
     horizontal-pod-autoscaler/label: "true"
   name: v3-data-examples-full
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-full
   finalizers: []
 spec:
   maxReplicas: 20

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-ingress.yml
@@ -30,7 +30,12 @@ metadata:
     ingress/label: "true"
   name: v3-data-examples-full
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-full
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-service.yml
@@ -30,7 +30,12 @@ metadata:
     service/label: "true"
   name: v3-data-examples-full
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-full
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-deployment.yml
@@ -25,7 +25,12 @@ metadata:
     deployment/label: "true"
   name: v3-data-examples-v3minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-v3minimal
   finalizers: []
 spec:
   replicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-hpa.yml
@@ -24,7 +24,12 @@ metadata:
     horizontal-pod-autoscaler/label: "true"
   name: v3-data-examples-v3minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-v3minimal
   finalizers: []
 spec:
   maxReplicas: 5

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-ingress.yml
@@ -26,7 +26,12 @@ metadata:
     ingress/label: "true"
   name: v3-data-examples-v3minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-v3minimal
   finalizers: []
 spec:
   tls: []

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-service.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-service.yml
@@ -24,7 +24,12 @@ metadata:
     service/label: "true"
   name: v3-data-examples-v3minimal
   namespace: default
-  ownerReferences: []
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-v3minimal
   finalizers: []
 spec:
   ports:

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -109,7 +109,7 @@ def sanitize_resource_name(yml_path):
     return re.sub("[^-a-z0-9]", "-", yml_path.replace(".yml", ""))
 
 
-def assert_k8s_resource_matches(resource, expected_dict, image, service_type, deployment_id, strongbox_groups):
+def assert_k8s_resource_matches(resource, expected_dict, image, service_type, deployment_id, strongbox_groups, app_uid=None):
     actual_dict = deepcopy(resource.as_dict())
     expected_dict = deepcopy(expected_dict)
 
@@ -125,6 +125,10 @@ def assert_k8s_resource_matches(resource, expected_dict, image, service_type, de
 
     if expected_dict["kind"] == "Service":
         _set_service_type(expected_dict, service_type)
+
+    if app_uid:
+        for ref in expected_dict["metadata"]["ownerReferences"]:
+            ref["uid"] = app_uid
 
     # the k8s client library doesn't return apiVersion or kind, so ignore those fields
     del expected_dict['apiVersion']
@@ -343,3 +347,12 @@ class KindWrapper(object):
 
 def _is_macos():
     return os.uname()[0] == 'Darwin'
+
+
+class TypeMatcher(object):
+
+    def __init__(self, _type):
+        self._type = _type
+
+    def __eq__(self, other):
+        return isinstance(other, self._type)


### PR DESCRIPTION
This adds a new service, OwnerReferences can be used to set the ownerReferences field on a k8s Model passed to it, using the relevant information from an AppSpec.

For the e2e tests, to allow the checking of the set uid field to that of the Application, it's modified to set that value on the expected object.

- 1f295df adds the new service, but without using it
- f728fa1 adds the ref to the Ingress object, and this commit includes the changes to the tests that are then used by the rest
- then there is a commit per object-type

I split it up to (hopefully) aid reviewing, as the test changes are a little noisy - I will squash before merging.

The code for handing the delete events isn't removed here, as any currently deployed applications won't have the owner set, and so wouldn't cleanup properly if they were deleted. Leaving some time between releasing this, and removing the delete flow, will allow time for those applications to be re-deployed so they set the reference. (The code is ready, I can open a separate PR so it can be looked at.)

This also doesn't yet include attaching the owner to the ApplicationStatus; those currently aren't cleaned up by the deletion event anyway, so there's no regression, and the code to support that is a little different. (It's ready, I'll open a separate PR for that too).

Part of #10 