### PR TITLE
Fix default for tls-issuer-type

### DIFF
--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -144,8 +144,8 @@ If `default_on` tls configuration will be applied unless explicitly disabled in 
 Used to configure how the ingress will be annotated for issuing a TLS certificate using cert-manager:
 
 * `tls-certificate-issuer` sets the _value_ of the annotation, for example to decide between production and staging versions of an issuer in different namespaces
-* `tls-certificate-issuer-type-default` sets the default for the _key_ of the annotation, for example to use either `certmanager.k8s.io/cluster-issuer` (the default) or `certmanager.k8s.io/issuer`
-* `tls-certificate-issuer-type-overrides` allows specifying a mapping between the suffix of a domain and the issuer-type, to override the default. For example, assuming the 'cluster-issuer' type as the default, then specifying `--tls-certificate-issuer-type-overrides foo.example.com=certmanager.k8s.io/issuer` would mean that foo.example.com and any of its subdomains will use the 'issuer' type instead. In the case of multiple matching suffixes, the more specific (i.e. longest) will be used.
+* `tls-certificate-issuer-type-default` sets the default for the _key_ of the annotation, for example to use either `cert-manager.k8s.io/cluster-issuer` (the default) or `cert-manager.k8s.io/issuer`
+* `tls-certificate-issuer-type-overrides` allows specifying a mapping between the suffix of a domain and the issuer-type, to override the default. For example, assuming the 'cluster-issuer' type as the default, then specifying `--tls-certificate-issuer-type-overrides foo.example.com=cert-manager.k8s.io/issuer` would mean that foo.example.com and any of its subdomains will use the 'issuer' type instead. In the case of multiple matching suffixes, the more specific (i.e. longest) will be used.
 
 ### use-in-memory-emptydirs
 

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -246,7 +246,7 @@ class Configuration(Namespace):
                                 default=None)
         tls_parser.add_argument("--tls-certificate-issuer-type-default",
                                 help="The annotation to set for cert-manager to provision certificates",
-                                default="certmanager.k8s.io/cluster-issuer")
+                                default="cert-manager.k8s.io/cluster-issuer")
         tls_parser.add_argument("--tls-certificate-issuer-type-overrides", help="Issuers to use for specified domain suffixes",
                                 default=[],
                                 action="append", type=KeyValue, dest="tls_certificate_issuer_type_overrides")

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -34,8 +34,8 @@ LABELS = {"ingress_deployer": "pass through", "app": "testapp", "fiaas/deploymen
 ANNOTATIONS = {"some/annotation": "val"}
 LABEL_SELECTOR_PARAMS = {"labelSelector": "app=testapp,fiaas/deployment_id,fiaas/deployment_id!=12345"}
 INGRESSES_URI = '/apis/extensions/v1beta1/namespaces/default/ingresses/'
-DEFAULT_TLS_ISSUER = "certmanager.k8s.io/cluster-issuer"
-DEFAULT_TLS_ANNOTATIONS = {"certmanager.k8s.io/cluster-issuer": "letsencrypt"}
+DEFAULT_TLS_ISSUER = "cert-manager.k8s.io/cluster-issuer"
+DEFAULT_TLS_ANNOTATIONS = {"cert-manager.k8s.io/cluster-issuer": "letsencrypt"}
 
 
 def app_spec(**kwargs):
@@ -635,9 +635,9 @@ class TestIngressDeployer(object):
     @pytest.fixture
     def deployer_issuer_overrides(self, config, ingress_tls, owner_references):
         config.tls_certificate_issuer_type_overrides = {
-            "foo.example.com": "certmanager.k8s.io/issuer",
-            "bar.example.com": "certmanager.k8s.io/cluster-issuer",
-            "foo.bar.example.com": "certmanager.k8s.io/issuer"
+            "foo.example.com": "cert-manager.k8s.io/issuer",
+            "bar.example.com": "cert-manager.k8s.io/cluster-issuer",
+            "foo.bar.example.com": "cert-manager.k8s.io/issuer"
         }
         return IngressDeployer(config, ingress_tls, owner_references)
 
@@ -727,12 +727,12 @@ class TestIngressTls(object):
          app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer="myoverwrite")),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
-         {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
+         {"cert-manager.k8s.io/cluster-issuer": "myoverwrite"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
          app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer="myoverwrite")),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
-         {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
+         {"cert-manager.k8s.io/cluster-issuer": "myoverwrite"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
          app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-ingress-cert-issuer.yml
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
-    certmanager.k8s.io/cluster-issuer: "myissuer"
+    cert-manager.k8s.io/cluster-issuer: "myissuer"
   labels:
     app: v3-data-examples-tls-enabled-cert-issuer
     fiaas/deployed_by: ""

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override1.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override1.yml
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "true"
-    certmanager.k8s.io/cluster-issuer: "someissuer"
+    cert-manager.k8s.io/cluster-issuer: "someissuer"
   labels:
     app: v3-data-examples-tls-issuer-override
     fiaas/deployed_by: ""

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_override2.yml
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "true"
-    certmanager.k8s.io/issuer: "someissuer"
+    cert-manager.k8s.io/issuer: "someissuer"
   labels:
     app: v3-data-examples-tls-issuer-override
     fiaas/deployed_by: ""

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -114,7 +114,7 @@ class TestE2E(object):
             "--datadog-container-image", "DATADOG_IMAGE:tag",
             "--strongbox-init-container-image", "STRONGBOX_IMAGE",
             "--secret-init-containers", "parameter-store=PARAM_STORE_IMAGE",
-            "--tls-certificate-issuer-type-overrides", "use-issuer.example.com=certmanager.k8s.io/issuer",
+            "--tls-certificate-issuer-type-overrides", "use-issuer.example.com=cert-manager.k8s.io/issuer",
             "--use-ingress-tls", "default_off",
         ]
         if crd_supported(k8s_version):


### PR DESCRIPTION
the annotation should be cert-manager, with a hyphen :/