### PR TITLE
Add note about secret init-containers

### DIFF
--- a/docs/v3_spec.md
+++ b/docs/v3_spec.md
@@ -701,7 +701,7 @@ for the application.
 The init-container should make secrets available as files under `/var/run/secrets/fiaas`. Any additional structure
 or convention will depend on the init-container being used.
 
-Example:
+Example (Note: the specific structure of this will depend on the configuration of FIAAS in your cluster/namespace):
 ```yaml
 extensions:
   secrets:


### PR DESCRIPTION
The 'key' under secrets is configurable by fiaas-admins, and this example has caused some confusion with our users,
so call out more directly that this is an example, and details can vary.