### PR TITLE
switch to official kind

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -34,6 +34,7 @@ blocks:
           - docker run --rm --privileged multiarch/qemu-user-static:4.2.0-7 --reset -p yes
           - export PATH="$PATH:$HOME/.local/bin"
           - pip install --user .[ci]
+          - curl -Lo $HOME/.local/bin/kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64 && chmod +x $HOME/.local/bin/kind
           - tox -e codestyle,test
           # Build docker image
           - docker login --username "${DOCKER_USERNAME}" --password-stdin <<< "${DOCKER_PASSWORD}"

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -31,6 +31,7 @@ from .types import FiaasApplication, FiaasApplicationStatus
 from ..base_thread import DaemonThread
 from ..deployer import DeployerEvent
 from ..log_extras import set_extras
+from ..retry import retry_on_upsert_conflict
 from ..specs.factory import InvalidConfiguration
 
 LOG = logging.getLogger(__name__)
@@ -68,6 +69,7 @@ class CrdWatcher(DaemonThread):
         cls._create("ApplicationStatus", "application-statuses", ("status", "appstatus", "fs"), "fiaas.schibsted.io")
 
     @staticmethod
+    @retry_on_upsert_conflict
     def _create(kind, plural, short_names, group):
         name = "%s.%s" % (plural, group)
         metadata = ObjectMeta(name=name)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ TESTS_REQ = [
     'pytest == 3.10.1',
     'requests-file == 1.4.3',
     'callee == 0.3',
-    'docker == 4.0.2'
 ]
 
 DEV_TOOLS = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,16 +164,12 @@ def use_docker_for_e2e(request):
             "-i", "--rm",
             "-e", "NAMESPACE",
             "--name", container_name,
+            "--network=kind",
             "--publish", "{port}:{port}".format(port=port),
             "--mount", "type=bind,src={},dst={},ro".format(cert_path, cert_path),
             # make `kubernetes` resolve to the apiserver's IP to make it possible to validate its TLS cert
             "--add-host", "kubernetes:{}".format(apiserver_ip),
         ]
-        if not _is_macos():
-            # Linux needs host networking to make the fiaas-deploy-daemon port available on localhost when running it
-            # in a container. To do the same thing on Docker for mac it is enough to use --publish, and enabling host
-            # networking will make it impossible to connect to the port.
-            args += ["--network", "host"]
         return args + ["fiaas/fiaas-deploy-daemon:latest"]
 
     if request.config.getoption(DOCKER_FOR_E2E_OPTION):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import itertools
 import os
 import re
 import subprocess
-import uuid
+import uuid as uuidlib
 
 import pytest
 from xdist.scheduler import LoadScopeScheduling
@@ -26,6 +26,10 @@ from xdist.scheduler import LoadScopeScheduling
 DOCKER_FOR_E2E_OPTION = "--use-docker-for-e2e"
 
 pytest_plugins = ['helpers_namespace']
+
+
+def uuid():
+    return str(uuidlib.uuid4())[:8]
 
 
 @pytest.fixture(autouse=True)
@@ -157,7 +161,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def use_docker_for_e2e(request):
     def dockerize(test_request, cert_path, service_type, k8s_version, port, apiserver_ip):
