### PR TITLE
Use v1.16.15 for Kubernetes 1.16 e2e test

### DIFF
--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -188,6 +188,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", pytest.param("v1.16.3", marks=pytest.mark.e2e_latest)))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", pytest.param("v1.16.15", marks=pytest.mark.e2e_latest)))
 def k8s_version(request):
     yield request.param


### PR DESCRIPTION
It looks like the `bsycorp/kind:v1.16.3` image's cluster component
certificates have expired, so update to the most recent patch release
image for Kubernetes 1.16 to fix e2e tests.

```
$ docker run --entrypoint /bin/bash -it bsycorp/kind:v1.16.3
bash-4.4# apk add -u openssl
bash-4.4# openssl x509 -in /var/lib/kubelet/pki/kubelet.crt -text | grep -i after
            Not After : Jan  5 08:14:05 2021 GMT
```