### PR TITLE
Support deploying multiple ingresses

### DIFF
--- a/docs/v3_spec.md
+++ b/docs/v3_spec.md
@@ -143,7 +143,8 @@ replicas:
 
 This object configures path-based/layer 7 routing of requests to the application.
 It is a list of hosts which can each have a list of path and port combinations. Requests to the combination of host and
-path will be routed to the port specified on the path element.
+path will be routed to the port specified on the path element. Setting annotations on an entry means a separate Ingress
+will be created, and will have metadata.annotations set accordingly.
 
 Default value:
 ```yaml
@@ -152,21 +153,22 @@ ingress:
     paths:
     - path: /
       port: http
+    annotations: {}
 ```
 
-All applications will get a set of default hosts, if the cluster operator has defined ingress suffixes. 
+All applications will get a set of default hosts, if the cluster operator has defined ingress suffixes.
 If you do not specify a host in your `ingress` configuration, these default hosts will be used.
-For example : 
+For example :
 1. `your-app.example1.com`
 2. `your-app.example2.com`
 
-When you expose a path on a host you get that one as well. For example : 
+When you expose a path on a host you get that one as well. For example :
 ```yaml
 ingress:
   - host: example.com
     paths:
     - path: /my-path
-``` 
+```
 
 If you want to customize paths for default hosts as well, you can do it as :
 ```yaml
@@ -179,8 +181,8 @@ ingress:
 
 ```
 
-This will make `/some-other-path` available on default hosts, but not on the host you provided in ingress. 
-Remember, default hosts will also contain the paths from the ingress.   
+This will make `/some-other-path` available on default hosts, but not on the host you provided in ingress.
+Remember, default hosts will also contain the paths from the ingress.
 
 ### host
 
@@ -203,7 +205,7 @@ ingress:
   - host: your-app.example.com
 ```
 
