### PR TITLE
Document setuptools requirement in getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ See the config-module for more information.
 Getting started with developing
 -------------------------------
 
-First ensure you have the most recent version of setuptools for python2. This is required for the following steps to work
-- `pip install setuptools==44.0.0`
-Use  `$ pip install -r requirements.txt` to install dependencies
+- First ensure you have the most recent version of setuptools for python2 with `pip install setuptools==44.0.0`. This is required for the following steps to work
+- Use  `$ pip install -r requirements.txt` to install dependencies
 - Make changes to code
 Run tests with `tox`:
 - `$ tox -e codestyle` checks code style, indentations etc.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ See the config-module for more information.
 Getting started with developing
 -------------------------------
 
+First ensure you have the most recent version of setuptools for python2. This is required for the following steps to work
+- `pip install setuptools==44.0.0`
 Use  `$ pip install -r requirements.txt` to install dependencies
 - Make changes to code
 Run tests with `tox`:


### PR DESCRIPTION
For the dependencies declared in [`setup_requires`](https://github.com/fiaas/fiaas-deploy-daemon/blob/master/setup.py#L92) to be installed correctly it is necessary to have a updated setuptools version, so recommend installing the latest version which still has python 2 support.

As a sidenote, after upgrading to python 3 it might make sense to look into using a pyproject.toml to replace(?)/in addition to setup.py, since that should make it possible to declare requirements such as python version and build tool version, which might help avoid running into similar issues in the future.