### PR TITLE
Fix TLS hosts for ingress created for custom issuer

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -94,9 +94,11 @@ class IngressDeployer(object):
         explicit_host = _has_explicitly_set_host(app_spec.ingresses)
         ingress_items = app_spec.ingresses + self._expand_default_hosts(app_spec)
 
-        AnnotatedIngress = namedtuple("AnnotatedIngress", ["name", "ingress_items", "annotations", "explicit_host", "issuer_type"])
+        AnnotatedIngress = namedtuple("AnnotatedIngress", ["name", "ingress_items", "annotations", "explicit_host",
+                                      "issuer_type", "default"])
         default_ingress = AnnotatedIngress(name=app_spec.name, ingress_items=[], annotations={},
-                                           explicit_host=explicit_host, issuer_type=self._tls_issuer_type_default)
+                                           explicit_host=explicit_host, issuer_type=self._tls_issuer_type_default,
+                                           default=True)
         ingresses = [default_ingress]
         override_issuer_ingresses = {}
         for ingress_item in ingress_items:
@@ -105,7 +107,8 @@ class IngressDeployer(object):
             if ingress_item.annotations:
                 annotated_ingresses = AnnotatedIngress(name=next_name, ingress_items=[ingress_item],
                                                        annotations=ingress_item.annotations,
-                                                       explicit_host=True, issuer_type=issuer_type)
+                                                       explicit_host=True, issuer_type=issuer_type,
+                                                       default=False)
                 ingresses.append(annotated_ingresses)
             elif issuer_type != self._tls_issuer_type_default:
                 annotated_ingress = override_issuer_ingresses.setdefault(issuer_type,
@@ -113,7 +116,8 @@ class IngressDeployer(object):
                                                                                           ingress_items=[],
                                                                                           annotations={},
                                                                                           explicit_host=explicit_host,
-                                                                                          issuer_type=issuer_type))
+                                                                                          issuer_type=issuer_type,
+                                                                                          default=False))
                 annotated_ingress.ingress_items.append(ingress_item)
             else:
                 default_ingress.ingress_items.append(ingress_item)
@@ -138,10 +142,10 @@ class IngressDeployer(object):
             for ingress_item in annotated_ingress.ingress_items
             if ingress_item.host is not None
         ]
-        if annotated_ingress.annotations:
-            use_suffixes = False
-        else:
+        if annotated_ingress.default:
             use_suffixes = True
+        else:
+            use_suffixes = False
 
         ingress_spec = IngressSpec(rules=per_host_ingress_rules)
 

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override2.yml
@@ -35,7 +35,6 @@ metadata:
 spec:
   tls:
   - hosts:
-    - m3gt6a6nipvljp4l4dixj4jhmge5bii5.svc.test.example.com
     - use-issuer.example.com
     secretName: v3-data-examples-tls-issuer-override-1-ingress-tls
   rules:


### PR DESCRIPTION
The TLS hosts for the ingress used when the domain is for an
overridden issuer shouldn't include the "collapsed" host, which
is based on the default-suffixes.