### PR TITLE
Keep autoscaler min_replicas=max_replicas if max < min

### DIFF
--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -72,8 +72,9 @@ class Factory(BaseFactory):
 
     @staticmethod
     def _autoscaler_spec(replicas_lookup):
-        minimum = replicas_lookup["minimum"]
         maximum = replicas_lookup["maximum"]
+        minimum = replicas_lookup["minimum"]
+        minimum = maximum if maximum < minimum else minimum
         enabled = minimum != maximum
         cpu_threshold_percentage = replicas_lookup["cpu_threshold_percentage"]
         return AutoscalerSpec(

--- a/tests/fiaas_deploy_daemon/specs/v3/data/examples/autoscaling_max_less_than_min.yml
+++ b/tests/fiaas_deploy_daemon/specs/v3/data/examples/autoscaling_max_less_than_min.yml
@@ -1,0 +1,19 @@
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 3
+replicas:
+  maximum: 1
+  # minimum: 2 -> not acutally specified, uses the default

--- a/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
+++ b/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
@@ -95,6 +95,12 @@ TEST_DATA = {
         "autoscaler.max_replicas": 3,
         "autoscaler.cpu_threshold_percentage": 50,
     },
+    "autoscaling_max_less_than_min": {
+        "autoscaler.enabled": False,
+        "autoscaler.min_replicas": 1,
+        "autoscaler.max_replicas": 1,
+        "autoscaler.cpu_threshold_percentage": 50,
+    },
     "multiple_hosts_multiple_paths": {
         "ingresses[0].host": None,
         "ingresses[0].pathmappings[0].path": "/0noport",
@@ -371,6 +377,15 @@ class TestFactory(object):
                            None, None)
         assert app_spec.name == NAME
         assert app_spec.image == IMAGE
+
+    @pytest.mark.parametrize("filename", (
+            "autoscaling_max_less_than_min",
+    ))
+    def test_autoscaling_max_less_than_min(self, load_app_config_testdata, factory, filename):
+        app_spec = factory(UID, NAME, IMAGE, load_app_config_testdata(filename), ["IO"], ["foo"], "deployment_id", NAMESPACE,
+                           None, None)
+        assert app_spec.autoscaler.min_replicas == TEST_DATA[filename]["autoscaler.min_replicas"]
+        assert app_spec.autoscaler.max_replicas == TEST_DATA[filename]["autoscaler.max_replicas"]
 
     @pytest.mark.parametrize("filename", (
             "invalid_no_health_check_defined_http",


### PR DESCRIPTION
If the user specifies a minimum number of replicas higher than the
max number of replicas, the autoscaling will set the deployment
number of replicas to the minimum (which is higher than the maximum).

Setting max < min doesn't make much sense in any case, but this
is even more unexpected when the user specify a max=1 and doesn't
even specify minimum and it takes the default(2).

This fix makes sure autoscaler.min_replicas is never higher than
autoscaler.max_replicas.

Signed-off-by: Xavi León <xavi.leon@adevinta.com>