### PR TITLE
Update hpa scaleTargetRef apiVersion

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
@@ -40,7 +40,7 @@ class AutoscalerDeployer(object):
             custom_labels = merge_dicts(app_spec.labels.horizontal_pod_autoscaler, labels)
             metadata = ObjectMeta(name=app_spec.name, namespace=app_spec.namespace, labels=custom_labels,
                                   annotations=app_spec.annotations.horizontal_pod_autoscaler)
-            scale_target_ref = CrossVersionObjectReference(kind=u"Deployment", name=app_spec.name, apiVersion="extensions/v1beta1")
+            scale_target_ref = CrossVersionObjectReference(kind=u"Deployment", name=app_spec.name, apiVersion="apps/v1")
             spec = HorizontalPodAutoscalerSpec(scaleTargetRef=scale_target_ref,
                                                minReplicas=app_spec.autoscaler.min_replicas,
                                                maxReplicas=app_spec.autoscaler.max_replicas,

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_autoscaler.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_autoscaler.py
@@ -70,7 +70,7 @@ class TestAutoscalerDeployer(object):
                 "scaleTargetRef": {
                     "kind": "Deployment",
                     "name": "testapp",
-                    "apiVersion": "extensions/v1beta1"
+                    "apiVersion": "apps/v1"
                 },
                 "minReplicas": 2,
                 "maxReplicas": 4,
@@ -107,7 +107,7 @@ class TestAutoscalerDeployer(object):
                 "scaleTargetRef": {
                     "kind": "Deployment",
                     "name": "testapp",
-                    "apiVersion": "extensions/v1beta1"
+                    "apiVersion": "apps/v1"
                 },
                 "minReplicas": 2,
                 "maxReplicas": 4,

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-hpa.yml
@@ -33,7 +33,7 @@ spec:
   maxReplicas: 5
   minReplicas: 2
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v3-data-examples-multiple-hosts-multiple-paths
   targetCPUUtilizationPercentage: 50

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-hpa.yml
@@ -33,7 +33,7 @@ spec:
   maxReplicas: 2
   minReplicas: 1
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v2-data-examples-partial-override
   targetCPUUtilizationPercentage: 50

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-hpa.yml
@@ -33,7 +33,7 @@ spec:
   maxReplicas: 5
   minReplicas: 2
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v3-data-examples-strongbox
   targetCPUUtilizationPercentage: 50

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa-cert-issuer.yml
@@ -33,7 +33,7 @@ spec:
   maxReplicas: 5
   minReplicas: 2
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v3-data-examples-tls-enabled-cert-issuer
   targetCPUUtilizationPercentage: 50

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-hpa.yml
@@ -33,7 +33,7 @@ spec:
   maxReplicas: 5
   minReplicas: 2
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v3-data-examples-tls-enabled
   targetCPUUtilizationPercentage: 50

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-hpa.yml
@@ -40,7 +40,7 @@ spec:
   maxReplicas: 20
   minReplicas: 10
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v3-data-examples-full
   targetCPUUtilizationPercentage: 60

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-hpa.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-hpa.yml
@@ -35,7 +35,7 @@ spec:
   maxReplicas: 5
   minReplicas: 2
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: v3-data-examples-v3minimal
   targetCPUUtilizationPercentage: 50


### PR DESCRIPTION
Following pr #64, updates the scalerefTarget to use apps/v1 instead of
extensions/v1beta to locate the deployment.

It's needed to run fiaas on 1.16 cluster