### PR TITLE
"Extensions" for fiaas applications

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -39,6 +39,7 @@ from .specs import SpecBindings
 from .tools import log_request_response
 from .usage_reporting import UsageReportingBindings
 from .web import WebBindings
+from .extension_hook_caller import ExtensionHookCaller
 from prometheus_client import Info
 
 
@@ -52,6 +53,7 @@ class MainBindings(pinject.BindingSpec):
         bind("deploy_queue", to_instance=self._deploy_queue)
         bind("health_check", to_class=HealthCheck)
         bind("lifecycle", to_class=Lifecycle)
+        bind("extension_hook", to_class=ExtensionHookCaller)
 
     def provide_session(self, config):
         session = requests.Session()

--- a/fiaas_deploy_daemon/bootstrap/__init__.py
+++ b/fiaas_deploy_daemon/bootstrap/__init__.py
@@ -31,6 +31,7 @@ from ..deployer.kubernetes import K8sAdapterBindings
 from ..lifecycle import Lifecycle
 from ..logsetup import init_logging
 from ..specs import SpecBindings
+from ..extension_hook_caller import ExtensionHookCaller
 
 
 class MainBindings(pinject.BindingSpec):
@@ -43,6 +44,7 @@ class MainBindings(pinject.BindingSpec):
         bind("deploy_queue", to_instance=self._deploy_queue)
         bind("bootstrapper", to_class=Bootstrapper)
         bind("lifecycle", to_class=Lifecycle)
