### PR TITLE
Fix e2e tests for Kubernetes 1.12 and 1.14

### DIFF
--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -188,6 +188,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.4", pytest.param("v1.16.3", marks=pytest.mark.e2e_latest)))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", pytest.param("v1.16.3", marks=pytest.mark.e2e_latest)))
 def k8s_version(request):
     yield request.param


### PR DESCRIPTION
Update Kubernetes 1.14 image to 1.14.10, which seems to work.

For Kubernetes 1.12, even the latest bsycorp/kind image seems to be built over a year ago, which means some internal certificate already has expired.  I've built a new image as fiaas/kind:v1.12.10 from bsycorp/kind@5b67b70 following the same procedure as in https://github.com/fiaas/fiaas-deploy-daemon/pull/45, and modified the e2e test for Kubernetes 1.12 to use that image.

Closes #115 