-        container_name = "fdd_{}_{}_{}".format(service_type, k8s_version, str(uuid.uuid4()))
+        container_name = "fdd_{}_{}_{}".format(service_type, k8s_version, uuid())
         test_request.addfinalizer(lambda: subprocess.call(["docker", "stop", container_name]))
         args = [
             "docker", "run",

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -191,11 +191,11 @@ def _open():
 
 @pytest.fixture(scope="session", params=(
     "v1.15.12",
-    "v1.16.13",
-    "v1.18.6",
-    "v1.19.4",
+    "v1.16.15",
+    "v1.18.19",
+    "v1.19.11",
     "v1.20.7",
-    pytest.param("v1.21.1", marks=pytest.mark.e2e_latest)
+    pytest.param("v1.21.2", marks=pytest.mark.e2e_latest)
 ))
 def k8s_version(request):
     yield request.param

--- a/tests/fiaas_deploy_daemon/test_bootstrap_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_bootstrap_e2e.py
@@ -18,7 +18,6 @@ import os
 import os.path
 import subprocess
 import sys
-import uuid
 
 import pytest
 from k8s import config
@@ -34,7 +33,7 @@ from fiaas_deploy_daemon.crd.watcher import CrdWatcher
 from fiaas_deploy_daemon.tools import merge_dicts
 from utils import wait_until, crd_available, crd_supported, \
     skip_if_crd_not_supported, read_yml, sanitize_resource_name, assert_k8s_resource_matches, get_unbound_port, \
-    KindWrapper
+    KindWrapper, uuid
 
 PATIENCE = 30
 TIMEOUT = 5
@@ -85,7 +84,7 @@ class TestBootstrapE2E(object):
     @pytest.fixture(scope="module")
     def kubernetes(self, k8s_version):
         try:
-            name = str(uuid.uuid4())
+            name = 'kind-bootstrap-{}-{}'.format(k8s_version, uuid())
             kind = KindWrapper(k8s_version, name)
             try:
                 yield kind.start()

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -17,13 +17,11 @@
 
 from __future__ import absolute_import, print_function
 
-import contextlib
 import os
 import subprocess
 import sys
 import time
 import uuid
-from datetime import datetime
 
 import pytest
 import requests
@@ -66,7 +64,7 @@ class TestE2E(object):
     @pytest.fixture(scope="module")
     def kubernetes(self, service_type, k8s_version):
         try:
-            name = "_".join((service_type, k8s_version, str(uuid.uuid4())))
+            name = str(uuid.uuid4())
             kind = KindWrapper(k8s_version, name)
             try:
                 yield kind.start()
@@ -75,48 +73,9 @@ class TestE2E(object):
         except Exception as e:
             msg = "Unable to run kind: %s"
             pytest.fail(msg % str(e))
-
-    @pytest.fixture(scope="module")
-    def kubernetes_per_app_service_account(self, k8s_version):
-        service_type = "ClusterIP"
-        try:
-            name = "_".join((service_type, k8s_version, str(uuid.uuid4())))
-            kind = KindWrapper(k8s_version, name)
-            try:
-                yield kind.start()
-            finally:
-                kind.delete()
-        except Exception as e:
-            msg = "Unable to run kind: %s"
-            pytest.fail(msg % str(e))
-
-    @pytest.fixture
-    def kind_logger(self, kubernetes):
-        return self.get_wrapped(kubernetes)
-
-    @pytest.fixture
-    def kind_logger_per_app_service_account(self, kubernetes_per_app_service_account):
-        return self.get_wrapped(kubernetes_per_app_service_account)
-
-    def get_wrapped(self, kubernetes):
-        @contextlib.contextmanager
-        def wrapped():
-            start_time = datetime.now()
-            try:
-                yield
-            finally:
-                kubernetes["log_dumper"](since=start_time, until=datetime.now())
-        return wrapped
 
     @pytest.fixture()
     def k8s_client(self, kubernetes):
-        self.prepare_k8s_client(kubernetes)
-
-    @pytest.fixture()
-    def k8s_client_service_account(self, kubernetes_per_app_service_account):
-        self.prepare_k8s_client(kubernetes_per_app_service_account)
-
-    def prepare_k8s_client(self, kubernetes):
         Client.clear_session()
         config.api_server = kubernetes["host-to-container-server"]
         config.debug = True
@@ -137,15 +96,15 @@ class TestE2E(object):
             self._end_popen(daemon)
 
     @pytest.fixture(scope="module")
-    def fdd_service_account(self, request, kubernetes_per_app_service_account, k8s_version, use_docker_for_e2e):
-        args, port, ready = self.prepare_fdd(request, kubernetes_per_app_service_account, k8s_version,
+    def fdd_service_account(self, request, kubernetes, k8s_version, use_docker_for_e2e):
+        args, port, ready = self.prepare_fdd(request, kubernetes, k8s_version,
                                              use_docker_for_e2e, "ClusterIP", service_account=True)
         try:
             daemon = subprocess.Popen(args, stdout=sys.stderr, env=merge_dicts(os.environ, {"NAMESPACE": "default"}))
             time.sleep(1)
             if daemon.poll() is not None:
                 pytest.fail("fiaas-deploy-daemon has crashed after startup, inspect logs")
-            self.wait_until_fdd_ready(k8s_version, kubernetes_per_app_service_account, ready)
+            self.wait_until_fdd_ready(k8s_version, kubernetes, ready)
             yield "http://localhost:{}/fiaas".format(port)
         finally:
             self._end_popen(daemon)
@@ -366,6 +325,7 @@ class TestE2E(object):
         return fiaas_path, expected, additional_labels
 
     def _ensure_clean(self, name, expected):
+        pass
         kinds = self._select_kinds(expected)
         for kind in kinds:
             try:
@@ -444,20 +404,13 @@ class TestE2E(object):
         wait_until(cleanup_complete, patience=PATIENCE)
 
     @pytest.mark.usefixtures("fdd", "k8s_client")
-    def test_custom_resource_definition_deploy_without_service_account(self,
-                                                                       custom_resource_definition,
-                                                                       service_type,
-                                                                       kind_logger):
-        with kind_logger():
-            self.run_crd_deploy(custom_resource_definition, service_type)
+    def test_custom_resource_definition_deploy_without_service_account(self, custom_resource_definition, service_type):
+        self.run_crd_deploy(custom_resource_definition, service_type)
 
-    @pytest.mark.usefixtures("fdd_service_account", "k8s_client_service_account")
-    def test_custom_resource_definition_deploy_with_service_account(self,
-                                                                    custom_resource_definition_service_account,
-                                                                    kind_logger_per_app_service_account):
+    @pytest.mark.usefixtures("fdd_service_account", "k8s_client")
+    def test_custom_resource_definition_deploy_with_service_account(self, custom_resource_definition_service_account):
         service_type = "ClusterIP"
-        with kind_logger_per_app_service_account():
-            self.run_crd_deploy(custom_resource_definition_service_account, service_type, service_account=True)
+        self.run_crd_deploy(custom_resource_definition_service_account, service_type, service_account=True)
 
     @pytest.mark.usefixtures("fdd", "k8s_client")
     @pytest.mark.parametrize("input, expected", [
@@ -474,65 +427,64 @@ class TestE2E(object):
             "v3-data-examples-tls-issuer-override-1": "e2e_expected/tls_issuer_override2.yml"
         })
     ])
