### PR TITLE
fix: Ensure the default host has a path defined

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -27,7 +27,7 @@ from k8s.models.common import ObjectMeta
 from k8s.models.ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend, \
     IngressTLS
 
-from fiaas_deploy_daemon.specs.models import IngressItemSpec
+from fiaas_deploy_daemon.specs.models import IngressItemSpec, IngressPathMappingSpec
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
 from collections import namedtuple
@@ -77,6 +77,10 @@ class IngressDeployer(object):
     def _expand_default_hosts(self, app_spec):
         all_pathmappings = list(_deduplicate_in_order(chain.from_iterable(ingress_item.pathmappings
                                                       for ingress_item in app_spec.ingresses if not ingress_item.annotations)))
+
+        if not all_pathmappings:
+            all_pathmappings = [IngressPathMappingSpec(path='/', port=80)]
+
         return [IngressItemSpec(host=host, pathmappings=all_pathmappings, annotations=None)
                 for host in self._generate_default_hosts(app_spec.name)]
 

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -27,7 +27,7 @@ from k8s.models.common import ObjectMeta
 from k8s.models.ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend, \
     IngressTLS
 
-from fiaas_deploy_daemon.specs.models import IngressItemSpec
+from fiaas_deploy_daemon.specs.models import IngressItemSpec, IngressPathMappingSpec
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
 from collections import namedtuple
@@ -76,17 +76,28 @@ class IngressDeployer(object):
         self._delete_unused(app_spec, custom_labels)
 
     def _expand_default_hosts(self, app_spec):
-        def extract_pathmappings(ingresses):
-            return list(_deduplicate_in_order(chain.from_iterable(ingress_item.pathmappings
-                                                                  for ingress_item in ingresses if
-                                                                  not ingress_item.annotations)))
+        all_pathmappings = list(_deduplicate_in_order(chain.from_iterable(ingress_item.pathmappings
+                                                      for ingress_item in app_spec.ingresses if not ingress_item.annotations)))
 
-        all_pathmappings = extract_pathmappings(app_spec.ingresses)
         if not all_pathmappings:
-            all_pathmappings = extract_pathmappings(self._default_app_spec().ingresses)
+            # no pathmappings were found, build the default ingress
+            http_port = self._resolve_http_port(app_spec)
+            default_path = self._resolve_default_path()
+            all_pathmappings = [IngressPathMappingSpec(path=default_path, port=http_port)]
 
         return [IngressItemSpec(host=host, pathmappings=all_pathmappings, annotations=None)
                 for host in self._generate_default_hosts(app_spec.name)]
+
+    @staticmethod
+    def _resolve_http_port(app_spec):
+        try:
+            return next(portspec.port for portspec in app_spec.ports if portspec.name == "http")
+        except StopIteration:
+            raise ValueError("Cannot find http port mapping in application spec")
+
+    def _resolve_default_path(self):
+        default_ingress_item = next(ingress_item for ingress_item in self._default_app_spec().ingresses)
+        return next(pathmapping.path for pathmapping in default_ingress_item.pathmappings)
 
     def _get_issuer_type(self, host):
         for (suffix, issuer_type) in self._tls_issuer_type_overrides:

--- a/fiaas_deploy_daemon/specs/__init__.py
+++ b/fiaas_deploy_daemon/specs/__init__.py
@@ -21,12 +21,14 @@ import pkgutil
 
 import pinject
 
+from .default import DefaultAppSpec
 from .factory import SpecFactory
 
 
 class SpecBindings(pinject.BindingSpec):
     def configure(self, bind):
         bind("spec_factory", to_class=SpecFactory)
+        bind("default_app_spec", to_class=DefaultAppSpec)
 
     def provide_factory(self):
         from .v3 import Factory

--- a/fiaas_deploy_daemon/specs/default.py
+++ b/fiaas_deploy_daemon/specs/default.py
@@ -1,0 +1,16 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+class DefaultAppSpec(object):
+    DEFAULT_APP_CONFIG = {
+        'version': 3,
+    }
+
+    def __init__(self, spec_factory):
+        self.default_app_spec = spec_factory(None, None, None, self.DEFAULT_APP_CONFIG, None, None, None, None, None,
+                                             None)
+
+    def __call__(self, *args, **kwargs):
+        return self.default_app_spec

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -18,7 +18,7 @@ import mock
 import pytest
 from k8s.models.common import ObjectMeta
 from k8s.models.ingress import Ingress, IngressTLS
-from mock import create_autospec
+from mock import create_autospec, Mock
 from requests import Response
 
 from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
@@ -503,13 +503,18 @@ class TestIngressDeployer(object):
         return config
 
     @pytest.fixture
-    def deployer(self, config, ingress_tls, owner_references):
-        return IngressDeployer(config, ingress_tls, owner_references)
+    def deployer(self, config, ingress_tls, owner_references, default_app_spec):
+        return IngressDeployer(config, ingress_tls, owner_references, default_app_spec)
 
     @pytest.fixture
-    def deployer_no_suffix(self, config, ingress_tls, owner_references):
+    def deployer_no_suffix(self, config, ingress_tls, owner_references, default_app_spec):
         config.ingress_suffixes = []
