### PR TITLE
Improve stability of CI build/reduce parallelism of e2e tests in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -39,7 +39,7 @@ blocks:
           - docker login --username "${DOCKER_USERNAME}" --password-stdin <<< "${DOCKER_PASSWORD}"
           - ./bin/docker_build
           # Run end-to-end/integration tests
-          - tox -e integration_test -- -n 4 --use-docker-for-e2e
+          - tox -e integration_test -- -n 2 --use-docker-for-e2e
           # Store metadata for promotion jobs
           - echo "$SEMAPHORE_JOB_ID" > semaphore_job_id
           - echo "$SEMAPHORE_GIT_SHA" > semaphore_git_sha


### PR DESCRIPTION
e2e tests have been very flaky in CI lately. This change reduces the number of tests run in parallel from 4 to 2, to see if that yields more stable CI builds. This seems to increase the full CI build time from around 15-16 minutes to 21-22 minutes, which is not ideal, but maybe the build will be more stable now. 
I've retriggered the build on this branch 3 times and it has passed each time, where the master branch has failed the last 4 builds.