### PR TITLE
Run e2e tests on Kubernetes v1.18

### DIFF
--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -188,6 +188,12 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", "v1.16.13", pytest.param("v1.18.6", marks=pytest.mark.e2e_latest)))
+@pytest.fixture(scope="session", params=(
+    "v1.9.11",
+    "v1.12.10",
+    "v1.14.10",
+    "v1.16.13",
+    pytest.param("v1.18.6", marks=pytest.mark.e2e_latest)
+))
 def k8s_version(request):
     yield request.param

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -188,6 +188,6 @@ def _open():
         yield mock_open
 
 
-@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", pytest.param("v1.16.13", marks=pytest.mark.e2e_latest)))
+@pytest.fixture(scope="session", params=("v1.9.11", "v1.12.10", "v1.14.10", "v1.16.13", pytest.param("v1.18.6", marks=pytest.mark.e2e_latest)))
 def k8s_version(request):
     yield request.param


### PR DESCRIPTION
We are upgrading to k8s v1.18 in Finn, and would like to have e2e testing for it. From my local runs it looks like everything should work.