-    def test_multiple_ingresses(self, request, kind_logger, input, expected):
-        with kind_logger():
-            fiaas_path = "v3/data/examples/%s.yml" % input
-            fiaas_yml = read_yml(request.fspath.dirpath().join("specs").join(fiaas_path).strpath)
+    def test_multiple_ingresses(self, request, input, expected):
+        fiaas_path = "v3/data/examples/%s.yml" % input
+        fiaas_yml = read_yml(request.fspath.dirpath().join("specs").join(fiaas_path).strpath)
 
-            name = sanitize_resource_name(fiaas_path)
+        name = sanitize_resource_name(fiaas_path)
 
-            expected = {k: read_yml(request.fspath.dirpath().join(v).strpath) for (k, v) in expected.items()}
-            metadata = ObjectMeta(name=name, namespace="default", labels={"fiaas/deployment_id": DEPLOYMENT_ID1})
-            spec = FiaasApplicationSpec(application=name, image=IMAGE1, config=fiaas_yml)
-            fiaas_application = FiaasApplication(metadata=metadata, spec=spec)
+        expected = {k: read_yml(request.fspath.dirpath().join(v).strpath) for (k, v) in expected.items()}
+        metadata = ObjectMeta(name=name, namespace="default", labels={"fiaas/deployment_id": DEPLOYMENT_ID1})
+        spec = FiaasApplicationSpec(application=name, image=IMAGE1, config=fiaas_yml)
+        fiaas_application = FiaasApplication(metadata=metadata, spec=spec)
 
-            fiaas_application.save()
-            app_uid = fiaas_application.metadata.uid
+        fiaas_application.save()
+        app_uid = fiaas_application.metadata.uid
 
-            # Check that deployment status is RUNNING
-            def _assert_status():
-                status = FiaasApplicationStatus.get(create_name(name, DEPLOYMENT_ID1))
-                assert status.result == u"RUNNING"
-                assert len(status.logs) > 0
-                assert any("Saving result RUNNING for default/{}".format(name) in line for line in status.logs)
+        # Check that deployment status is RUNNING
+        def _assert_status():
+            status = FiaasApplicationStatus.get(create_name(name, DEPLOYMENT_ID1))
+            assert status.result == u"RUNNING"
+            assert len(status.logs) > 0
+            assert any("Saving result RUNNING for default/{}".format(name) in line for line in status.logs)
 
