### PR TITLE
fix e2e tests with kind

### DIFF
--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -188,6 +188,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", pytest.param("v1.16.15", marks=pytest.mark.e2e_latest)))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", pytest.param("v1.16.13", marks=pytest.mark.e2e_latest)))
 def k8s_version(request):
     yield request.param


### PR DESCRIPTION
the version 1.16.15 was updated on 10/03, I suspect a regression.

I think it should be solved when a new version of kind is released with this PR: https://github.com/bsycorp/kind/pull/43