-If the operator of your cluster has configured host-rewrite rules they will be applied to the hostname given in this 
+If the operator of your cluster has configured host-rewrite rules they will be applied to the hostname given in this
 field. See [the operator guide](operator_guide.md#host-rewrite-rules) for details about how this feature works.
 
 In typical clusters, this value should be the host used by your application in production, and host-rewrite rules should
@@ -234,6 +236,52 @@ your application. Requests to `your-app.example.com/metrics` will go to the port
 be defined under the `ports` configuration structure. It is also possible to use a port number, but named ports are
 strongly recommended.
 
+### annotations
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+A map of annotations to add to the ingress.
+
+Each entry in the ingress list that contains a non-empty `annotations` value will cause a separate Ingress object to
+be created during the deployment. All items that have an empty value will have their hosts/paths merged into a single
+Ingress.
+
+Example:
+```yaml
+ingress:
+  - host: your-app.example.com
+    paths:
+      - path: /foo
+  - host: other.example.com
+    paths:
+      - path: /foo
+    annotations:
+      some/annotation: bar
+```
+
+In this example, the first ingress will be created for `your-app.example.com` (along with any default suffixes, if present) and
+a second will be created for `other.example.com` and this will be annotated with the provided values.
+
+Annotations defined within the `ingress.annotations` config will take precedence over any defined in the top-level `annotations`
+configuration.
+
+Example:
+```yaml
+ingress:
+  - host: app.example.com
+  - host: other.example.com
+    annotations:
+      some/annotation: foo
+
+annotations:
+  ingress:
+    some/annotation: bar
+```
+
+In this example, the ingress for `app.example.com` will have the annotation set with the value `bar`, while the ingress for
+`other.example.com` will have it set to `foo`.
 
 ## healthchecks
 

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -22,12 +22,14 @@ import logging
 from itertools import chain
 
 from k8s.client import NotFound
+from k8s.base import Equality, Inequality, Exists
 from k8s.models.common import ObjectMeta
 from k8s.models.ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend, \
     IngressTLS
 
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
+from collections import namedtuple
 
 LOG = logging.getLogger(__name__)
 
@@ -43,48 +45,95 @@ class IngressDeployer(object):
         if self._should_have_ingress(app_spec):
             self._create(app_spec, labels)
         else:
-            self.delete(app_spec)
+            self._delete_unused(app_spec, labels)
 
     def delete(self, app_spec):
-        LOG.info("Deleting ingress for %s", app_spec.name)
+        LOG.info("Deleting ingresses for %s", app_spec.name)
         try:
-            Ingress.delete(app_spec.name, app_spec.namespace)
+            Ingress.delete_list(namespace=app_spec.namespace, labels={"app": Equality(app_spec.name), "fiaas/deployment_id": Exists()})
         except NotFound:
             pass
 
-    @retry_on_upsert_conflict
     def _create(self, app_spec, labels):
-        LOG.info("Creating/updating ingress for %s", app_spec.name)
-        annotations = {
-            u"fiaas/expose": u"true" if _has_explicitly_set_host(app_spec) else u"false"
-        }
-
+        LOG.info("Creating/updating ingresses for %s", app_spec.name)
         custom_labels = merge_dicts(app_spec.labels.ingress, labels)
-        custom_annotations = merge_dicts(app_spec.annotations.ingress, annotations)
-        metadata = ObjectMeta(name=app_spec.name, namespace=app_spec.namespace, labels=custom_labels,
-                              annotations=custom_annotations)
+
+        ingresses = self._group_ingresses_by_annotations(app_spec)
+
+        LOG.info("Will create %s ingresses", len(ingresses))
+        for annotated_ingress in ingresses:
+            if len(annotated_ingress.ingress_items) == 0:
+                LOG.info("No items, skipping: %s", annotated_ingress)
+                continue
+
+            self._create_ingress(app_spec, annotated_ingress, custom_labels)
+
+        self._delete_unused(app_spec, custom_labels)
+
+    def _group_ingresses_by_annotations(self, app_spec):
+        ''' Group the ingresses so that those with annotations are individual, keeping all without
+        annotations together
+        '''
+        AnnotatedIngress = namedtuple("AnnotatedIngress", ["name", "ingress_items", "annotations"])
+        unannotated_ingress = AnnotatedIngress(name=app_spec.name, ingress_items=[], annotations={})
+        ingresses = [unannotated_ingress]
+        for ingress_item in app_spec.ingresses:
+            if ingress_item.annotations:
+                next_name = "{}-{}".format(app_spec.name, len(ingresses))
+                annotated_ingresses = AnnotatedIngress(name=next_name, ingress_items=[ingress_item], annotations=ingress_item.annotations)
+                ingresses.append(annotated_ingresses)
+            else:
+                unannotated_ingress.ingress_items.append(ingress_item)
+
+        return ingresses
+
+    @retry_on_upsert_conflict
+    def _create_ingress(self, app_spec, annotated_ingress, labels):
+        default_annotations = {
+            u"fiaas/expose": u"true" if _has_explicitly_set_host(annotated_ingress.ingress_items) else u"false"
+        }
+        annotations = merge_dicts(app_spec.annotations.ingress, annotated_ingress.annotations, default_annotations)
+
+        metadata = ObjectMeta(name=annotated_ingress.name, namespace=app_spec.namespace, labels=labels,
+                              annotations=annotations)
 
         per_host_ingress_rules = [
             IngressRule(host=self._apply_host_rewrite_rules(ingress_item.host),
                         http=self._make_http_ingress_rule_value(app_spec, ingress_item.pathmappings))
-            for ingress_item in app_spec.ingresses
+            for ingress_item in annotated_ingress.ingress_items
             if ingress_item.host is not None
         ]
-        default_host_ingress_rules = self._create_default_host_ingress_rules(app_spec)
+        if annotated_ingress.annotations:
+            use_suffixes = False
+            host_ingress_rules = per_host_ingress_rules
+        else:
+            use_suffixes = True
+            host_ingress_rules = per_host_ingress_rules + self._create_default_host_ingress_rules(app_spec)
 
-        ingress_spec = IngressSpec(rules=per_host_ingress_rules + default_host_ingress_rules)
+        ingress_spec = IngressSpec(rules=host_ingress_rules)
 
         ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
-        self._ingress_tls.apply(ingress, app_spec, self._get_hosts(app_spec))
+
+        hosts_for_tls = [rule.host for rule in host_ingress_rules]
+        self._ingress_tls.apply(ingress, app_spec, hosts_for_tls, use_suffixes=use_suffixes)
         self._owner_references.apply(ingress, app_spec)
         ingress.save()
+
+    def _delete_unused(self, app_spec, labels):
+        filter_labels = [
+            ("app", Equality(labels["app"])),
+            ("fiaas/deployment_id", Exists()),
+            ("fiaas/deployment_id", Inequality(labels["fiaas/deployment_id"]))
+        ]
+        Ingress.delete_list(namespace=app_spec.namespace, labels=filter_labels)
 
     def _generate_default_hosts(self, name):
         for suffix in self._ingress_suffixes:
             yield u"{}.{}".format(name, suffix)
 
     def _create_default_host_ingress_rules(self, app_spec):
-        all_pathmappings = chain.from_iterable(ingress_item.pathmappings for ingress_item in app_spec.ingresses)
+        all_pathmappings = chain.from_iterable(ingress_item.pathmappings
+                                               for ingress_item in app_spec.ingresses if not ingress_item.annotations)
         http_ingress_rule_value = self._make_http_ingress_rule_value(app_spec, all_pathmappings)
         return [IngressRule(host=host, http=http_ingress_rule_value)
                 for host in self._generate_default_hosts(app_spec.name)]
@@ -99,7 +148,7 @@ class IngressDeployer(object):
         return self._can_generate_host(app_spec) and _has_ingress(app_spec) and _has_http_port(app_spec)
 
     def _can_generate_host(self, app_spec):
-        return len(self._ingress_suffixes) > 0 or _has_explicitly_set_host(app_spec)
+        return len(self._ingress_suffixes) > 0 or _has_explicitly_set_host(app_spec.ingresses)
 
     @staticmethod
     def _make_http_ingress_rule_value(app_spec, pathmappings):
@@ -115,8 +164,8 @@ class IngressDeployer(object):
                 for ingress_item in app_spec.ingresses if ingress_item.host is not None]
 
 
