### PR TITLE
Fix continuous integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN apk --no-cache add \
 COPY . /fiaas-deploy-daemon
 COPY .wheel_cache/*.whl /links/
 WORKDIR /fiaas-deploy-daemon
+
+# setuptools needs to be upgraded in order to perform the build of the wheels
+# Note: setuptools 45.0.0 will drop the support for python 2
+RUN pip install -U setuptools==44.1.1
 RUN pip wheel . --no-cache-dir --wheel-dir=/wheels/ --find-links=/links/
 
 FROM common as production

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ TESTS_REQ = [
 
 DEV_TOOLS = [
     "tox==3.14.5",
+    "virtualenv==20.4.2"
 ]
 
 


### PR DESCRIPTION
Upgrade virtualenv to run the tests using tox.
Upgrade setuptools in the docker image used to build the wheels.

I don't really understand why it fails now though.