-        return IngressDeployer(config, ingress_tls, owner_references)
+        return IngressDeployer(config, ingress_tls, owner_references, default_app_spec)
+
+    @pytest.fixture
+    def default_app_spec(self):
+        default_app_spec = Mock(return_value=app_spec())
+        return default_app_spec
 
     def pytest_generate_tests(self, metafunc):
         fixtures = ("app_spec", "expected_ingress")
@@ -539,6 +544,8 @@ class TestIngressDeployer(object):
     @pytest.mark.usefixtures("dtparse", "get")
     def test_multiple_ingresses(self, post, delete, deployer, app_spec):
         app_spec.annotations.ingress.update(ANNOTATIONS.copy())
+
+        del app_spec.ingresses[:]  # make sure the default ingress will be re-created
         app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
                                                   pathmappings=[IngressPathMappingSpec(path="/", port=8000)],
                                                   annotations={"some/annotation": "some-value"}))
@@ -635,13 +642,13 @@ class TestIngressDeployer(object):
             ingress_tls.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
 
     @pytest.fixture
-    def deployer_issuer_overrides(self, config, ingress_tls, owner_references):
+    def deployer_issuer_overrides(self, config, ingress_tls, owner_references, default_app_spec):
         config.tls_certificate_issuer_type_overrides = {
             "foo.example.com": "certmanager.k8s.io/issuer",
             "bar.example.com": "certmanager.k8s.io/cluster-issuer",
             "foo.bar.example.com": "certmanager.k8s.io/issuer"
         }
-        return IngressDeployer(config, ingress_tls, owner_references)
+        return IngressDeployer(config, ingress_tls, owner_references, default_app_spec)
 
     @pytest.mark.usefixtures("delete")
     def test_applies_ingress_tls_issuser_overrides(self, post, deployer_issuer_overrides, ingress_tls, app_spec):

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress_default_host1.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress_default_host1.yml
@@ -1,0 +1,43 @@
+
+# Copyright 2017-2021 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "false"
+  labels:
+    app: v3-data-examples-multiple-ingress-default-host
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-multiple-ingress-default-host
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-ingress-default-host
+  finalizers: []
+spec:
+  tls: []
+  rules:
+  - host: v3-data-examples-multiple-ingress-default-host.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-multiple-ingress-default-host
+          servicePort: '80'
+        path: /

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress_default_host2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_ingress_default_host2.yml
@@ -1,0 +1,44 @@
+
+# Copyright 2017-2021 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+    foo/ingress-class: "internal"
+  labels:
+    app: v3-data-examples-multiple-ingress-default-host
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-multiple-ingress-default-host-1
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-ingress-default-host
+  finalizers: []
+spec:
+  tls: []
+  rules:
+  - host: internal.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: v3-data-examples-multiple-ingress-default-host
+          servicePort: '80'
+        path: /

--- a/tests/fiaas_deploy_daemon/specs/v3/data/examples/multiple_ingress_default_host.yml
+++ b/tests/fiaas_deploy_daemon/specs/v3/data/examples/multiple_ingress_default_host.yml
@@ -1,0 +1,20 @@
+
+# Copyright 2017-2021 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 3
+ingress:
+  - host: internal.example.com
+    annotations:
+        foo/ingress-class: internal

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -335,6 +335,10 @@ class TestE2E(object):
             "v3-data-examples-multiple-ingress": "e2e_expected/multiple_ingress1.yml",
             "v3-data-examples-multiple-ingress-1": "e2e_expected/multiple_ingress2.yml"
         }),
+        ("multiple_ingress_default_host", {
+            "v3-data-examples-multiple-ingress-default-host": "e2e_expected/multiple_ingress_default_host1.yml",
+            "v3-data-examples-multiple-ingress-default-host-1": "e2e_expected/multiple_ingress_default_host2.yml"
+        }),
         ("tls_issuer_override", {
             "v3-data-examples-tls-issuer-override": "e2e_expected/tls_issuer_override1.yml",
             "v3-data-examples-tls-issuer-override-1": "e2e_expected/tls_issuer_override2.yml"
@@ -376,6 +380,10 @@ class TestE2E(object):
 
             # Remove 2nd ingress to make sure cleanup works
             fiaas_application.spec.config["ingress"].pop()
+            if not fiaas_application.spec.config["ingress"]:
+                # if the test contains only one ingress,
+                # deleting the list will force the creation of the default ingress
+                del fiaas_application.spec.config["ingress"]
             fiaas_application.metadata.labels["fiaas/deployment_id"] = DEPLOYMENT_ID2
             fiaas_application.save()
 


### PR DESCRIPTION
Fix the case when the default ingress is wrongly created when only annotated
hosts are specified. For example, a fiaas spec like this one:
```
application: myapp
config:
    ingress:
    - host: myhost
      paths:
      - path: /
      annotations:
        kubernetes.io/ingress.class: internal
```
leads to the create the default ingress as follow:
```
spec:
  rules:
  - host: myapp.192.168.49.2.xip.io
```
This commit ensure that the default ingress is always created with the default
path.