### PR TITLE
Support alternate issuer types for TLS

### DIFF
--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -32,11 +32,11 @@ In order for FIAAS to function in a cluster, some basics needs to be in place
 * Applications expect DNS to work, so kube-dns, coredns or an equivalent substitute should be installed
 * Log aggregation, so that stdout and stderr from applications are collected and aggregated and collected somewhere it can be found. Typically Fluentd collecting and sending to a suitable storage.
 * An ingress controller capable of handling all the required features
-* One or more DNS wildcards that will direct traffic to the ingress controller (see the [--ingress-suffix](#ingress-suffix) option) 
+* One or more DNS wildcards that will direct traffic to the ingress controller (see the [--ingress-suffix](#ingress-suffix) option)
 
 In addition, some conventions might be useful to know about:
 
-* In fiaas.yml v3, the default paths for probes and metrics starts with `/_/`. As a cluster operator, it might be useful to configure your cluster to disallow public access to any path that starts with this prefix. 
+* In fiaas.yml v3, the default paths for probes and metrics starts with `/_/`. As a cluster operator, it might be useful to configure your cluster to disallow public access to any path that starts with this prefix.
 
 How to set configuration options
 --------------------------------
@@ -139,6 +139,14 @@ If `default_off` tls configuration can be explicitly requested on a per applicat
 
 If `default_on` tls configuration will be applied unless explicitly disabled in application manifests.
 
+### tls-certificate-issuer-*
+
+Used to configure how the ingress will be annotated for issuing a TLS certificate using cert-manager:
+
+* `tls-certificate-issuer` sets the _value_ of the annotation, for example to decide between production and staging versions of an issuer in different namespaces
+* `tls-certificate-issuer-type-default` sets the default for the _key_ of the annotation, for example to use either `certmanager.k8s.io/cluster-issuer` (the default) or `certmanager.k8s.io/issuer`
+* `tls-certificate-issuer-type-overrides` allows specifying a mapping between the suffix of a domain and the issuer-type, to override the default. For example, assuming the 'cluster-issuer' type as the default, then specifying `--tls-certificate-issuer-type-overrides foo.example.com=certmanager.k8s.io/issuer` would mean that foo.example.com and any of its subdomains will use the 'issuer' type instead. In the case of multiple matching suffixes, the more specific (i.e. longest) will be used.
+
 ### use-in-memory-emptydirs
 
 Inside the container, `/tmp` will be mounted from an emptyDir volume, to allow applications some scratch-space without writing through the underlying docker storage driver. Similarly, when using the [Secrets init container](#secrets-init-container), the secrets are written to an emptyDir volume.
@@ -162,9 +170,9 @@ To deploy an application with FIAAS, you need three things:
 - A docker image reference
 - A FIAAS configuration for your application (commonly referred to as `fiaas.yml`)
 
-To deploy an application, create an Application object describing your application. A JSON schema describing the various objects FIAAS uses is in [schema.json](schema.json). 
+To deploy an application, create an Application object describing your application. A JSON schema describing the various objects FIAAS uses is in [schema.json](schema.json).
 
-When you create or update your Application object, and at various intervals in between, fiaas-deploy-daemon will load the description of your application and create or update all relevant objects to match what is described in your Application. A requirement is that you also set a label on the Application named `fiaas/deployment_id` (the Deployment ID). This should reflect a particular deployment that is to be considered distinct from previous or later deployments. Typically this will change when you either change your image or your FIAAS config. 
+When you create or update your Application object, and at various intervals in between, fiaas-deploy-daemon will load the description of your application and create or update all relevant objects to match what is described in your Application. A requirement is that you also set a label on the Application named `fiaas/deployment_id` (the Deployment ID). This should reflect a particular deployment that is to be considered distinct from previous or later deployments. Typically this will change when you either change your image or your FIAAS config.
 
 When you want to deploy a new version, you can in the simplest case update the `image` field and the Deployment ID label, and FIAAS will ensure a rolling deploy to the new image is performed. Making changes to the other fields in Application will likewise update the deployment.
 
@@ -198,7 +206,7 @@ In all cases, the container will be responsible for getting the application secr
 
 In the init container, the environment variable `K8S_DEPLOYMENT` will be the name of the application. In addition, any variables specified in a ConfigMap named `fiaas-secrets-init-container` will be exposed as environment variables.
 
-The ConfigMap will also be mounted at `/var/run/config/fiaas-secrets-init-container/`. If there exists a ConfigMap for the application then it will be mounted at `/var/run/config/fiaas/`. 
+The ConfigMap will also be mounted at `/var/run/config/fiaas-secrets-init-container/`. If there exists a ConfigMap for the application then it will be mounted at `/var/run/config/fiaas/`.
 
 #### Secrets init container (--secrets-init-container-image)
 
@@ -244,7 +252,7 @@ A Prometheus installation in the cluster, with ability to scrape all pods. It ca
 
 ### Datadog
 
-In order to use DataDog in a namespace, a secret named `datadog` needs to be provisioned. The secret should have a single key, `apikey`, which is a valid DataDog API key. The cluster operator also needs to configure fiaas-deploy-daemon with a `datadog-container-image`, which will be attached as a sidecar on all pods to receive metrics and forward to Datadog. 
+In order to use DataDog in a namespace, a secret named `datadog` needs to be provisioned. The secret should have a single key, `apikey`, which is a valid DataDog API key. The cluster operator also needs to configure fiaas-deploy-daemon with a `datadog-container-image`, which will be attached as a sidecar on all pods to receive metrics and forward to Datadog.
 
 The container will get these environment variables set:
 
@@ -261,7 +269,7 @@ Usage Reporting
 
 FIAAS can optionally report usage data to a web-service via POSTs to an HTTP endpoint. Fiaas-deploy-daemon will POST a JSON structure to the endpoint on deployment start, deployment failure and deployment success.
 
-The JSON document contains details about the application being deployed, where it is deployed and the result of that deployment. In the future, we might consider implementing other formats. 
+The JSON document contains details about the application being deployed, where it is deployed and the result of that deployment. In the future, we might consider implementing other formats.
 
 Except where noted, FIAAS passes these values on to the collector without processing.
 

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -190,11 +190,6 @@ class Configuration(Namespace):
                             default=None)
         parser.add_argument("--enable-deprecated-multi-namespace-support", help=MULTI_NAMESPACE_HELP,
                             action="store_true")
-        parser.add_argument("--use-ingress-tls", help=TLS_HELP,
-                            choices=("disabled", "default_off", "default_on"),
-                            default="disabled")
-        parser.add_argument("--tls-certificate-issuer", help="Certificate issuer to use with cert-manager to provision certificates",
-                            default=None)
         parser.add_argument("--use-in-memory-emptydirs", help="Use memory for emptydirs mounted in the deployed application",
                             action="store_true")
         parser.add_argument("--deployment-max-surge", help="maximum number of extra pods that can be scheduled above the desired "
@@ -246,10 +241,27 @@ class Configuration(Namespace):
                                                    env_var="FIAAS_SECRET_INIT_CONTAINERS",
                                                    help="Images to use for secret init-containers by key",
                                                    action="append", type=KeyValue, dest="secret_init_containers")
+
+        tls_parser = parser.add_argument_group("Ingress TLS")
+        tls_parser.add_argument("--use-ingress-tls", help=TLS_HELP,
+                                choices=("disabled", "default_off", "default_on"),
+                                default="disabled")
+        tls_parser.add_argument("--tls-certificate-issuer",
+                                help="Certificate issuer to use with cert-manager to provision certificates",
+                                default=None)
+        tls_parser.add_argument("--tls-certificate-issuer-type-default",
+                                help="The annotation to set for cert-manager to provision certificates",
+                                default="certmanager.k8s.io/cluster-issuer")
+        tls_parser.add_argument("--tls-certificate-issuer-type-overrides", help="Issuers to use for specified domain suffixes",
+                                default=[],
+                                action="append", type=KeyValue, dest="tls_certificate_issuer_type_overrides")
+
         parser.parse_args(args, namespace=self)
         self.global_env = {env_var.key: env_var.value for env_var in self.global_env}
         self.datadog_global_tags = {tag.key: tag.value for tag in self.datadog_global_tags}
         self.secret_init_containers = {provider.key: provider.value for provider in self.secret_init_containers}
+        self.tls_certificate_issuer_type_overrides = {issuer_type.key: issuer_type.value
+                                                      for issuer_type in self.tls_certificate_issuer_type_overrides}
 
     def _resolve_api_config(self):
         token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -42,6 +42,8 @@ class IngressDeployer(object):
         self._ingress_tls = ingress_tls
         self._owner_references = owner_references
         self._tls_issuer_type_default = config.tls_certificate_issuer_type_default
+        self._tls_issuer_type_overrides = sorted(config.tls_certificate_issuer_type_overrides.iteritems(),
+                                                 key=lambda (k, v): len(k), reverse=True)
 
     def deploy(self, app_spec, labels):
         if self._should_have_ingress(app_spec):
@@ -60,7 +62,7 @@ class IngressDeployer(object):
         LOG.info("Creating/updating ingresses for %s", app_spec.name)
         custom_labels = merge_dicts(app_spec.labels.ingress, labels)
 
-        ingresses = self._group_ingresses_by_annotations(app_spec)
+        ingresses = self._group_ingresses(app_spec)
 
         LOG.info("Will create %s ingresses", len(ingresses))
         for annotated_ingress in ingresses:
@@ -78,26 +80,45 @@ class IngressDeployer(object):
         return [IngressItemSpec(host=host, pathmappings=all_pathmappings, annotations=None)
                 for host in self._generate_default_hosts(app_spec.name)]
 
-    def _group_ingresses_by_annotations(self, app_spec):
-        ''' Group the ingresses so that those with annotations are individual, keeping all without
-        annotations together
+    def _get_issuer_type(self, host):
+        for (suffix, issuer_type) in self._tls_issuer_type_overrides:
+            if host and (host == suffix or host.endswith("." + suffix)):
+                return issuer_type
+
+        return self._tls_issuer_type_default
+
+    def _group_ingresses(self, app_spec):
+        ''' Group the ingresses so that those with annotations are individual, and so that those using non-default TLS-issuers
+        are separated
         '''
         explicit_host = _has_explicitly_set_host(app_spec.ingresses)
         ingress_items = app_spec.ingresses + self._expand_default_hosts(app_spec)
 
         AnnotatedIngress = namedtuple("AnnotatedIngress", ["name", "ingress_items", "annotations", "explicit_host", "issuer_type"])
-        unannotated_ingress = AnnotatedIngress(name=app_spec.name, ingress_items=[], annotations={},
-                                               explicit_host=explicit_host, issuer_type=self._tls_issuer_type_default)
-        ingresses = [unannotated_ingress]
+        default_ingress = AnnotatedIngress(name=app_spec.name, ingress_items=[], annotations={},
+                                           explicit_host=explicit_host, issuer_type=self._tls_issuer_type_default)
+        ingresses = [default_ingress]
+        override_issuer_ingresses = {}
         for ingress_item in ingress_items:
+            issuer_type = self._get_issuer_type(ingress_item.host)
+            next_name = "{}-{}".format(app_spec.name, len(ingresses))
             if ingress_item.annotations:
-                next_name = "{}-{}".format(app_spec.name, len(ingresses))
                 annotated_ingresses = AnnotatedIngress(name=next_name, ingress_items=[ingress_item],
                                                        annotations=ingress_item.annotations,
-                                                       explicit_host=True, issuer_type=self._tls_issuer_type_default)
+                                                       explicit_host=True, issuer_type=issuer_type)
                 ingresses.append(annotated_ingresses)
+            elif issuer_type != self._tls_issuer_type_default:
+                annotated_ingress = override_issuer_ingresses.setdefault(issuer_type,
+                                                                         AnnotatedIngress(name=next_name,
+                                                                                          ingress_items=[],
+                                                                                          annotations={},
+                                                                                          explicit_host=explicit_host,
+                                                                                          issuer_type=issuer_type))
+                annotated_ingress.ingress_items.append(ingress_item)
             else:
-                unannotated_ingress.ingress_items.append(ingress_item)
+                default_ingress.ingress_items.append(ingress_item)
+
+        ingresses.extend(i for i in override_issuer_ingresses.values())
 
         return ingresses
 

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override1.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override1.yml
@@ -1,0 +1,56 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+    certmanager.k8s.io/cluster-issuer: "someissuer"
+  labels:
+    app: v3-data-examples-tls-issuer-override
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-tls-issuer-override
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-issuer-override
+  finalizers: []
+spec:
+  tls:
+  - hosts:
+    - m3gt6a6nipvljp4l4dixj4jhmge5bii5.svc.test.example.com
+    - www.example.com
+    - v3-data-examples-tls-issuer-override.svc.test.example.com
+    secretName: v3-data-examples-tls-issuer-override-ingress-tls
+  rules:
+  - host: www.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-tls-issuer-override
+          servicePort: '80'
+        path: /
+  - host: v3-data-examples-tls-issuer-override.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-tls-issuer-override
+          servicePort: '80'
+        path: /

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override2.yml
@@ -1,0 +1,48 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+    certmanager.k8s.io/issuer: "someissuer"
+  labels:
+    app: v3-data-examples-tls-issuer-override
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-tls-issuer-override-1
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-issuer-override
+  finalizers: []
+spec:
+  tls:
+  - hosts:
+    - m3gt6a6nipvljp4l4dixj4jhmge5bii5.svc.test.example.com
+    - use-issuer.example.com
+    secretName: v3-data-examples-tls-issuer-override-1-ingress-tls
+  rules:
+  - host: use-issuer.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-tls-issuer-override
+          servicePort: '80'
+        path: /

--- a/tests/fiaas_deploy_daemon/specs/v3/data/examples/tls_issuer_override.yml
+++ b/tests/fiaas_deploy_daemon/specs/v3/data/examples/tls_issuer_override.yml
@@ -1,0 +1,23 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 3
+ingress:
+  - host: www.example.com
+  - host: use-issuer.example.com
+extensions:
+  tls:
+    enabled: true
+    certificate_issuer: someissuer

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -206,6 +206,15 @@ class TestConfig(object):
         config = Configuration(["--datadog-global-tags=%s" % arg for arg in args])
         assert config.datadog_global_tags == {KeyValue(arg).key: KeyValue(arg).value for arg in args}
 
+    def test_tls_issuers(self):
+        issuer_types = ["foo.bar.com=issuer", "woo.foo.bar.com=other"]
+        args = ["--tls-certificate-issuer-type-overrides=%s" % issuer_type for issuer_type in issuer_types]
+        config = Configuration(args)
+        assert config.tls_certificate_issuer_type_overrides == {
+            "foo.bar.com": "issuer",
+            "woo.foo.bar.com": "other"
+        }
+
 
 class TestHostRewriteRule(object):
     def test_equality(self):

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -114,6 +114,7 @@ class TestE2E(object):
             "--datadog-container-image", "DATADOG_IMAGE:tag",
             "--strongbox-init-container-image", "STRONGBOX_IMAGE",
             "--secret-init-containers", "parameter-store=PARAM_STORE_IMAGE",
+            "--tls-certificate-issuer-type-overrides", "use-issuer.example.com=certmanager.k8s.io/issuer",
             "--use-ingress-tls", "default_off",
         ]
         if crd_supported(k8s_version):
@@ -329,17 +330,24 @@ class TestE2E(object):
             wait_until(cleanup_complete, patience=PATIENCE)
 
     @pytest.mark.usefixtures("fdd")
-    def test_multiple_ingresses(self, request, kind_logger):
+    @pytest.mark.parametrize("input, expected", [
+        ("multiple_ingress", {
+            "v3-data-examples-multiple-ingress": "e2e_expected/multiple_ingress1.yml",
+            "v3-data-examples-multiple-ingress-1": "e2e_expected/multiple_ingress2.yml"
+        }),
+        ("tls_issuer_override", {
+            "v3-data-examples-tls-issuer-override": "e2e_expected/tls_issuer_override1.yml",
+            "v3-data-examples-tls-issuer-override-1": "e2e_expected/tls_issuer_override2.yml"
+        })
+    ])
+    def test_multiple_ingresses(self, request, kind_logger, input, expected):
         with kind_logger():
-            fiaas_path = "v3/data/examples/multiple_ingress.yml"
+            fiaas_path = "v3/data/examples/%s.yml" % input
             fiaas_yml = read_yml(request.fspath.dirpath().join("specs").join(fiaas_path).strpath)
 
             name = sanitize_resource_name(fiaas_path)
 
-            expected = {
-                name: read_yml(request.fspath.dirpath().join("e2e_expected/multiple_ingress1.yml").strpath),
-                "{}-1".format(name): read_yml(request.fspath.dirpath().join("e2e_expected/multiple_ingress2.yml").strpath)
-            }
+            expected = {k: read_yml(request.fspath.dirpath().join(v).strpath) for (k, v) in expected.items()}
             metadata = ObjectMeta(name=name, namespace="default", labels={"fiaas/deployment_id": DEPLOYMENT_ID1})
             spec = FiaasApplicationSpec(application=name, image=IMAGE1, config=fiaas_yml)
             fiaas_application = FiaasApplication(metadata=metadata, spec=spec)


### PR DESCRIPTION
This allows, for example, using `certmanager.k8s.io/issuer: letsencrypt` for a namespace-level issuer, instead of always cluster-issuer. To allow for a mixture of issuer types between the hosts an app might use, this requires splitting the ingress items amongst separate ingress objects, similar to how it's done for supporting separate annotations in the configuration

Requires #118

Closes #114