### PR TITLE
Remove code-path for responding to Delete events

### DIFF
--- a/fiaas_deploy_daemon/deployer/deploy.py
+++ b/fiaas_deploy_daemon/deployer/deploy.py
@@ -47,8 +47,6 @@ class Deployer(DaemonThread):
             LOG.info("Received %r for %s", event.app_spec, event.action)
             if event.action == "UPDATE":
                 self._update(event.app_spec, event.lifecycle_subject)
-            elif event.action == "DELETE":
-                self._delete(event.app_spec)
             else:
                 raise ValueError("Unknown DeployerEvent action {}".format(event.action))
 
@@ -68,10 +66,6 @@ class Deployer(DaemonThread):
             LOG.exception("Error while deploying %s: ", app_spec.name)
             self._lifecycle.failed(lifecycle_subject)
             self._bookkeeper.failed(app_spec)
-
-    def _delete(self, app_spec):
-        self._adapter.delete(app_spec)
-        LOG.info("Completed removal of %r", app_spec)
 
 
 def _make_gen(func):

--- a/fiaas_deploy_daemon/deployer/kubernetes/adapter.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/adapter.py
@@ -47,12 +47,6 @@ class K8s(object):
         self._deployment_deployer.deploy(app_spec, selector, labels, _besteffort_qos_is_required(app_spec))
         self._autoscaler_deployer.deploy(app_spec, labels)
 
-    def delete(self, app_spec):
-        self._ingress_deployer.delete(app_spec)
-        self._autoscaler_deployer.delete(app_spec)
-        self._service_deployer.delete(app_spec)
-        self._deployment_deployer.delete(app_spec)
-
     def _make_labels(self, app_spec):
         labels = {
             "app": app_spec.name,

--- a/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
@@ -55,13 +55,6 @@ class AutoscalerDeployer(object):
             except NotFound:
                 pass
 
-    def delete(self, app_spec):
-        LOG.info("Deleting autoscaler for %s", app_spec.name)
-        try:
-            HorizontalPodAutoscaler.delete(app_spec.name, app_spec.namespace)
-        except NotFound:
-            pass
-
 
 def should_have_autoscaler(app_spec):
     if not _autoscaler_enabled(app_spec.autoscaler):

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -124,14 +124,6 @@ class DeploymentDeployer(object):
         self._owner_references.apply(deployment, app_spec)
         deployment.save()
 
-    def delete(self, app_spec):
-        LOG.info("Deleting deployment for %s", app_spec.name)
-        try:
-            body = {"kind": "DeleteOptions", "apiVersion": "v1", "propagationPolicy": "Foreground"}
-            Deployment.delete(app_spec.name, app_spec.namespace, body=body)
-        except NotFound:
-            pass
-
     def _make_volumes(self, app_spec):
         volumes = []
         volumes.append(Volume(name="{}-config".format(app_spec.name),

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -43,9 +43,9 @@ class IngressDeployer(object):
         if self._should_have_ingress(app_spec):
             self._create(app_spec, labels)
         else:
-            self.delete(app_spec)
+            self._delete(app_spec)
 
-    def delete(self, app_spec):
+    def _delete(self, app_spec):
         LOG.info("Deleting ingress for %s", app_spec.name)
         try:
             Ingress.delete(app_spec.name, app_spec.namespace)

--- a/fiaas_deploy_daemon/deployer/kubernetes/service.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/service.py
@@ -38,9 +38,9 @@ class ServiceDeployer(object):
         if self._should_have_service(app_spec):
             self._create(app_spec, selector, labels)
         else:
-            self.delete(app_spec)
+            self._delete(app_spec)
 
-    def delete(self, app_spec):
+    def _delete(self, app_spec):
         LOG.info("Deleting service for %s", app_spec.name)
         try:
             Service.delete(app_spec.name, app_spec.namespace)


### PR DESCRIPTION
Now that we are setting ownerReferences on the created objects
kubernetes will take care of deleting them for us when the application
is deleted, so we can remove all the code related to that.

The delete methods for service, ingress and autoscaler are still needed
for the case where the config changes such that they are no longer
required, but now they can be private/internal methods.