### PR TITLE
reform k8s versions which are tested

### DIFF
--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -190,12 +190,12 @@ def _open():
 
 
 @pytest.fixture(scope="session", params=(
-    "v1.9.11",
-    "v1.12.10",
-    "v1.14.10",
+    "v1.15.12",
     "v1.16.13",
     "v1.18.6",
-    pytest.param("v1.19.4", marks=pytest.mark.e2e_latest)
+    "v1.19.4",
+    "v1.20.7",
+    pytest.param("v1.21.1", marks=pytest.mark.e2e_latest)
 ))
 def k8s_version(request):
     yield request.param

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -48,7 +48,7 @@ IMAGE1 = u"finntech/application-name:123"
 IMAGE2 = u"finntech/application-name:321"
 DEPLOYMENT_ID1 = u"deployment_id_1"
 DEPLOYMENT_ID2 = u"deployment_id_2"
-PATIENCE = 40
+PATIENCE = 60
 TIMEOUT = 5
 SHOULD_NOT_EXIST = object()  # Mapped to Kinds that should not exist in a test case
 

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -260,11 +260,8 @@ class KindWrapper(object):
     DOCKER_IMAGES = defaultdict(lambda: "bsycorp/kind")
     # old bsycorp/kind versions isn't being updated, and the latest version has an expired cert
     # See https://github.com/fiaas/fiaas-deploy-daemon/pull/45
-    DOCKER_IMAGES["v1.9.11"] = "fiaas/kind"
-    # See https://github.com/fiaas/fiaas-deploy-daemon/issues/115
-    DOCKER_IMAGES["v1.12.10"] = "fiaas/kind"
-    # Created the docker image in fiaas/kind because the certificate expired
-    DOCKER_IMAGES["v1.14.10"] = "fiaas/kind"
+    DOCKER_IMAGES["v1.15.12"] = "fiaas/kind"
+    # Created the docker image in fiaas/kind because the tests are not passing with v1.16.15 in semaphore-ci
     DOCKER_IMAGES["v1.16.13"] = "fiaas/kind"
 
     def __init__(self, k8s_version, name):


### PR DESCRIPTION
We have not been testing FDD with the latest versions of Kubernetes. Furthermore we are still testing it for very old versions such as 1.9, 1.12 and 1.14. These should be removed so as to reduce the time spent running tests, while newer versions should be added to ensure our software remains compatible with Kubernetes.