-def _has_explicitly_set_host(app_spec):
-    return any(ingress.host is not None for ingress in app_spec.ingresses)
+def _has_explicitly_set_host(ingress_items):
+    return any(ingress_item.host is not None for ingress_item in ingress_items)
 
 
 def _has_http_port(app_spec):
@@ -142,7 +191,7 @@ class IngressTls(object):
         self._shortest_suffix = sorted(config.ingress_suffixes, key=len)[0] if config.ingress_suffixes else None
         self.enable_deprecated_tls_entry_per_host = config.enable_deprecated_tls_entry_per_host
 
-    def apply(self, ingress, app_spec, hosts):
+    def apply(self, ingress, app_spec, hosts, use_suffixes=True):
         if self._should_have_ingress_tls(app_spec):
             tls_annotations = {}
             if self._cert_issuer or app_spec.ingress_tls.certificate_issuer:
@@ -162,8 +211,12 @@ class IngressTls(object):
             else:
                 ingress.spec.tls = []
 
-            collapsed = self._collapse_hosts(app_spec, hosts)
-            ingress.spec.tls.append(IngressTLS(hosts=collapsed, secretName="{}-ingress-tls".format(app_spec.name)))
+            if use_suffixes:
+                # adding app-name to suffixes could result in a host too long to be the common-name of a cert, and
+                # as the user doesn't control it we should generate a host we know will fit
+                hosts = self._collapse_hosts(app_spec, hosts)
+
+            ingress.spec.tls.append(IngressTLS(hosts=hosts, secretName="{}-ingress-tls".format(ingress.metadata.name)))
 
     def _collapse_hosts(self, app_spec, hosts):
         """The first hostname in the list will be used as Common Name in the certificate"""

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -119,6 +119,7 @@ LabelAndAnnotationSpec = namedtuple("LabelAndAnnotationSpec", [
 IngressItemSpec = namedtuple("IngressItemSpec", [
     "host",
     "pathmappings",
+    "annotations"
 ])
 
 IngressPathMappingSpec = namedtuple("IngressPathMappingSpec", [

--- a/fiaas_deploy_daemon/specs/v3/defaults.yml
+++ b/fiaas_deploy_daemon/specs/v3/defaults.yml
@@ -25,6 +25,7 @@ ingress: # Generate ingress rules for access from outside cluster. To disable, s
     paths: # List of paths exposed to which application port
     - path: / # Path the application answers on
       port: http # Name of the port path is served on
+    annotations: {}
 healthchecks: # Healthchecks defined for your application. If omitted and a single port is defined, liveness will default to http or tcp depending on port type, and readiness will be a copy of liveness. If no ports or multiple ports are defined, healthchecks are not provided and should be defined explicitly
   liveness:
     # Valid configuration requires exactly one of execute|http|tcp

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -207,15 +207,15 @@ class Factory(BaseFactory):
             else:
                 raise InvalidConfiguration("{} is not a valid port name or port number".format(port))
 
-        def ingress_item(host, paths):
+        def ingress_item(host, paths, annotations):
             ingress_path_mapping_specs = [
                 IngressPathMappingSpec(path=pathmapping["path"], port=resolve_port_number(pathmapping["port"]))
                 for pathmapping in paths
             ]
-            return IngressItemSpec(host=host, pathmappings=ingress_path_mapping_specs)
+            return IngressItemSpec(host=host, pathmappings=ingress_path_mapping_specs, annotations=annotations)
 
         if len(http_ports.items()) > 0:
-            return [ingress_item(host_path_mapping["host"], host_path_mapping["paths"])
+            return [ingress_item(host_path_mapping["host"], host_path_mapping["paths"], host_path_mapping["annotations"])
                     for host_path_mapping in ingress_lookup]
         else:
             return []

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ GENERIC_REQ = [
     "pinject == 0.14.1",
     "six == 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.14.0",
+    "k8s == 0.15.0",
     "monotonic == 1.5",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,11 @@ def prometheus_registry():
 
 
 @pytest.helpers.register
-def assert_any_call(mockk, first, *args):
+def assert_any_call(mockk, first, *args, **kwargs):
     __tracebackhide__ = True
 
     def _assertion():
-        mockk.assert_any_call(first, *args)
+        mockk.assert_any_call(first, *args, **kwargs)
 
     _add_useful_error_message(_assertion, mockk, first, args)
 

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -62,7 +62,7 @@ def app_spec():
         deployment_id="test_app_deployment_id",
         labels=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}),
         annotations=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}),
-        ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)])],
+        ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
         ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