-            wait_until(_assert_status, patience=PATIENCE)
+        wait_until(_assert_status, patience=PATIENCE)
 
-            def _check_two_ingresses():
-                assert Ingress.get(name)
-                assert Ingress.get("{}-1".format(name))
+        def _check_two_ingresses():
+            assert Ingress.get(name)
+            assert Ingress.get("{}-1".format(name))
 
-                for ingress_name, expected_dict in expected.items():
-                    actual = Ingress.get(ingress_name)
-                    assert_k8s_resource_matches(actual, expected_dict, IMAGE1, None, DEPLOYMENT_ID1, None, app_uid)
+            for ingress_name, expected_dict in expected.items():
+                actual = Ingress.get(ingress_name)
+                assert_k8s_resource_matches(actual, expected_dict, IMAGE1, None, DEPLOYMENT_ID1, None, app_uid)
 
-            wait_until(_check_two_ingresses, patience=PATIENCE)
+        wait_until(_check_two_ingresses, patience=PATIENCE)
 
-            # Remove 2nd ingress to make sure cleanup works
-            fiaas_application.spec.config["ingress"].pop()
-            if not fiaas_application.spec.config["ingress"]:
-                # if the test contains only one ingress,
-                # deleting the list will force the creation of the default ingress
-                del fiaas_application.spec.config["ingress"]
-            fiaas_application.metadata.labels["fiaas/deployment_id"] = DEPLOYMENT_ID2
-            fiaas_application.save()
+        # Remove 2nd ingress to make sure cleanup works
+        fiaas_application.spec.config["ingress"].pop()
+        if not fiaas_application.spec.config["ingress"]:
+            # if the test contains only one ingress,
+            # deleting the list will force the creation of the default ingress
+            del fiaas_application.spec.config["ingress"]
+        fiaas_application.metadata.labels["fiaas/deployment_id"] = DEPLOYMENT_ID2
+        fiaas_application.save()
 
-            def _check_one_ingress():
-                assert Ingress.get(name)
+        def _check_one_ingress():
+            assert Ingress.get(name)
+            with pytest.raises(NotFound):
+                Ingress.get("{}-1".format(name))
+
+        wait_until(_check_one_ingress, patience=PATIENCE)
+
+        # Cleanup
+        FiaasApplication.delete(name)
+
+        def cleanup_complete():
+            for name, _ in expected.items():
                 with pytest.raises(NotFound):
-                    Ingress.get("{}-1".format(name))
+                    Ingress.get(name)
 
-            wait_until(_check_one_ingress, patience=PATIENCE)
-
-            # Cleanup
-            FiaasApplication.delete(name)
-
-            def cleanup_complete():
-                for name, _ in expected.items():
-                    with pytest.raises(NotFound):
-                        Ingress.get(name)
-
-            wait_until(cleanup_complete, patience=PATIENCE)
+        wait_until(cleanup_complete, patience=PATIENCE)
 
 
 def _deploy_success(name, service_type, image, expected, deployment_id, strongbox_groups=None, app_uid=None):

--- a/tests/fiaas_deploy_daemon/test_e2e.py
+++ b/tests/fiaas_deploy_daemon/test_e2e.py
@@ -345,7 +345,6 @@ class TestE2E(object):
         return fiaas_path, expected, additional_labels
 
     def _ensure_clean(self, name, expected):
-        pass
         kinds = self._select_kinds(expected)
         for kind in kinds:
             try:

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -19,16 +19,16 @@ import contextlib
 import os
 import re
 import socket
+import subprocess
 import sys
 import tempfile
 import time
 import traceback
 from copy import deepcopy
-from collections import defaultdict
 from datetime import datetime
 from urlparse import urljoin
 
-import docker
+import json
 import pytest
 import requests
 import yaml
