### PR TITLE
Fix default suffix hosts being rewritten

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -92,7 +92,8 @@ class IngressDeployer(object):
         are separated
         '''
         explicit_host = _has_explicitly_set_host(app_spec.ingresses)
-        ingress_items = app_spec.ingresses + self._expand_default_hosts(app_spec)
+        ingress_items = [item._replace(host=self._apply_host_rewrite_rules(item.host)) for item in app_spec.ingresses if item.host]
+        ingress_items += self._expand_default_hosts(app_spec)
 
         AnnotatedIngress = namedtuple("AnnotatedIngress", ["name", "ingress_items", "annotations", "explicit_host",
                                       "issuer_type", "default"])
@@ -137,7 +138,7 @@ class IngressDeployer(object):
                               annotations=annotations)
 
         per_host_ingress_rules = [
-            IngressRule(host=self._apply_host_rewrite_rules(ingress_item.host),
+            IngressRule(host=ingress_item.host,
                         http=self._make_http_ingress_rule_value(app_spec, ingress_item.pathmappings))
             for ingress_item in annotated_ingress.ingress_items
             if ingress_item.host is not None

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -494,7 +494,9 @@ class TestIngressDeployer(object):
         config.ingress_suffixes = ["svc.test.example.com", "127.0.0.1.xip.io"]
         config.host_rewrite_rules = [
             HostRewriteRule("rewrite.example.com=test.rewrite.example.com"),
-            HostRewriteRule(r"([a-z0-9](?:[-a-z0-9]*[a-z0-9])?).rewrite.example.com=test.\1.rewrite.example.com")
+            HostRewriteRule(r"([a-z0-9](?:[-a-z0-9]*[a-z0-9])?).rewrite.example.com=test.\1.rewrite.example.com"),
+            HostRewriteRule(r"([\w\.\-]+)\.svc.test.example.com=dont-rewrite-suffix-urls.example.com"),
+            HostRewriteRule(r"([\w\.\-]+)\.127.0.0.1.xip.io=dont-rewrite-suffix-urls.example.com"),
         ]
         config.tls_certificate_issuer_type_default = DEFAULT_TLS_ISSUER
         config.tls_certificate_issuer_type_overrides = {}


### PR DESCRIPTION
Changes in #118 resulted in a change in behaviour, by using
the rewrite patterns also on the hosts generated from the default
suffixes, which wasn't previously the case.
This change applies those rewrites only to the hosts specified by
the application, before they are expanded.

Kudos to @oyvindio for the simple breaking testcase 🏆 