@@ -36,7 +36,7 @@ def create_metadata(app_name, namespace='default', labels=None, external=None, a
         'finalizers': [],
     }
     if annotations is not None:
-        metadata['annotations'] = annotations
+        metadata['annotations'] = annotations.copy()
 
     if external is not None:
         expose_annotations = {'fiaas/expose': str(external).lower()}

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress1.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress1.yml
@@ -1,0 +1,50 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+  labels:
+    app: v3-data-examples-multiple-ingress
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-multiple-ingress
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-ingress
+  finalizers: []
+spec:
+  tls: []
+  rules:
+  - host: www.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-multiple-ingress
+          servicePort: '80'
+        path: /
+  - host: v3-data-examples-multiple-ingress.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-multiple-ingress
+          servicePort: '80'
+        path: /

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress2.yml
@@ -1,0 +1,44 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+    foo/ingress-class: "internal"
+  labels:
+    app: v3-data-examples-multiple-ingress
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-multiple-ingress-1
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-ingress
+  finalizers: []
+spec:
+  tls: []
+  rules:
+  - host: internal.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-multiple-ingress
+          servicePort: '80'
+        path: /

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-multiple.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-multiple.yml
@@ -22,9 +22,9 @@ spec:
   tls:
   - hosts:
     - qp4ouhml4krhfiltuenvy6ilm5pze3n3.svc.test.example.com
-    - v3-data-examples-tls-enabled-multiple.svc.test.example.com
     - example.com
     - example.org
+    - v3-data-examples-tls-enabled-multiple.svc.test.example.com
     secretName: v3-data-examples-tls-enabled-multiple-ingress-tls
   rules:
   - host: example.com

--- a/tests/fiaas_deploy_daemon/specs/v3/data/examples/multiple_ingress.yml
+++ b/tests/fiaas_deploy_daemon/specs/v3/data/examples/multiple_ingress.yml
@@ -1,0 +1,21 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 3
+ingress:
+  - host: www.example.com
+  - host: internal.example.com
+    annotations:
+        foo/ingress-class: internal


### PR DESCRIPTION
This adds support for deploying multiple ingresses with FIAAS, by
separating the ingresses specified in the config by their distinct
requirements for annotations. This is useful as it means for ingress
controllers that use annotations for configuration - this can be
determining which controller is used (public/private network,
or configuration that affects behaviour (whitelisting, HTTP-auth)
per host/path.

This closes #89