### PR TITLE
Remove ability to set config options via environment variables

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -165,9 +165,10 @@ def warn_if_env_variable_config(config, log):
     possible_config_env_variables = sorted(configuration_env_variable_keys & environ_keys)
     if len(possible_config_env_variables) > 0:
         log.warn("found configuration environment variables %s. The ability to configure fiaas-deploy-daemon via environment variables " +
-                 "will be removed. If these environment variables are the primary source for this configuration, please switch to " +
-                 "configuring via a config file/ConfigMap or command-line flags. See " +
-                 "https://github.com/fiaas/fiaas-deploy-daemon/issues/12 for more information", ', '.join(possible_config_env_variables))
+                 "has been removed. If you are trying to use these environment variables to configure fiaas-deploy-daemon, " +
+                 "that configuration will not take effect. Please switch to configuring via a config file/ConfigMap or command-line " +
+                 "flags. See https://github.com/fiaas/fiaas-deploy-daemon/issues/12 for more information.",
+                 ', '.join(possible_config_env_variables))
 
 
 def main():

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -44,7 +44,7 @@ regex pattern, and a replacement value. The `host` is matched against each
 pattern in the order given, stopping at the first match. The replacement can
 contain groups using regular regex replace syntax.
 
-Regardless of how a rule is passed in (option, environment variable or in
+Regardless of how a rule is passed in (option or in
 a config file), it must be specified as `<pattern>=<replacement>`. In
 particular, be aware that even if it would be natural to use the map type
 in YAML, this is not possible.
@@ -56,7 +56,7 @@ GLOBAL_ENV_LONG_HELP = """
 If you wish to expose certain environment variables to every application
 in your cluster, define them here.
 
-Regardless of how a variable is passed in (option, environment variable or in
+Regardless of how a variable is passed in (option or in
 a config file), it must be specified as `<key>=<value>`.
 """
 
@@ -101,15 +101,14 @@ In the config-file, these should be defined as a YAML list
 (see https://github.com/bw2/ConfigArgParse#special-values).
 
 If an arg is specified in more than one place, then commandline values
-override environment variables which override config file values which
-override defaults.
+override config file values which override defaults.
 """.format(DEFAULT_CONFIG_FILE)
 
 DATADOG_GLOBAL_TAGS_LONG_HELP = """
 If you wish to send certain tags to datadog in every application
 in your cluster, define them here.
 
-Regardless of how a variable is passed in (option, environment variable or in
+Regardless of how a variable is passed in (option or in
 a config file), it must be specified as `<key>=<value>`.
 """
 
@@ -137,8 +136,7 @@ class Configuration(Namespace):
         self.namespace = self._resolve_namespace()
 
     def _parse_args(self, args):
-        parser = configargparse.ArgParser(auto_env_var_prefix="",
-                                          add_config_file_help=False,
+        parser = configargparse.ArgParser(add_config_file_help=False,
                                           add_env_var_help=False,
                                           config_file_parser_class=configargparse.YAMLConfigFileParser,
                                           default_config_files=[DEFAULT_CONFIG_FILE],
@@ -151,16 +149,15 @@ class Configuration(Namespace):
                             default=DEFAULT_SECRETS_DIR)
         parser.add_argument("--log-format", help="Set logformat (default: %(default)s)", choices=self.VALID_LOG_FORMAT,
                             default="plain")
-        parser.add_argument("--proxy", help="Use http proxy (currently only used for for usage reporting)",
-                            env_var="http_proxy")
+        parser.add_argument("--proxy", help="Use http proxy (currently only used for for usage reporting)")
         parser.add_argument("--debug", help="Enable a number of debugging options (including disable SSL-verification)",
                             action="store_true")
-        parser.add_argument("--environment", help="Environment to deploy to", env_var="FIAAS_ENVIRONMENT", default="")
-        parser.add_argument("--service-type", help="Type of kubernetes Service to create", env_var="FIAAS_SERVICE_TYPE",
+        parser.add_argument("--environment", help="Environment to deploy to", default="")
+        parser.add_argument("--service-type", help="Type of kubernetes Service to create",
                             choices=("ClusterIP", "NodePort", "LoadBalancer"), default="ClusterIP")
         parser.add_argument("--infrastructure",
                             help="The underlying infrastructure of the cluster to deploy to. (default: %(default)s).",
-                            env_var="FIAAS_INFRASTRUCTURE", choices=("diy", "gke"), default="diy")
+                            choices=("diy", "gke"), default="diy")
         parser.add_argument("--port", help="Port to use for the web-interface (default: %(default)s)", type=int,
                             default=5000)
         parser.add_argument("--enable-crd-support", help="Enable Custom Resource Definition support.",
@@ -176,7 +173,6 @@ class Configuration(Namespace):
                             help="The amount of memory (request and limit) for the datadog sidecar", default="2Gi")
         datadog_global_tags_parser = parser.add_argument_group("Datadog Global tags", DATADOG_GLOBAL_TAGS_LONG_HELP)
         datadog_global_tags_parser.add_argument("--datadog-global-tags", default=[],
-                                                env_var="FIAAS_DATADOG_GLOBAL_TAGS",
                                                 help="Various non-essential global tags to send to datadog for all applications",
                                                 action="append", type=KeyValue, dest="datadog_global_tags")
         parser.add_argument("--pre-stop-delay", type=int,
@@ -222,18 +218,16 @@ class Configuration(Namespace):
         client_cert_parser.add_argument("--client-key", help="Client certificate key to use", default=None)
         ingress_parser = parser.add_argument_group("Ingress suffix", INGRESS_SUFFIX_LONG_HELP)
         ingress_parser.add_argument("--ingress-suffix", help="Suffix to use for ingress", action="append",
-                                    dest="ingress_suffixes", env_var="INGRESS_SUFFIXES", default=[])
+                                    dest="ingress_suffixes", default=[])
         host_rule_parser = parser.add_argument_group("Host rewrite rules", HOST_REWRITE_RULE_LONG_HELP)
         host_rule_parser.add_argument("--host-rewrite-rule", help="Rule for rewriting host", action="append",
-                                      type=HostRewriteRule, dest="host_rewrite_rules", env_var="HOST_REWRITE_RULES",
-                                      default=[])
+                                      type=HostRewriteRule, dest="host_rewrite_rules", default=[])
         global_env_parser = parser.add_argument_group("Global environment variables", GLOBAL_ENV_LONG_HELP)
-        global_env_parser.add_argument("--global-env", default=[], env_var="FIAAS_GLOBAL_ENV",
+        global_env_parser.add_argument("--global-env", default=[],
                                        help="Various non-essential global variables to expose for all applications",
                                        action="append", type=KeyValue, dest="global_env")
         secret_init_containers_parser = parser.add_argument_group("Secret init-containers", SECRET_CONTAINERS_LONG_HELP)
         secret_init_containers_parser.add_argument("--secret-init-containers", default=[],
-                                                   env_var="FIAAS_SECRET_INIT_CONTAINERS",
                                                    help="Images to use for secret init-containers by key",
                                                    action="append", type=KeyValue, dest="secret_init_containers")
 

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -35,19 +35,6 @@ class TestConfig(object):
             yield _open
 
     @pytest.mark.parametrize("format", ["plain", "json"])
-    def test_resolve_log_format_env(self, monkeypatch, format):
-        monkeypatch.setenv("LOG_FORMAT", format)
-        config = Configuration([])
-
-        assert config.log_format == format
-
-    def test_invalid_log_format_env(self, monkeypatch):
-        monkeypatch.setenv("LOG_FORMAT", "fail")
-
-        with pytest.raises(SystemExit):
-            Configuration([])
-
-    @pytest.mark.parametrize("format", ["plain", "json"])
     def test_log_format_param(self, format):
         config = Configuration(["--log-format", format])
 
@@ -90,26 +77,6 @@ class TestConfig(object):
 
         assert config.infrastructure == "gke"
 
-    @pytest.mark.parametrize("env,key", [
-        ("API_SERVER", "api_server"),
-        ("API_TOKEN", "api_token"),
-        ("API_CERT", "api_cert"),
-        ("FIAAS_ENVIRONMENT", "environment"),
-        ("IMAGE", "image"),
-        ("STRONGBOX_INIT_CONTAINER_IMAGE", "strongbox_init_container_image"),
-    ])
-    def test_env(self, monkeypatch, env, key):
-        monkeypatch.setenv(env, "value")
-        config = Configuration([])
-
-        assert getattr(config, key) == "value"
-
-    def test_infrastructure_env(self, monkeypatch):
-        monkeypatch.setenv("FIAAS_INFRASTRUCTURE", "gke")
-        config = Configuration([])
-
-        assert config.infrastructure == "gke"
-
     @pytest.mark.parametrize("key", (
         "debug",
         "enable_crd_support",
@@ -122,20 +89,6 @@ class TestConfig(object):
         assert getattr(config, key) is False
         config = Configuration([flag])
         assert getattr(config, key) is True
-
-    @pytest.mark.parametrize("cmdline,envvar,expected", [
-        ([], "", None),
-        (["--infrastructure", "gke"], "", None),
-        ([], "http://proxy.example.com", "http://proxy.example.com"),
-        (["--infrastructure", "gke"], "http://proxy.example.com", "http://proxy.example.com"),
-        (["--proxy", "http://proxy.example.com"], "", "http://proxy.example.com"),
-    ])
-    def test_proxy(self, monkeypatch, cmdline, envvar, expected):
-        if envvar:
-            monkeypatch.setenv("http_proxy", envvar)
-        config = Configuration(cmdline)
-
-        assert config.proxy == expected
 
     @pytest.mark.parametrize("key,attr,value", [
         ("environment", "environment", "gke"),

--- a/tests/fiaas_deploy_daemon/test_warn_env_variable_config.py
+++ b/tests/fiaas_deploy_daemon/test_warn_env_variable_config.py
@@ -91,12 +91,11 @@ def test_warn_if_env_variable_config(monkeypatch, config_flags):
 
     expected_env_keys = ', '.join(sorted(cf.env_key for cf in config_flags))
     expected_log_message = (
-        "found configuration environment variables %s. The ability to configure fiaas-deploy-daemon via environment "
-        "variables will be removed. If these environment variables are the primary source for this configuration, please switch to "
-        "configuring via a config file/ConfigMap or command-line flags. See "
-        "https://github.com/fiaas/fiaas-deploy-daemon/issues/12 for more information"
+        "found configuration environment variables %s. The ability to configure fiaas-deploy-daemon via environment variables has been "
+        "removed. If you are trying to use these environment variables to configure fiaas-deploy-daemon, that configuration will not take "
+        "effect. Please switch to configuring via a config file/ConfigMap or command-line flags. See "
+        "https://github.com/fiaas/fiaas-deploy-daemon/issues/12 for more information."
     )
-
     log.warn.assert_called_once_with(expected_log_message, expected_env_keys)
 
 

--- a/tests/fiaas_deploy_daemon/test_warn_env_variable_config.py
+++ b/tests/fiaas_deploy_daemon/test_warn_env_variable_config.py
@@ -68,18 +68,6 @@ def config_flags():
     ]
 
 
-def test_env_variable_config(monkeypatch, config_flags):
-    """tests setting config flags via environment variables, but primarily it exists to ensure
-test_warn_env_variable_config has a complete, valid set of test data"""
-    for config_flag in config_flags:
-        monkeypatch.setenv(config_flag.env_key, config_flag.env_value)
-
-    config = Configuration([])
-
-    for config_flag in config_flags:
-        assert getattr(config, config_flag.config_key) == config_flag.config_value
-
-
 def test_warn_if_env_variable_config(monkeypatch, config_flags):
     for config_flag in config_flags:
         monkeypatch.setenv(config_flag.env_key, config_flag.env_value)
@@ -99,7 +87,7 @@ def test_warn_if_env_variable_config(monkeypatch, config_flags):
     log.warn.assert_called_once_with(expected_log_message, expected_env_keys)
 
 
-def test_dont_warn_if_no_env_config(monkeypatch, config_flags):
+def test_dont_warn_if_no_env_config():
     config = Configuration([])
 
     log = mock.MagicMock(spec=logging.Logger)


### PR DESCRIPTION
This is an attempt at solving #12, based on the suggestion here https://github.com/fiaas/fiaas-deploy-daemon/issues/12#issuecomment-688109631. 

fiaas-deploy-daemon's configuration is based on a merge (by order of precedence) of command-line flags, environment variables and the cluster_config.yaml configuration file, typically provided via a ConfigMap. 
Because of the order of precedence (command-line flags > environment variables > config file), and because fiaas-deploy-daemon sets environment variables from its configuration when deploying itself, this could lead to situations where a change in the config file would not take effect if the configuration option that was change was shadowed by a environment variable. There is an example of this in the associated issue.

To remove the potential for confusion stemming from this behavior, remove the ability to configure fiaas-deploy-daemon via environment variables. This is a backwards incompatible change for deployments of fiaas-deploy-daemon relying on environment variables for configuration. Deployments using environment variables will need to switch to command-line flags or config file/ConfigMap before updating to a version of fiaas-deploy-daemon including this fix.

Follow-up to #120 (this changeset should remove the warning implemented there)
Closes #12