### PR TITLE
Add flag to disable deprecated managed env vars

### DIFF
--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -91,6 +91,9 @@ application containing all hosts. This feature is deprecated and will soon be re
 DISABLE_PIPELINE_CONSUMER_HELP = """disable pipeline consumer. this flag only exists to ease removing the pipeline
 consumer completely, and will be removed as soon as the pipeline consumer code is removed, do not use this flag"""
 
+DISABLE_DEPRECATED_MANAGED_ENV_VARS = """disable the deprecated managed environment variables (ARTIFACT_NAME,
+IMAGE and VERSION) in favour of the FIAAS_ prefixed variables (FIAAS_ARTIFACT_NAME, FIAAS_IMAGE and FIAAS_VERSION). """
+
 EPILOG = """
 Args that start with '--' (eg. --log-format) can also be set in a config file
 ({} or specified via -c). The config file uses YAML syntax and must represent
@@ -206,6 +209,8 @@ class Configuration(Namespace):
                                  "number of seconds  (default: %(default)s)", default=10)
         parser.add_argument("--disable-pipeline-consumer", help=DISABLE_PIPELINE_CONSUMER_HELP,
                             action="store_true")
+        parser.add_argument("--disable-deprecated-managed-env-vars", help=DISABLE_DEPRECATED_MANAGED_ENV_VARS,
+                            action="store_true", default=False)
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)
         usage_reporting_parser.add_argument("--usage-reporting-cluster-name",
                                             help="Name of the cluster where the fiaas-deploy-daemon instance resides")
@@ -255,9 +260,14 @@ class Configuration(Namespace):
 
     def _resolve_env(self):
         image = os.getenv("IMAGE")
+        if not image:
+            image = os.getenv("FIAAS_IMAGE")
         if image:
             self.image = image
+
         version = os.getenv("VERSION")
+        if not version:
+            version = os.getenv("FIAAS_VERSION")
         if version:
             self.version = version
 

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-deployment.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v2bootstrap-deployment.yml
@@ -67,6 +67,10 @@ spec:
           value: specs-v2-data-examples-v2bootstrap
         - name: CONSTRETTO_TAGS
           value: kubernetes
+        - name: FIAAS_ARTIFACT_NAME
+          value: specs-v2-data-examples-v2bootstrap
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -103,6 +107,8 @@ spec:
               containerName: specs-v2-data-examples-v2bootstrap
               divisor: "1"
               resource: requests.memory
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: IMAGE
           value: nginx:1.13.9-alpine
         - name: LOG_FORMAT

--- a/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-deployment.yml
+++ b/tests/fiaas_deploy_daemon/bootstrap_e2e_expected/v3bootstrap-deployment.yml
@@ -67,6 +67,10 @@ spec:
           value: specs-v3-data-examples-v3bootstrap
         - name: CONSTRETTO_TAGS
           value: kubernetes
+        - name: FIAAS_ARTIFACT_NAME
+          value: specs-v3-data-examples-v3bootstrap
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -103,6 +107,8 @@ spec:
               containerName: specs-v3-data-examples-v3bootstrap
               divisor: "1"
               resource: requests.memory
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: IMAGE
           value: nginx:1.13.9-alpine
         - name: LOG_FORMAT

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -172,6 +172,18 @@ class TestDeploymentDeployer(object):
         return mock.create_autospec(Secrets(config, None, None), spec_set=True, instance=True)
 
     @pytest.mark.usefixtures("get")
+    def test_managed_environment_variables(self, post, config, app_spec, datadog, prometheus, secrets, owner_references):
+        deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references)
+        env = deployer._make_env(app_spec)
+        env_keys = [var.name for var in env]
+        assert 'FIAAS_ARTIFACT_NAME' in env_keys
+        assert 'FIAAS_IMAGE' in env_keys
+        assert 'FIAAS_VERSION' in env_keys
+        assert ('ARTIFACT_NAME' not in env_keys) == config.disable_deprecated_managed_env_vars
+        assert ('IMAGE' not in env_keys) == config.disable_deprecated_managed_env_vars
+        assert ('VERSION' not in env_keys) == config.disable_deprecated_managed_env_vars
+
+    @pytest.mark.usefixtures("get")
     def test_deploy_new_deployment(self, post, config, app_spec, datadog, prometheus, secrets, owner_references):
         expected_deployment = create_expected_deployment(config, app_spec)
         mock_response = create_autospec(Response)

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -81,12 +81,12 @@ class TestDeploymentDeployer(object):
         yield request.param
 
     @pytest.fixture(params=(
-        # key: (infrastructure, global_env, use_in_memory_emptydirs)
-        ("gke", {}, True),
+        # key: (infrastructure, global_env, use_in_memory_emptydirs, disable_deprecated_managed_env_vars)
+        ("gke", {}, True, True),
         ("diy", {
             'A_GLOBAL_DIGIT': '0.01',
             'A_GLOBAL_STRING': 'test',
-        }, True),
+        }, True, True),
         ("gke", {
             'A_GLOBAL_DIGIT': '0.01',
             'A_GLOBAL_STRING': 'test',
@@ -97,7 +97,7 @@ class TestDeploymentDeployer(object):
             'LOG_STDOUT': 'false',
             'FIAAS_ENVIRONMENT': 'override_environment',
             'FIAAS_INFRASTRUCTURE': 'override_infrastructure',
-        }, False),
+        }, False, False),
         ("diy", {
             'A_GLOBAL_DIGIT': '0.01',
             'A_GLOBAL_STRING': 'test',
@@ -106,10 +106,10 @@ class TestDeploymentDeployer(object):
             # derived FIAAS_INFRASTRUCTURE and FIAAS_ENVIRONMENT
             'ENVIRONMENT': 'override_fiaas_environment',
             'INFRASTRUCTURE': 'override_fiaas_infrastructure',
-        }, True)
+        }, True, False)
     ))
     def config(self, request, environment):
-        infra, global_env, use_in_memory_emptydirs = request.param
+        infra, global_env, use_in_memory_emptydirs, disable_deprecated_managed_env_vars = request.param
         config = mock.create_autospec(Configuration([]), spec_set=True)
         config.infrastructure = infra
         config.environment = environment
@@ -119,6 +119,7 @@ class TestDeploymentDeployer(object):
         config.use_in_memory_emptydirs = use_in_memory_emptydirs
         config.deployment_max_surge = u"25%"
         config.deployment_max_unavailable = 0
+        config.disable_deprecated_managed_env_vars = disable_deprecated_managed_env_vars
         yield config
 
     @pytest.fixture(params=(
@@ -271,7 +272,7 @@ class TestDeploymentDeployer(object):
                             'image': 'finntech/testimage:version',
                             'volumeMounts': expected_volume_mounts,
                             'command': [],
-                            'env': create_environment_variables(config.infrastructure,
+                            'env': create_environment_variables(config,
                                                                 global_env=config.global_env,
                                                                 environment=config.environment),
                             'envFrom': [{
@@ -393,7 +394,7 @@ def create_expected_deployment(config,
             }
         },
         'command': [],
-        'env': create_environment_variables(config.infrastructure, global_env=config.global_env,
+        'env': create_environment_variables(config, global_env=config.global_env,
                                             version=version, environment=config.environment),
         'envFrom': expected_env_from,
         'imagePullPolicy': 'IfNotPresent',
@@ -452,16 +453,26 @@ def create_expected_deployment(config,
     return deployment
 
 
-def create_environment_variables(infrastructure, global_env=None, version="version", environment=None):
+def create_environment_variables(config, global_env=None, version="version", environment=None):
     _env_variables = {
-        'ARTIFACT_NAME': 'testapp',
         'LOG_STDOUT': 'true',
-        'VERSION': version,
-        'FIAAS_INFRASTRUCTURE': infrastructure,
+        'FIAAS_INFRASTRUCTURE': config.infrastructure,
         'LOG_FORMAT': 'json',
-        'IMAGE': 'finntech/testimage:' + version,
         'CONSTRETTO_TAGS': _create_constretto_tag(environment),
     }
+
+    _managed_env_variables = {
+        'FIAAS_ARTIFACT_NAME': 'testapp',
+        'FIAAS_VERSION': version,
+        'FIAAS_IMAGE': 'finntech/testimage:' + version,
+    }
+    if not config.disable_deprecated_managed_env_vars:
+        _managed_env_variables.update({
+            'ARTIFACT_NAME': 'testapp',
+            'VERSION': version,
+            'IMAGE': 'finntech/testimage:' + version,
+        })
+    _env_variables.update(_managed_env_variables)
 
     if environment:
         _env_variables.update({

--- a/tests/fiaas_deploy_daemon/e2e_expected/exec-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/exec-deployment.yml
@@ -66,8 +66,12 @@ spec:
           value: v2-data-examples-exec-config
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v2-data-examples-exec-config
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v2-data-examples-exec-config
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/host-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/host-deployment.yml
@@ -66,10 +66,14 @@ spec:
           value: v2-data-examples-host
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v2-data-examples-host
         - name: FIAAS_ENVIRONMENT
           value: test
         - name: FIAAS_INFRASTRUCTURE
           value: diy
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_LIMITS_CPU
           valueFrom:
             resourceFieldRef:
@@ -104,6 +108,8 @@ spec:
               containerName: v2-data-examples-host
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/host-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/host-deployment.yml
@@ -70,10 +70,10 @@ spec:
           value: v2-data-examples-host
         - name: FIAAS_ENVIRONMENT
           value: test
-        - name: FIAAS_INFRASTRUCTURE
-          value: diy
         - name: FIAAS_IMAGE
           value: IMAGE
+        - name: FIAAS_INFRASTRUCTURE
+          value: diy
         - name: FIAAS_LIMITS_CPU
           valueFrom:
             resourceFieldRef:

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-deployment.yml
@@ -66,8 +66,12 @@ spec:
           value: v3-data-examples-multiple-hosts-multiple-paths
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-multiple-hosts-multiple-paths
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v3-data-examples-multiple-hosts-multiple-paths
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ports-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ports-deployment.yml
@@ -65,8 +65,12 @@ spec:
           value: v2-data-examples-multiple-ports
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v2-data-examples-multiple-ports
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -103,6 +107,8 @@ spec:
               containerName: v2-data-examples-multiple-ports
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          name: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-deployment.yml
@@ -66,8 +66,12 @@ spec:
           value: v2-data-examples-partial-override
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v2-data-examples-partial-override
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v2-data-examples-partial-override
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/secrets-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/secrets-deployment.yml
@@ -68,8 +68,12 @@ spec:
           value: v3-data-examples-secrets
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-secrets
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -106,6 +110,8 @@ spec:
               containerName: v3-data-examples-secrets
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/single-replica-not-singleton.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single-replica-not-singleton.yml
@@ -66,8 +66,12 @@ spec:
           value: v3-data-examples-single-replica-not-singleton
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-single-replica-not-singleton
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v3-data-examples-single-replica-not-singleton
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/single-replica-singleton.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single-replica-singleton.yml
@@ -66,8 +66,12 @@ spec:
           value: v3-data-examples-single-replica-singleton
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-single-replica-singleton
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v3-data-examples-single-replica-singleton
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/single_tcp_port-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/single_tcp_port-deployment.yml
@@ -62,8 +62,12 @@ spec:
           value: v2-data-examples-single-tcp-port
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v2-data-examples-single-tcp-port
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -100,6 +104,8 @@ spec:
               containerName: v2-data-examples-single-tcp-port
               resource: requests.memory
               divisor: "1"
+        - name:  FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-deployment.yml
@@ -67,8 +67,12 @@ spec:
           value: v3-data-examples-strongbox
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-strongbox
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -105,6 +109,8 @@ spec:
               containerName: v3-data-examples-strongbox
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/tcp_ports-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tcp_ports-deployment.yml
@@ -62,8 +62,12 @@ spec:
           value: v2-data-examples-tcp-ports
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v2-data-examples-tcp-ports
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -100,6 +104,8 @@ spec:
               containerName: v2-data-examples-tcp-ports
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment-cert-issuer.yml
@@ -66,8 +66,12 @@ spec:
           value: v3-data-examples-tls-enabled-cert-issuer
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-tls-enabled-cert-issuer
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v3-data-examples-tls-enabled-cert-issuer
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-deployment.yml
@@ -66,8 +66,12 @@ spec:
           value: v3-data-examples-tls-enabled
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-tls-enabled
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: v3-data-examples-tls-enabled
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-deployment.yml
@@ -66,8 +66,12 @@ spec:
           value: data-v2minimal
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: data-v2minimal
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -104,6 +108,8 @@ spec:
               containerName: data-v2minimal
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
@@ -79,8 +79,12 @@ spec:
           value: v3-data-examples-full
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-full
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -117,6 +121,8 @@ spec:
               containerName: v3-data-examples-full
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-deployment.yml
@@ -70,8 +70,12 @@ spec:
           value: v3-data-examples-v3minimal
         - name: CONSTRETTO_TAGS
           value: kubernetes-test,kubernetes,test
+        - name: FIAAS_ARTIFACT_NAME
+          value: v3-data-examples-v3minimal
         - name: FIAAS_ENVIRONMENT
           value: test
+        - name: FIAAS_IMAGE
+          value: IMAGE
         - name: FIAAS_INFRASTRUCTURE
           value: diy
         - name: FIAAS_LIMITS_CPU
@@ -108,6 +112,8 @@ spec:
               containerName: v3-data-examples-v3minimal
               resource: requests.memory
               divisor: "1"
+        - name: FIAAS_VERSION
+          value: VERSION
         - name: FINN_ENV
           value: test
         - name: IMAGE

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -69,6 +69,7 @@ class TestConfig(object):
         assert config.image == ""
         assert config.enable_deprecated_multi_namespace_support is False
         assert config.enable_deprecated_tls_entry_per_host is False
+        assert config.disable_deprecated_managed_env_vars is False
 
     @pytest.mark.parametrize("arg,key", [
         ("--api-server", "api_server"),

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -180,9 +180,9 @@ def _set_image(expected_dict, image):
 def _set_env(expected_dict, image):
     def generate_updated_env():
         for item in expected_dict["spec"]["template"]["spec"]["containers"][0]["env"]:
-            if item["name"] == "VERSION":
+            if item["name"] == "VERSION" or item["name"] == "FIAAS_VERSION":
                 item["value"] = image.split(":")[-1]
-            if item["name"] == "IMAGE":
+            if item["name"] == "IMAGE" or item["name"] == "FIAAS_IMAGE":
                 item["value"] = image
             yield item
 


### PR DESCRIPTION
FDD historically injected some environment variables that
describe the version, the docker image and the artifact name.
These variables however conflict with variables used by
some docker images creating unexpected behaviours.

This change adds the prefix `FIAAS_` to these managed
environment variables alongside the previous (now) deprecated
variables so they can cohexist for a while.

This change also introduces a flag to disable the deprecated
non-prefixed variables so this change can be rolled out
in a controller way.

Partially fixes: https://github.com/fiaas/fiaas-deploy-daemon/issues/70

Signed-off-by: Xavi León <xavi.leon@adevinta.com>