@@ -65,8 +65,7 @@ def wait_until(action, description=None, exception_class=AssertionError, patienc
     if cause:
         message.append("\nThe last exception was:\n")
         message.extend(cause)
-    header = "Gave up waiting for {} after {} seconds at {}".format(description, patience,
-                                                                    datetime.now().isoformat(" "))
+    header = "Gave up waiting for {} after {} seconds at {}".format(description, patience, datetime.now().isoformat(" "))
     message.insert(0, header)
     raise exception_class("".join(message))
 
@@ -80,11 +79,14 @@ def crd_available(kubernetes, timeout=5):
     session.cert = (kubernetes["client-cert"], kubernetes["client-key"])
 
     def _crd_available():
-        plog("Checking if CRDs are available")
         for url in (app_url, status_url):
-            plog("Checking %s" % url)
+            plog("Check if CRDs are available at %s" % url)
             resp = session.get(url, timeout=timeout)
-            resp.raise_for_status()
+            try:
+                resp.raise_for_status()
+            except Exception as e:
+                plog(e)
+                raise
             plog("!!!!! %s is available !!!!" % url)
 
     return _crd_available
@@ -257,95 +259,71 @@ def get_unbound_port():
 
 
 class KindWrapper(object):
-    DOCKER_IMAGES = defaultdict(lambda: "bsycorp/kind")
-    # old bsycorp/kind versions isn't being updated, and the latest version has an expired cert
-    # See https://github.com/fiaas/fiaas-deploy-daemon/pull/45
-    DOCKER_IMAGES["v1.15.12"] = "fiaas/kind"
-    # Created the docker image in fiaas/kind because the tests are not passing with v1.16.15 in semaphore-ci
-    DOCKER_IMAGES["v1.16.13"] = "fiaas/kind"
-
     def __init__(self, k8s_version, name):
         self.k8s_version = k8s_version
         self.name = name
         # on Docker for mac, directories under $TMPDIR can't be mounted by default. use /tmp, which works
         tmp_dir = '/tmp' if _is_macos() else None
         self._workdir = tempfile.mkdtemp(prefix="kind-{}-".format(name), dir=tmp_dir)
-        self._client = docker.from_env()
-        self._container = None
+        self._kubeconfig = os.path.join(self._workdir, "kubeconfig")
 
     def start(self):
+        plog("creating kubeconfig at " + self._kubeconfig)
+        image_name = "kindest/node:" + self.k8s_version
+        args = ["kind", "create", "cluster", "--name="+self.name, "--kubeconfig="+self._kubeconfig, "--image="+image_name, "--wait=40s"]
+        output = None
         try:
-            self._start()
-            in_container_server_ip, api_port, config_port = self._get_ports()
-            wait_until(self._endpoint_ready(config_port, "config"), "config available")
-            resp = requests.get("http://localhost:{}/config".format(config_port))
-            resp.raise_for_status()
-            config = yaml.safe_load(resp.content)
+            output, code = self._run_cmd(args)
+            if code != 0:
+                raise Exception("kind returned status code {}".format(code))
+
+            with open(self._kubeconfig, 'r') as f:
+                config = yaml.safe_load(f.read())
             api_cert = self._save_to_file("api_cert", config["clusters"][-1]["cluster"]["certificate-authority-data"])
             client_cert = self._save_to_file("client_cert", config["users"][-1]["user"]["client-certificate-data"])
             client_key = self._save_to_file("client_key", config["users"][-1]["user"]["client-key-data"])
+            apiserver_url = config["clusters"][-1]["cluster"]["server"]
+
+            container_name = self.name + "-control-plane"
+            inspect_output, code = self._run_cmd(["docker", "inspect", container_name])
+            if code != 0:
+                output = inspect_output
+                raise Exception("docker inspect returned status code {}".format(code))
+            inspect = json.loads(inspect_output)
+            in_container_server_ip = inspect[0]["NetworkSettings"]["Networks"]["kind"]["IPAddress"]
+
             result = {
                 # the apiserver's IP. We need to map this to `kubernetes` in the fdd container to be able to validate
                 # the TLS cert of the apiserver
                 "container-to-container-server-ip": in_container_server_ip,
                 # apiserver endpoint when running fdd as a container
-                "container-to-container-server": "https://kubernetes:8443",
+                "container-to-container-server": "https://{}:6443".format(container_name),
                 # apiserver endpoint for k8s client in tests, or when running fdd locally
-                "host-to-container-server": "https://localhost:{}".format(api_port),
+                "host-to-container-server": apiserver_url,
                 "client-cert": client_cert,
                 "client-key": client_key,
                 "api-cert": api_cert,
-                "log_dumper": self.dump_logs,
             }
-            plog("Waiting for container {} with name {} to become ready".format(self._container.id, self.name))
-            wait_until(self._endpoint_ready(config_port, "kubernetes-ready"), "kubernetes ready", patience=180)
+            plog("started kind cluster at {}".format(apiserver_url))
             return result
-        except Exception:
-            self.dump_logs()
+        except Exception as e:
+            if output:
+                self.dump_output(output)
             self.delete()
-            raise
+            raise e
 
-    def dump_logs(self, since=None, until=None):
-        if self._container:
-            logs = self._container.logs(since=since)
-            plog("vvvvvvvvvvvvvvvv Output from kind container vvvvvvvvvvvvvvvv")
-            if logs:
-                plog(logs, end="")
-            plog("^^^^^^^^^^^^^^^^ Output from kind container ^^^^^^^^^^^^^^^^")
+    def dump_output(self, output):
+        plog("vvvvvvvvvvvvvvvv Output from kind vvvvvvvvvvvvvvvv")
+        plog(output)
+        plog("^^^^^^^^^^^^^^^^ Output from kind ^^^^^^^^^^^^^^^^")
 
     def delete(self):
-        if self._container:
-            try:
-                self._container.stop()
-            except docker.errors.NotFound:
-                pass  # container has already stopped
-
-    def _endpoint_ready(self, port, endpoint):
-        url = "http://localhost:{}/{}".format(port, endpoint)
-
-        def ready():
-            resp = requests.get(url)
-            resp.raise_for_status()
-
-        return ready
-
-    def _start(self):
-        image_name = self.DOCKER_IMAGES[self.k8s_version]
-
-        self._container = self._client.containers.run("{}:{}".format(image_name, self.k8s_version),
-                                                      detach=True, stdout=True, stderr=True,
-                                                      remove=True, auto_remove=True, privileged=True,
-                                                      name=self.name, hostname=self.name,
-                                                      ports={"10080/tcp": None, "8443/tcp": None})
-        plog("Launched container {} with name {}".format(self._container.id, self.name))
-
-    def _get_ports(self):
-        self._container.reload()
-        ip = self._container.attrs["NetworkSettings"]["IPAddress"]
-        ports = self._container.attrs["NetworkSettings"]["Ports"]
-        config_port = ports["10080/tcp"][-1]["HostPort"]
-        api_port = ports["8443/tcp"][-1]["HostPort"]
-        return ip, api_port, config_port
+        output, code = self._run_cmd(["kind", "delete", "cluster", "--name", self.name])
+        if code != 0:
+            self.dump_output(output)
+            raise "deleting kind cluster: kind returned status code {}".format(code)
+        else:
+            plog("cluster deleted")
 
     def _save_to_file(self, name, data):
         raw_data = base64.b64decode(data)
@@ -353,6 +331,11 @@ class KindWrapper(object):
         with open(path, "wb") as fobj:
             fobj.write(raw_data)
         return path
+
+    def _run_cmd(self, args):
+        cmd = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        output = cmd.communicate()[0].strip()
+        return output, cmd.returncode
 
 
 def _is_macos():

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import time
 import traceback
+import uuid as uuidlib
 from copy import deepcopy
 from datetime import datetime
 from urlparse import urljoin
@@ -39,6 +40,10 @@ from k8s.models.service import Service
 from monotonic import monotonic as time_monotonic
 
 from fiaas_deploy_daemon.crd.types import FiaasApplication, FiaasApplicationStatus
+
+
+def uuid():
+    return str(uuidlib.uuid4())[:8]
 
 
 def plog(message, **kwargs):
@@ -80,7 +85,7 @@ def crd_available(kubernetes, timeout=5):
 
     def _crd_available():
         for url in (app_url, status_url):
-            plog("Check if CRDs are available at %s" % url)
+            plog("Checking if CRDs are available at %s" % url)
             resp = session.get(url, timeout=timeout)
             try:
                 resp.raise_for_status()


### PR DESCRIPTION
using bsycorp/kind to run kubernetes clusters in docker during integration tests has caused us many hours of pain. The issue usually observed is that the Kubernetes control plan certificates which are prebaked into the kind images expire after one year, forcing us to build/push our own with their own certificates which expire after one year.

kindest/node functions well and is maintained. We should be using this instead, thereby avoiding troubleshooting issues with bsycorp's kind.