### PR TITLE
Set ownerReferences on ApplicationStatus

### DIFF
--- a/fiaas_deploy_daemon/bootstrap/bootstrapper.py
+++ b/fiaas_deploy_daemon/bootstrap/bootstrapper.py
@@ -96,7 +96,8 @@ class Bootstrapper(object):
             raise ValueError("The Application {} is missing the 'fiaas/deployment_id' label".format(
                 application.spec.application))
 
-        lifecycle_subject = self._lifecycle.initiate(app_name=application.spec.application,
+        lifecycle_subject = self._lifecycle.initiate(uid=application.metadata.uid,
+                                                     app_name=application.spec.application,
                                                      namespace=application.metadata.namespace,
                                                      deployment_id=deployment_id,
                                                      repository=None,

--- a/fiaas_deploy_daemon/crd/status.py
+++ b/fiaas_deploy_daemon/crd/status.py
@@ -58,7 +58,7 @@ def _handle_signal(sender, status, subject):
 
 @retry_on_upsert_conflict
 def _save_status(result, subject):
-    (app_name, namespace, deployment_id, repository, labels, annotations) = subject
+    (uid, app_name, namespace, deployment_id, repository, labels, annotations) = subject
     LOG.info("Saving result %s for %s/%s deployment_id=%s", result, namespace, app_name, deployment_id)
     name = create_name(app_name, deployment_id)
     labels = labels or {}

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -100,7 +100,8 @@ class CrdWatcher(DaemonThread):
             LOG.debug("Have already deployed %s for app %s", deployment_id, app_name)
             return
         repository = _repository(application)
-        lifecycle_subject = self._lifecycle.initiate(app_name=app_name,
+        lifecycle_subject = self._lifecycle.initiate(uid=application.metadata.uid,
+                                                     app_name=app_name,
                                                      namespace=application.metadata.namespace,
                                                      deployment_id=deployment_id,
                                                      repository=repository,

--- a/fiaas_deploy_daemon/lifecycle.py
+++ b/fiaas_deploy_daemon/lifecycle.py
@@ -26,7 +26,7 @@ STATUS_SUCCESS = "success"
 STATUS_INITIATED = "initiated"
 
 
-Subject = namedtuple("Subject", ("app_name", "namespace", "deployment_id", "repository", "labels", "annotations"))
+Subject = namedtuple("Subject", ("uid", "app_name", "namespace", "deployment_id", "repository", "labels", "annotations"))
 
 
 class Lifecycle(object):
@@ -35,8 +35,8 @@ class Lifecycle(object):
     def change(self, status, subject):
         self.state_change_signal.send(status=status, subject=subject)
 
-    def initiate(self, app_name, namespace, deployment_id, repository=None, labels=None, annotations=None):
-        subject = Subject(app_name, namespace, deployment_id, repository, labels, annotations)
+    def initiate(self, uid, app_name, namespace, deployment_id, repository=None, labels=None, annotations=None):
+        subject = Subject(uid, app_name, namespace, deployment_id, repository, labels, annotations)
         self.state_change_signal.send(status=STATUS_INITIATED, subject=subject)
         return subject
 

--- a/tests/fiaas_deploy_daemon/crd/test_crd_status.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_status.py
@@ -148,7 +148,14 @@ class TestStatusReport(object):
                 },
                 'namespace': 'default',
                 'name': app_name,
-                'ownerReferences': [],
+                'ownerReferences': [{
+                    'controller': True,
+                    'apiVersion': 'fiaas.schibsted.io/v1',
+                    'kind': 'Application',
+                    'blockOwnerDeletion': True,
+                    'name': app_spec.name,
+                    'uid': app_spec.uid
+                }],
                 'finalizers': [],
             }
         }

--- a/tests/fiaas_deploy_daemon/crd/test_crd_status.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_status.py
@@ -260,7 +260,8 @@ class TestStatusReport(object):
 
 
 def _subject_from_app_spec(app_spec):
-    return Subject(app_spec.name,
+    return Subject(app_spec.uid,
+                   app_spec.name,
                    app_spec.namespace,
                    app_spec.deployment_id,
                    None,

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -39,7 +39,8 @@ class TestReadyCheck(object):
 
     @pytest.fixture
     def lifecycle_subject(self, app_spec):
-        return Subject(app_spec.name, app_spec.namespace, app_spec.deployment_id, None, app_spec.labels.status, app_spec.annotations.status)
+        return Subject(app_spec.uid, app_spec.name, app_spec.namespace, app_spec.deployment_id, None,
+                       app_spec.labels.status, app_spec.annotations.status)
 
     @pytest.fixture
     def config(self):

--- a/tests/fiaas_deploy_daemon/deployer/test_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/test_deploy.py
@@ -51,7 +51,7 @@ class TestDeploy(object):
 
     @pytest.fixture
     def lifecycle_subject(self, app_spec):
-        return Subject(app_spec.name, app_spec.namespace, app_spec.deployment_id, None,
+        return Subject(app_spec.uid, app_spec.name, app_spec.namespace, app_spec.deployment_id, None,
                        app_spec.labels.status, app_spec.annotations.status)
 
     @pytest.fixture

--- a/tests/fiaas_deploy_daemon/usage_reporting/test_usage_reporter.py
+++ b/tests/fiaas_deploy_daemon/usage_reporting/test_usage_reporter.py
@@ -57,8 +57,8 @@ class TestUsageReporter(object):
     def test_signal_to_event(self, config, mock_transformer, mock_session, mock_auth, app_spec, result, repository):
         reporter = UsageReporter(config, mock_transformer, mock_session, mock_auth)
 
-        lifecycle_subject = Subject(app_name=app_spec.name, namespace=app_spec.namespace, deployment_id=app_spec.deployment_id,
-                                    repository=repository, labels=None, annotations=None)
+        lifecycle_subject = Subject(uid=app_spec.uid, app_name=app_spec.name, namespace=app_spec.namespace,
+                                    deployment_id=app_spec.deployment_id, repository=repository, labels=None, annotations=None)
         signal(DEPLOY_STATUS_CHANGED).send(status=result, subject=lifecycle_subject)
 
         event = reporter._event_queue.get_nowait()


### PR DESCRIPTION
To make the uid available to the saving of the ApplicationStatus too
requires that we include the uid in the Subject that is the base for
updating the Status

This fixes #78 