+        bind("extension_hook", to_class=ExtensionHookCaller)
 
     def provide_session(self, config):
         session = requests.Session()

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -121,6 +121,11 @@ Using 'default' as the 'type' will mean the container will be attached automatic
 if the application doesn't specify any.
 """
 
+HOOK_SERVICE_HELP = """
+You can add a url that will be called at various hook points
+during the deploy 'lifecycle'.
+"""
+
 
 class Configuration(Namespace):
     VALID_LOG_FORMAT = ("plain", "json")
@@ -197,6 +202,7 @@ class Configuration(Namespace):
                                  "number of seconds  (default: %(default)s)", default=10)
         parser.add_argument("--disable-deprecated-managed-env-vars", help=DISABLE_DEPRECATED_MANAGED_ENV_VARS,
                             action="store_true", default=False)
+        parser.add_argument("--hook-service", help=HOOK_SERVICE_HELP, default=None)
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)
         usage_reporting_parser.add_argument("--usage-reporting-cluster-name",
                                             help="Name of the cluster where the fiaas-deploy-daemon instance resides")

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -36,11 +36,12 @@ LOG = logging.getLogger(__name__)
 class DeploymentDeployer(object):
     MINIMUM_GRACE_PERIOD = 30
 
-    def __init__(self, config, datadog, prometheus, deployment_secrets, owner_references):
+    def __init__(self, config, datadog, prometheus, deployment_secrets, owner_references, extension_hook):
         self._datadog = datadog
         self._prometheus = prometheus
         self._secrets = deployment_secrets
         self._owner_references = owner_references
+        self._extension_hook = extension_hook
         self._legacy_fiaas_env = _build_fiaas_env(config)
         self._global_env = _build_global_env(config.global_env)
         self._lifecycle = None
@@ -123,6 +124,7 @@ class DeploymentDeployer(object):
         self._prometheus.apply(deployment, app_spec)
         self._secrets.apply(deployment, app_spec)
         self._owner_references.apply(deployment, app_spec)
+        self._extension_hook.apply("Deployment", deployment, app_spec)
         deployment.save()
 
     def delete(self, app_spec):

--- a/fiaas_deploy_daemon/extension_hook_caller.py
+++ b/fiaas_deploy_daemon/extension_hook_caller.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2021 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+from collections import OrderedDict
+
+from six import string_types
+
+
+LOG = logging.getLogger(__name__)
+
+
+class ExtensionHookCaller(object):
+
+    def __init__(self, config, session):
+        self._url = config.hook_service
+        self._session = session
+
+    def apply(self, kind, obj, app_spec):
+        if self._url is None:
+            return obj
+        url = str(self._url) + "/fiaas/deploy/" + str(kind)
+        dump = json.dumps({"object": obj.as_dict(), "application": self._app_spec_to_dict(app_spec)})
+        response = self._session.post(
+            url,
+            data=dump,
+            headers={'Content-Type': 'application/json', 'Accept': 'application/json'}
+        )
+        if response.status_code == 200:
+            data = response.json()
+            obj.update_from_dict(data)
+        elif response.status_code != 404:
+            raise Exception("The api call to " + url + " returns an status code of " + response.status_code)
+
+    @staticmethod
+    def _app_spec_to_dict(app_spec):
+        def _obj_to_dict(obj):
+            ''' check for namedtuples and collections that could contain namedtuples, recursively,
+            to turn them into dicts
+            '''
+            if hasattr(obj, "_asdict"):  # detect namedtuple
+                return OrderedDict(zip(obj._fields, (_obj_to_dict(item) for item in obj)))
+            elif isinstance(obj, string_types):  # strings are iterable but they can't contain namedtuples
+                return obj
+            elif hasattr(obj, "keys"):
+                return OrderedDict(zip(obj.keys(), (_obj_to_dict(item) for item in obj.values())))
+            elif hasattr(obj, "__iter__"):
+                return [_obj_to_dict(item) for item in obj]
+            else:  # non-iterable cannot contain namedtuples
+                return obj
+
+        app_spec_dict = _obj_to_dict(app_spec)
+        LOG.error(app_spec_dict)
+        return app_spec_dict

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -39,7 +39,8 @@ class AppSpec(namedtuple("AppSpec", [
     "strongbox",
     "singleton",
     "ingress_tls",
-    "secrets"
+    "secrets",
+    "hooks"
 ])):
     __slots__ = ()
 

--- a/fiaas_deploy_daemon/specs/v3/defaults.yml
+++ b/fiaas_deploy_daemon/specs/v3/defaults.yml
@@ -100,3 +100,4 @@ extensions:
     enabled: false # This is dynamically set based on the value for --use-ingress-tls passed to the instance
     certificate_issuer: # the name of certificate-issuer cert-manager should use
   secrets: {}
+  hooks: {}

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -67,6 +67,7 @@ class Factory(BaseFactory):
             ingress_tls=IngressTlsSpec(enabled=lookup["extensions"]["tls"]["enabled"],
                                        certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]),
             secrets=self._secrets_specs(lookup["extensions"]["secrets"]),
+            hooks=lookup["extensions"]["hooks"]
         )
         return app_spec
 

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -65,7 +65,8 @@ def app_spec():
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
         ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),
-        secrets=[]
+        secrets=[],
+        hooks={}
     )
 
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -69,7 +69,8 @@ def app_spec(**kwargs):
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
         ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),
-        secrets=[]
+        secrets=[],
+        hooks={}
     )
 
     return default_app_spec._replace(**kwargs)

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -65,7 +65,6 @@ class TestConfig(object):
         ("--environment", "environment"),
         ("--proxy", "proxy"),
         ("--strongbox-init-container-image", "strongbox_init_container_image"),
-
     ])
     def test_parameters(self, arg, key):
         config = Configuration([arg, "value"])
@@ -95,6 +94,7 @@ class TestConfig(object):
         ("proxy", "proxy", "http://proxy.example.com"),
         ("ingress-suffix", "ingress_suffixes", [r"1\.example.com", "2.example.com"]),
         ("strongbox-init-container-image", "strongbox_init_container_image", "fiaas/strongbox-image-test:123"),
+        ("hook-service", "hook_service", "hook-service-url"),
     ])
     def test_config_from_file(self, key, attr, value, tmpdir):
         config_file = tmpdir.join("config.yaml")

--- a/tests/fiaas_deploy_daemon/test_extension_hook_caller.py
+++ b/tests/fiaas_deploy_daemon/test_extension_hook_caller.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2021 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+
+import mock
+import pytest
+from k8s.models.deployment import Deployment, DeploymentSpec
+from k8s.models.pod import Container, PodSpec, PodTemplateSpec, EnvVar
+from requests import Response, Session
+
+from fiaas_deploy_daemon.extension_hook_caller import ExtensionHookCaller
+
+SENT_KIND = "Deployment"
+URL_PARAM = "URL"
+
+
+class Object(object):
+    pass
+
+
+class TestExtensionHookCaller(object):
+
+    @pytest.fixture
+    def session_respond_500(self):
+        mock_session = mock.create_autospec(Session)
+        mock_session.post.return_value = self.response_other(500)
+        return mock_session
+
+    @pytest.fixture
+    def session_respond_404(self):
+        mock_session = mock.create_autospec(Session)
+        mock_session.post.return_value = self.response_other(404)
+        return mock_session
+
+    @pytest.fixture
+    def session_respond_200(self):
+        mock_session = mock.create_autospec(Session)
+        data = self.deployment_v2()
+        mock_session.post.return_value = self.response_200(data)
+        return mock_session
+
+    @pytest.fixture
+    def session(self):
+        return mock.create_autospec(Session)
+
+    def deployment_v2(self):
+        main_container = Container(env=[EnvVar(name="DUMMY", value="CANARY")])
+        sidecar = Container(env=[EnvVar(name="SIDECAR", value="CANARY")])
+        pod_spec = PodSpec(containers=[main_container, sidecar])
+        pod_template_spec = PodTemplateSpec(spec=pod_spec)
+        deployment_spec = DeploymentSpec(template=pod_template_spec)
+        data = Deployment(spec=deployment_spec)
+        return data.as_dict()
+
+    @pytest.fixture
+    def deployment(self):
+        main_container = Container(env=[EnvVar(name="DUMMY", value="CANARY")])
+        pod_spec = PodSpec(containers=[main_container])
+        pod_template_spec = PodTemplateSpec(spec=pod_spec)
+        deployment_spec = DeploymentSpec(template=pod_template_spec)
+        return Deployment(spec=deployment_spec)
+
+    @staticmethod
+    def response_200(data):
+        mock_response = mock.create_autospec(Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = data
+        return mock_response
+
+    @staticmethod
+    def response_other(status):
+        mock_response = mock.create_autospec(Response)
+        mock_response.status_code = status
+        return mock_response
+
+    @pytest.mark.usefixtures("session_respond_404")
+    def test_return_same_object_when_404_occurs(self, session_respond_404, app_spec, deployment):
+        a = Object()
+        a.hook_service = URL_PARAM
+        extension_hook_caller = ExtensionHookCaller(a, session_respond_404)
+        obj = copy.deepcopy(deployment)
+        extension_hook_caller.apply(SENT_KIND, obj, app_spec)
+        assert obj == deployment
+
+    @pytest.mark.usefixtures("session_respond_200")
+    def test_return_respone_when_200_occurs(self, session_respond_200, app_spec, deployment):
+        a = Object()
+        a.hook_service = URL_PARAM
+        extension_hook_caller = ExtensionHookCaller(a, session_respond_200)
+        obj = copy.deepcopy(deployment)
+        expected = self.deployment_v2()
+        extension_hook_caller.apply(SENT_KIND, obj, app_spec)
+        assert isinstance(obj, type(deployment))
+        assert obj != deployment
+        assert obj.as_dict() == expected
+
+    @pytest.mark.usefixtures("session_respond_500")
+    def test_raise_exception_when_500_occurs(self, session_respond_500, app_spec, deployment):
+        a = Object()
+        a.hook_service = URL_PARAM
+        extension_hook_caller = ExtensionHookCaller(a, session_respond_500)
+        obj = copy.deepcopy(deployment)
+        with pytest.raises(Exception):
+            extension_hook_caller.apply(SENT_KIND, obj, app_spec)
+
+    @pytest.mark.usefixtures("session_respond_404")
+    def test_return_same_object_when_no_url_in_config(self, session, app_spec, deployment):
+        a = Object()
+        a.hook_service = None
+        extension_hook_caller = ExtensionHookCaller(a, session)
+        obj = copy.deepcopy(deployment)
+        extension_hook_caller.apply(SENT_KIND, obj, app_spec)
+        assert obj == deployment
+        session.post.assert_not_called()


### PR DESCRIPTION
This is a pull request to solve issue #154.

To solve it, we decided to add a call to an external service that will modify the deployment before actually saving it.

This new feature will only work if you specify the `--hook-service` argument with the URL of the external service, if you do not specify this argument, the way that the fiaas-deploy-daemon works remain the same.