### PR TITLE
split out ingress into beta and stable

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -206,7 +206,7 @@ def main():
         binding_specs = [
             MainBindings(cfg),
             DeployerBindings(),
-            K8sAdapterBindings(),
+            K8sAdapterBindings(cfg.use_networkingv1_ingress),
             WebBindings(),
             SpecBindings(),
             CustomResourceDefinitionBindings() if cfg.enable_crd_support else DisabledCustomResourceDefinitionBindings(),

--- a/fiaas_deploy_daemon/bootstrap/__init__.py
+++ b/fiaas_deploy_daemon/bootstrap/__init__.py
@@ -78,7 +78,7 @@ def main():
         binding_specs = [
             MainBindings(cfg),
             DeployerBindings(),
-            K8sAdapterBindings(),
+            K8sAdapterBindings(cfg.use_networkingv1_ingress),
             SpecBindings(),
         ]
         obj_graph = pinject.new_object_graph(modules=None, binding_specs=binding_specs)

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -219,6 +219,9 @@ class Configuration(Namespace):
         parser.add_argument("--extension-hook-url", help=EXTENSION_HOOK_URL_HELP, default=None)
         parser.add_argument("--enable-service-account-per-app", help=ENABLE_SERVICE_ACCOUNT_PER_APP,
                             action="store_true", default=False)
+        parser.add_argument("--use-networkingv1-ingress",
+                            help="use ingress from apiversion networking.k8s.io instead of extensions/v1beta1",
+                            action="store_true", default=False)
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)
         usage_reporting_parser.add_argument("--usage-reporting-cluster-name",
                                             help="Name of the cluster where the fiaas-deploy-daemon instance resides")

--- a/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
@@ -22,12 +22,17 @@ from .adapter import K8s
 from .autoscaler import AutoscalerDeployer
 from .deployment import DeploymentBindings
 from .ingress import IngressDeployer, IngressTls
+from .ingress_beta import BetaIngressAdapter
+from .ingress_stable import StableIngressAdapter
 from .service import ServiceDeployer
 from .service_account import ServiceAccountDeployer
 from .owner_references import OwnerReferences
 
 
 class K8sAdapterBindings(pinject.BindingSpec):
+    def __init__(self, use_networkingv1_ingress):
+        self.use_networkingv1_ingress = use_networkingv1_ingress
+
     def configure(self, bind):
         bind("adapter", to_class=K8s)
         bind("service_deployer", to_class=ServiceDeployer)
@@ -36,6 +41,11 @@ class K8sAdapterBindings(pinject.BindingSpec):
         bind("autoscaler", to_class=AutoscalerDeployer)
         bind("ingress_tls", to_class=IngressTls)
         bind("owner_references", to_class=OwnerReferences)
+
+        if self.use_networkingv1_ingress:
+            bind("ingress_adapter", to_class=StableIngressAdapter)
+        else:
+            bind("ingress_adapter", to_class=BetaIngressAdapter)
 
     def dependencies(self):
         return [DeploymentBindings()]

--- a/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
@@ -49,7 +49,7 @@ class K8sAdapterBindings(pinject.BindingSpec):
             bind("ingress_tls", to_class=StableIngressTLS)
         else:
             bind("ingress_adapter", to_class=BetaIngressAdapter)
-            bind("ingress_tls", to_class=BetaIngressTLS)
+            bind("ingress_tls", to_instance=BetaIngressTLS)
 
     def dependencies(self):
         return [DeploymentBindings()]

--- a/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
@@ -22,12 +22,12 @@ from .adapter import K8s
 from .autoscaler import AutoscalerDeployer
 from .deployment import DeploymentBindings
 from .ingress import IngressDeployer, IngressTLSDeployer
-from .ingress_beta import BetaIngressAdapter
-from .ingress_stable import StableIngressAdapter
+from .ingress_v1beta1 import V1Beta1IngressAdapter
+from .ingress_networkingv1 import NetworkingV1IngressAdapter
 from .service import ServiceDeployer
 from .service_account import ServiceAccountDeployer
 from .owner_references import OwnerReferences
-from k8s.models.ingress import IngressTLS as BetaIngressTLS
+from k8s.models.ingress import IngressTLS as V1Beta1IngressTLS
 from k8s.models.networking_v1_ingress import IngressTLS as StableIngressTLS
 
 
@@ -45,11 +45,11 @@ class K8sAdapterBindings(pinject.BindingSpec):
         bind("owner_references", to_class=OwnerReferences)
 
         if self.use_networkingv1_ingress:
-            bind("ingress_adapter", to_class=StableIngressAdapter)
+            bind("ingress_adapter", to_class=NetworkingV1IngressAdapter)
             bind("ingress_tls", to_class=StableIngressTLS)
         else:
-            bind("ingress_adapter", to_class=BetaIngressAdapter)
-            bind("ingress_tls", to_instance=BetaIngressTLS)
+            bind("ingress_adapter", to_class=V1Beta1IngressAdapter)
+            bind("ingress_tls", to_instance=V1Beta1IngressTLS)
 
     def dependencies(self):
         return [DeploymentBindings()]

--- a/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
@@ -21,12 +21,14 @@ import pinject
 from .adapter import K8s
 from .autoscaler import AutoscalerDeployer
 from .deployment import DeploymentBindings
-from .ingress import IngressDeployer, IngressTls
+from .ingress import IngressDeployer, IngressTLSDeployer
 from .ingress_beta import BetaIngressAdapter
 from .ingress_stable import StableIngressAdapter
 from .service import ServiceDeployer
 from .service_account import ServiceAccountDeployer
 from .owner_references import OwnerReferences
+from k8s.models.ingress import IngressTLS as BetaIngressTLS
+from k8s.models.networking_v1_ingress import IngressTLS as StableIngressTLS
 
 
 class K8sAdapterBindings(pinject.BindingSpec):
@@ -39,13 +41,15 @@ class K8sAdapterBindings(pinject.BindingSpec):
         bind("service_account_deployer", to_class=ServiceAccountDeployer)
         bind("ingress_deployer", to_class=IngressDeployer)
         bind("autoscaler", to_class=AutoscalerDeployer)
-        bind("ingress_tls", to_class=IngressTls)
+        bind("ingress_tls_deployer", to_class=IngressTLSDeployer)
         bind("owner_references", to_class=OwnerReferences)
 
         if self.use_networkingv1_ingress:
             bind("ingress_adapter", to_class=StableIngressAdapter)
+            bind("ingress_tls", to_class=StableIngressTLS)
         else:
             bind("ingress_adapter", to_class=BetaIngressAdapter)
+            bind("ingress_tls", to_class=BetaIngressTLS)
 
     def dependencies(self):
         return [DeploymentBindings()]

--- a/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/__init__.py
@@ -46,7 +46,7 @@ class K8sAdapterBindings(pinject.BindingSpec):
 
         if self.use_networkingv1_ingress:
             bind("ingress_adapter", to_class=NetworkingV1IngressAdapter)
-            bind("ingress_tls", to_class=StableIngressTLS)
+            bind("ingress_tls", to_instance=StableIngressTLS)
         else:
             bind("ingress_adapter", to_class=V1Beta1IngressAdapter)
             bind("ingress_tls", to_instance=V1Beta1IngressTLS)

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -29,7 +29,7 @@ LOG = logging.getLogger(__name__)
 
 
 class IngressDeployer(object):
-    def __init__(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+    def __init__(self, config, default_app_spec, ingress_adapter):
         self._default_app_spec = default_app_spec
         self._ingress_suffixes = config.ingress_suffixes
         self._host_rewrite_rules = config.host_rewrite_rules

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -21,14 +21,10 @@ import hashlib
 import logging
 from itertools import chain
 
-from k8s.client import NotFound
-from k8s.base import Equality, Inequality, Exists
-from k8s.models.common import ObjectMeta
-from k8s.models.ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend, \
-    IngressTLS
+from k8s.models.ingress import IngressTLS as BetaIngressTLS
+from k8s.models.networking_v1_ingress import IngressTLS as StableIngressTLS
 
 from fiaas_deploy_daemon.specs.models import IngressItemSpec, IngressPathMappingSpec
-from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
 from collections import namedtuple
 
@@ -36,13 +32,11 @@ LOG = logging.getLogger(__name__)
 
 
 class IngressDeployer(object):
-    def __init__(self, config, ingress_tls, owner_references, default_app_spec, extension_hook):
+    def __init__(self, config, ingress_tls, owner_references, default_app_spec, extension_hook, ingress_adapter):
         self._default_app_spec = default_app_spec
         self._ingress_suffixes = config.ingress_suffixes
         self._host_rewrite_rules = config.host_rewrite_rules
-        self._ingress_tls = ingress_tls
-        self._owner_references = owner_references
-        self._extension_hook = extension_hook
+        self._ingress_adapter = ingress_adapter
         self._tls_issuer_type_default = config.tls_certificate_issuer_type_default
         self._tls_issuer_type_overrides = sorted(config.tls_certificate_issuer_type_overrides.iteritems(),
                                                  key=lambda (k, v): len(k), reverse=True)
@@ -51,14 +45,11 @@ class IngressDeployer(object):
         if self._should_have_ingress(app_spec):
             self._create(app_spec, labels)
         else:
-            self._delete_unused(app_spec, labels)
+            self._ingress_adapter.delete_unused(app_spec, labels)
 
     def delete(self, app_spec):
         LOG.info("Deleting ingresses for %s", app_spec.name)
-        try:
-            Ingress.delete_list(namespace=app_spec.namespace, labels={"app": Equality(app_spec.name), "fiaas/deployment_id": Exists()})
-        except NotFound:
-            pass
+        self._ingress_adapter.delete_list(app_spec)
 
     def _create(self, app_spec, labels):
         LOG.info("Creating/updating ingresses for %s", app_spec.name)
@@ -72,13 +63,15 @@ class IngressDeployer(object):
                 LOG.info("No items, skipping: %s", annotated_ingress)
                 continue
 
-            self._create_ingress(app_spec, annotated_ingress, custom_labels)
+            self._ingress_adapter.create_ingress(app_spec, annotated_ingress, custom_labels)
 
-        self._delete_unused(app_spec, custom_labels)
+        self._ingress_adapter.delete_unused(app_spec, custom_labels)
 
     def _expand_default_hosts(self, app_spec):
-        all_pathmappings = list(_deduplicate_in_order(chain.from_iterable(ingress_item.pathmappings
-                                                      for ingress_item in app_spec.ingresses if not ingress_item.annotations)))
+        all_pathmappings = list(
+            deduplicate_in_order(chain.from_iterable(
+                ingress_item.pathmappings for ingress_item in app_spec.ingresses if not ingress_item.annotations))
+        )
 
         if not all_pathmappings:
             # no pathmappings were found, build the default ingress
@@ -147,45 +140,6 @@ class IngressDeployer(object):
 
         return ingresses
 
-    @retry_on_upsert_conflict
-    def _create_ingress(self, app_spec, annotated_ingress, labels):
-        default_annotations = {
-            u"fiaas/expose": u"true" if annotated_ingress.explicit_host else u"false"
-        }
-        annotations = merge_dicts(app_spec.annotations.ingress, annotated_ingress.annotations, default_annotations)
-
-        metadata = ObjectMeta(name=annotated_ingress.name, namespace=app_spec.namespace, labels=labels,
-                              annotations=annotations)
-
-        per_host_ingress_rules = [
-            IngressRule(host=ingress_item.host,
-                        http=self._make_http_ingress_rule_value(app_spec, ingress_item.pathmappings))
-            for ingress_item in annotated_ingress.ingress_items
-            if ingress_item.host is not None
-        ]
-        if annotated_ingress.default:
-            use_suffixes = True
-        else:
-            use_suffixes = False
-
-        ingress_spec = IngressSpec(rules=per_host_ingress_rules)
-
-        ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
-
-        hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
-        self._ingress_tls.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
-        self._owner_references.apply(ingress, app_spec)
-        self._extension_hook.apply(ingress, app_spec)
-        ingress.save()
-
-    def _delete_unused(self, app_spec, labels):
-        filter_labels = [
-            ("app", Equality(labels["app"])),
-            ("fiaas/deployment_id", Exists()),
-            ("fiaas/deployment_id", Inequality(labels["fiaas/deployment_id"]))
-        ]
-        Ingress.delete_list(namespace=app_spec.namespace, labels=filter_labels)
-
     def _generate_default_hosts(self, name):
         for suffix in self._ingress_suffixes:
             yield u"{}.{}".format(name, suffix)
@@ -201,14 +155,6 @@ class IngressDeployer(object):
 
     def _can_generate_host(self, app_spec):
         return len(self._ingress_suffixes) > 0 or _has_explicitly_set_host(app_spec.ingresses)
-
-    @staticmethod
-    def _make_http_ingress_rule_value(app_spec, pathmappings):
-        http_ingress_paths = [
-            HTTPIngressPath(path=pm.path, backend=IngressBackend(serviceName=app_spec.name, servicePort=pm.port))
-            for pm in _deduplicate_in_order(pathmappings)]
-
-        return HTTPIngressRuleValue(paths=http_ingress_paths)
 
     def _get_hosts(self, app_spec):
         return list(self._generate_default_hosts(app_spec.name)) + \
@@ -228,7 +174,7 @@ def _has_ingress(app_spec):
     return len(app_spec.ingresses) > 0
 
 
-def _deduplicate_in_order(iterator):
+def deduplicate_in_order(iterator):
     seen = set()
     for item in iterator:
         if item not in seen:
@@ -242,6 +188,10 @@ class IngressTls(object):
         self._cert_issuer = config.tls_certificate_issuer
         self._shortest_suffix = sorted(config.ingress_suffixes, key=len)[0] if config.ingress_suffixes else None
         self.enable_deprecated_tls_entry_per_host = config.enable_deprecated_tls_entry_per_host
+        if config.use_networkingv1_ingress:
+            self.ingress_tls = StableIngressTLS
+        else:
+            self.ingress_tls = BetaIngressTLS
 
     def apply(self, ingress, app_spec, hosts, issuer_type, use_suffixes=True):
         if self._should_have_ingress_tls(app_spec):
@@ -259,7 +209,7 @@ class IngressTls(object):
             if self.enable_deprecated_tls_entry_per_host:
                 # TODO: DOCD-1846 - Once new certificates has been provisioned, remove the single host entries and
                 # associated configuration flag
-                ingress.spec.tls = [IngressTLS(hosts=[host], secretName=host) for host in hosts if len(host) < 64]
+                ingress.spec.tls = [self.ingress_tls(hosts=[host], secretName=host) for host in hosts if len(host) < 64]
             else:
                 ingress.spec.tls = []
 
@@ -268,7 +218,7 @@ class IngressTls(object):
                 # as the user doesn't control it we should generate a host we know will fit
                 hosts = self._collapse_hosts(app_spec, hosts)
 
-            ingress.spec.tls.append(IngressTLS(hosts=hosts, secretName="{}-ingress-tls".format(ingress.metadata.name)))
+            ingress.spec.tls.append(self.ingress_tls(hosts=hosts, secretName="{}-ingress-tls".format(ingress.metadata.name)))
 
     def _collapse_hosts(self, app_spec, hosts):
         """The first hostname in the list will be used as Common Name in the certificate"""

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_beta.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_beta.py
@@ -28,8 +28,8 @@ from .ingress import deduplicate_in_order
 
 
 class BetaIngressAdapter(object):
-    def __init__(self, ingress_tls, owner_references, extension_hook):
-        self._ingress_tls = ingress_tls
+    def __init__(self, ingress_tls_deployer, owner_references, extension_hook):
+        self._ingress_tls_deployer = ingress_tls_deployer
         self._owner_references = owner_references
         self._extension_hook = extension_hook
 
@@ -57,7 +57,7 @@ class BetaIngressAdapter(object):
         ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
 
         hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
-        self._ingress_tls.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
+        self._ingress_tls_deployer.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
         self._owner_references.apply(ingress, app_spec)
         self._extension_hook.apply(ingress, app_spec)
         ingress.save()

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_beta.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_beta.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from k8s.client import NotFound
+from k8s.models.common import ObjectMeta
+from k8s.models.ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend
+from k8s.base import Equality, Inequality, Exists
+
+from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
+from fiaas_deploy_daemon.tools import merge_dicts
+
+from .ingress import deduplicate_in_order
+
+
+class BetaIngressAdapter(object):
+    def __init__(self, ingress_tls, owner_references, extension_hook):
+        self._ingress_tls = ingress_tls
+        self._owner_references = owner_references
+        self._extension_hook = extension_hook
+
+    @retry_on_upsert_conflict
+    def create_ingress(self, app_spec, annotated_ingress, labels):
+        default_annotations = {
+            u"fiaas/expose": u"true" if annotated_ingress.explicit_host else u"false"
+        }
+        annotations = merge_dicts(app_spec.annotations.ingress, annotated_ingress.annotations, default_annotations)
+
+        metadata = ObjectMeta(name=annotated_ingress.name, namespace=app_spec.namespace, labels=labels,
+                              annotations=annotations)
+
+        per_host_ingress_rules = [
+            IngressRule(host=ingress_item.host, http=self._make_http_ingress_rule_value(app_spec, ingress_item.pathmappings))
+            for ingress_item in annotated_ingress.ingress_items if ingress_item.host is not None
+        ]
+        if annotated_ingress.default:
+            use_suffixes = True
+        else:
+            use_suffixes = False
+
+        ingress_spec = IngressSpec(rules=per_host_ingress_rules)
+
+        ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
+
+        hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
+        self._ingress_tls.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
+        self._owner_references.apply(ingress, app_spec)
+        self._extension_hook.apply(ingress, app_spec)
+        ingress.save()
+
+    def delete_unused(self, app_spec, labels):
+        filter_labels = [
+            ("app", Equality(labels["app"])),
+            ("fiaas/deployment_id", Exists()),
+            ("fiaas/deployment_id", Inequality(labels["fiaas/deployment_id"]))
+        ]
+        Ingress.delete_list(namespace=app_spec.namespace, labels=filter_labels)
+
+    def delete_list(self, app_spec):
+        try:
+            Ingress.delete_list(namespace=app_spec.namespace,
+                                labels={"app": Equality(app_spec.name), "fiaas/deployment_id": Exists()})
+        except NotFound:
+            pass
+
+    def _make_http_ingress_rule_value(self, app_spec, pathmappings):
+        http_ingress_paths = [
+            HTTPIngressPath(path=pm.path, backend=IngressBackend(serviceName=app_spec.name, servicePort=pm.port))
+            for pm in deduplicate_in_order(pathmappings)]
+
+        return HTTPIngressRuleValue(paths=http_ingress_paths)

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_stable.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_stable.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+
+from k8s.client import NotFound
+from k8s.models.common import ObjectMeta
+from k8s.models.networking_v1_ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend, \
+    IngressServiceBackend, ServiceBackendPort
+from k8s.base import Equality, Inequality, Exists
+
+from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
+from fiaas_deploy_daemon.tools import merge_dicts
+
+from .ingress import deduplicate_in_order
+
+
+class StableIngressAdapter(object):
+    def __init__(self, ingress_tls, owner_references, extension_hook):
+        self._ingress_tls = ingress_tls
+        self._owner_references = owner_references
+        self._extension_hook = extension_hook
+
+    @retry_on_upsert_conflict
+    def create_ingress(self, app_spec, annotated_ingress, labels):
+        default_annotations = {
+            u"fiaas/expose": u"true" if annotated_ingress.explicit_host else u"false"
+        }
+        annotations = merge_dicts(app_spec.annotations.ingress, annotated_ingress.annotations, default_annotations)
+
+        metadata = ObjectMeta(name=annotated_ingress.name, namespace=app_spec.namespace, labels=labels,
+                              annotations=annotations)
+
+        per_host_ingress_rules = [
+            IngressRule(host=ingress_item.host, http=self._make_http_ingress_rule_value(app_spec, ingress_item.pathmappings))
+            for ingress_item in annotated_ingress.ingress_items if ingress_item.host is not None
+        ]
+        if annotated_ingress.default:
+            use_suffixes = True
+        else:
+            use_suffixes = False
+
+        ingress_spec = IngressSpec(rules=per_host_ingress_rules)
+
+        ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
+
+        hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
+        self._ingress_tls.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
+        self._owner_references.apply(ingress, app_spec)
+        self._extension_hook.apply(ingress, app_spec)
+        ingress.save()
+
+    def delete_unused(self, app_spec, labels):
+        filter_labels = [
+            ("app", Equality(labels["app"])),
+            ("fiaas/deployment_id", Exists()),
+            ("fiaas/deployment_id", Inequality(labels["fiaas/deployment_id"]))
+        ]
+        Ingress.delete_list(namespace=app_spec.namespace, labels=filter_labels)
+
+    def delete_list(self, app_spec):
+        try:
+            Ingress.delete_list(namespace=app_spec.namespace,
+                                labels={"app": Equality(app_spec.name), "fiaas/deployment_id": Exists()})
+        except NotFound:
+            pass
+
+    def _make_http_ingress_rule_value(self, app_spec, pathmappings):
+        http_ingress_paths = [
+            HTTPIngressPath(
+                path=pm.path,
+                pathType="ImplementationSpecific",
+                backend=IngressBackend(service=IngressServiceBackend(name=app_spec.name, port=ServiceBackendPort(number=pm.port))),
+            )
+            for pm in deduplicate_in_order(pathmappings)]
+
+        return HTTPIngressRuleValue(paths=http_ingress_paths)

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_stable.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_stable.py
@@ -29,8 +29,8 @@ from .ingress import deduplicate_in_order
 
 
 class StableIngressAdapter(object):
-    def __init__(self, ingress_tls, owner_references, extension_hook):
-        self._ingress_tls = ingress_tls
+    def __init__(self, ingress_tls_deployer, owner_references, extension_hook):
+        self._ingress_tls_deployer = ingress_tls_deployer
         self._owner_references = owner_references
         self._extension_hook = extension_hook
 
@@ -58,7 +58,7 @@ class StableIngressAdapter(object):
         ingress = Ingress.get_or_create(metadata=metadata, spec=ingress_spec)
 
         hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
-        self._ingress_tls.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
+        self._ingress_tls_deployer.apply(ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, use_suffixes=use_suffixes)
         self._owner_references.apply(ingress, app_spec)
         self._extension_hook.apply(ingress, app_spec)
         ingress.save()

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
@@ -18,8 +18,7 @@ from __future__ import absolute_import
 
 from k8s.client import NotFound
 from k8s.models.common import ObjectMeta
-from k8s.models.networking_v1_ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend, \
-    IngressServiceBackend, ServiceBackendPort
+from k8s.models.ingress import Ingress, IngressSpec, IngressRule, HTTPIngressRuleValue, HTTPIngressPath, IngressBackend
 from k8s.base import Equality, Inequality, Exists
 
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
@@ -28,7 +27,7 @@ from fiaas_deploy_daemon.tools import merge_dicts
 from .ingress import deduplicate_in_order
 
 
-class StableIngressAdapter(object):
+class V1Beta1IngressAdapter(object):
     def __init__(self, ingress_tls_deployer, owner_references, extension_hook):
         self._ingress_tls_deployer = ingress_tls_deployer
         self._owner_references = owner_references
@@ -80,11 +79,7 @@ class StableIngressAdapter(object):
 
     def _make_http_ingress_rule_value(self, app_spec, pathmappings):
         http_ingress_paths = [
-            HTTPIngressPath(
-                path=pm.path,
-                pathType="ImplementationSpecific",
-                backend=IngressBackend(service=IngressServiceBackend(name=app_spec.name, port=ServiceBackendPort(number=pm.port))),
-            )
+            HTTPIngressPath(path=pm.path, backend=IngressBackend(serviceName=app_spec.name, servicePort=pm.port))
             for pm in deduplicate_in_order(pathmappings)]
 
         return HTTPIngressRuleValue(paths=http_ingress_paths)

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -142,7 +142,7 @@ SecretsSpec = namedtuple("SecretsSpec", [
     "annotations"
 ])
 
-IngressTLSDeployerSpec = namedtuple("IngressTLSDeployerSpec", [
+IngressTLSSpec = namedtuple("IngressTLSSpec", [
     "enabled",
     "certificate_issuer",
 ])

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -142,7 +142,7 @@ SecretsSpec = namedtuple("SecretsSpec", [
     "annotations"
 ])
 
-IngressTlsSpec = namedtuple("IngressTlsSpec", [
+IngressTLSDeployerSpec = namedtuple("IngressTLSDeployerSpec", [
     "enabled",
     "certificate_issuer",
 ])

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -24,7 +24,7 @@ from ..factory import BaseFactory, InvalidConfiguration
 from ..lookup import LookupMapping
 from ..models import AppSpec, PrometheusSpec, DatadogSpec, ResourcesSpec, ResourceRequirementSpec, PortSpec, \
     HealthCheckSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, ExecCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSDeployerSpec, SecretsSpec
+    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec, SecretsSpec
 from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK
 from ...tools import merge_dicts
 
@@ -64,7 +64,7 @@ class Factory(BaseFactory):
             ingresses=self._ingress_items(lookup["ingress"], lookup["ports"]),
             strongbox=self._strongbox(lookup["extensions"]["strongbox"]),
             singleton=lookup["replicas"]["singleton"],
-            ingress_tls=IngressTLSDeployerSpec(enabled=lookup["extensions"]["tls"]["enabled"],
+            ingress_tls=IngressTLSSpec(enabled=lookup["extensions"]["tls"]["enabled"],
                                                certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]),
             secrets=self._secrets_specs(lookup["extensions"]["secrets"]),
             app_config=app_config

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -24,7 +24,7 @@ from ..factory import BaseFactory, InvalidConfiguration
 from ..lookup import LookupMapping
 from ..models import AppSpec, PrometheusSpec, DatadogSpec, ResourcesSpec, ResourceRequirementSpec, PortSpec, \
     HealthCheckSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, ExecCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTlsSpec, SecretsSpec
+    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSDeployerSpec, SecretsSpec
 from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK
 from ...tools import merge_dicts
 
@@ -64,8 +64,8 @@ class Factory(BaseFactory):
             ingresses=self._ingress_items(lookup["ingress"], lookup["ports"]),
             strongbox=self._strongbox(lookup["extensions"]["strongbox"]),
             singleton=lookup["replicas"]["singleton"],
-            ingress_tls=IngressTlsSpec(enabled=lookup["extensions"]["tls"]["enabled"],
-                                       certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]),
+            ingress_tls=IngressTLSDeployerSpec(enabled=lookup["extensions"]["tls"]["enabled"],
+                                               certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]),
             secrets=self._secrets_specs(lookup["extensions"]["secrets"]),
             app_config=app_config
         )

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -64,8 +64,10 @@ class Factory(BaseFactory):
             ingresses=self._ingress_items(lookup["ingress"], lookup["ports"]),
             strongbox=self._strongbox(lookup["extensions"]["strongbox"]),
             singleton=lookup["replicas"]["singleton"],
-            ingress_tls=IngressTLSSpec(enabled=lookup["extensions"]["tls"]["enabled"],
-                                               certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]),
+            ingress_tls=IngressTLSSpec(
+                enabled=lookup["extensions"]["tls"]["enabled"],
+                certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"]
+            ),
             secrets=self._secrets_specs(lookup["extensions"]["secrets"]),
             app_config=app_config
         )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ GENERIC_REQ = [
     "decorator < 5.0.0",  # 5.0.0 and later drops py2 support (transitive dep from pinject)
     "six == 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.20.0",
+    "k8s == 0.21.0",
     "monotonic == 1.6",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -23,7 +23,7 @@ from fiaas_deploy_daemon.specs.models import AppSpec, \
     ResourceRequirementSpec, ResourcesSpec, PrometheusSpec, DatadogSpec, \
     PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, \
     AutoscalerSpec, ExecCheckSpec, LabelAndAnnotationSpec, \
-    IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSDeployerSpec
+    IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec
 
 PROMETHEUS_SPEC = PrometheusSpec(enabled=True, port='http', path='/internal-backstage/prometheus')
 DATADOG_SPEC = DatadogSpec(enabled=False, tags={})
@@ -64,7 +64,7 @@ def app_spec():
         ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
-        ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None),
+        ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
         secrets=[],
         app_config={}
     )

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -23,7 +23,7 @@ from fiaas_deploy_daemon.specs.models import AppSpec, \
     ResourceRequirementSpec, ResourcesSpec, PrometheusSpec, DatadogSpec, \
     PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, \
     AutoscalerSpec, ExecCheckSpec, LabelAndAnnotationSpec, \
-    IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTlsSpec
+    IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSDeployerSpec
 
 PROMETHEUS_SPEC = PrometheusSpec(enabled=True, port='http', path='/internal-backstage/prometheus')
 DATADOG_SPEC = DatadogSpec(enabled=False, tags={})
@@ -64,7 +64,7 @@ def app_spec():
         ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
-        ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),
+        ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None),
         secrets=[],
         app_config={}
     )

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -28,7 +28,7 @@ from fiaas_deploy_daemon.deployer.kubernetes.ingress_beta import BetaIngressAdap
 from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
     ResourcesSpec, PrometheusSpec, DatadogSpec, \
     PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSDeployerSpec
+    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec
 
 from utils import TypeMatcher
 
@@ -70,7 +70,7 @@ def app_spec(**kwargs):
         ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
-        ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None),
+        ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
         secrets=[],
         app_config={},
     )
@@ -663,7 +663,7 @@ class TestIngressDeployer(object):
         return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
 
     @pytest.mark.usefixtures("delete")
-    def test_applies_ingress_tls_deployer_issuser_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):
+    def test_applies_ingress_tls_deployer_issuer_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):
         with mock.patch("k8s.models.ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             app_spec.ingresses[:] = [
@@ -721,53 +721,53 @@ class TestIngressTLSDeployer(object):
 
     @pytest.mark.parametrize("tls, app_spec, spec_tls, issuer_type, tls_annotations", [
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS,
          "overwrite-issuer",
          {"overwrite-issuer": "letsencrypt"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
          DEFAULT_TLS_ANNOTATIONS),
         ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer="myoverwrite")),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer="myoverwrite")),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
          {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer="myoverwrite")),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer="myoverwrite")),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
          {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
     ], indirect=['tls'])
     def test_apply_tls(self, tls, app_spec, spec_tls, issuer_type, tls_annotations):
         ingress = Ingress()

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -23,11 +23,12 @@ from requests import Response
 
 from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
-from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTls
+from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTLSDeployer
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_beta import BetaIngressAdapter
 from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
     ResourcesSpec, PrometheusSpec, DatadogSpec, \
     PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTlsSpec
+    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSDeployerSpec
 
 from utils import TypeMatcher
 
@@ -69,7 +70,7 @@ def app_spec(**kwargs):
         ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
-        ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None),
+        ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None),
         secrets=[],
         app_config={},
     )
@@ -491,8 +492,8 @@ class TestIngressDeployer(object):
         return mock.create_autospec(ExtensionHookCaller, spec_set=True, instance=True)
 
     @pytest.fixture
-    def ingress_tls(self, config):
-        return mock.create_autospec(IngressTls(config), spec_set=True, instance=True)
+    def ingress_tls_deployer(self, config):
+        return mock.create_autospec(IngressTLSDeployer(config, IngressTLS), spec_set=True, instance=True)
 
     @pytest.fixture
     def config(self):
@@ -509,13 +510,17 @@ class TestIngressDeployer(object):
         return config
 
     @pytest.fixture
-    def deployer(self, config, ingress_tls, owner_references, default_app_spec, extension_hook):
-        return IngressDeployer(config, ingress_tls, owner_references, default_app_spec, extension_hook)
+    def ingress_adapter(self, ingress_tls_deployer, owner_references, extension_hook):
+        return BetaIngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
 
     @pytest.fixture
-    def deployer_no_suffix(self, config, ingress_tls, owner_references, default_app_spec, extension_hook):
+    def deployer(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+
+    @pytest.fixture
+    def deployer_no_suffix(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
         config.ingress_suffixes = []
-        return IngressDeployer(config, ingress_tls, owner_references, default_app_spec, extension_hook)
+        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
 
     @pytest.fixture
     def default_app_spec(self):
@@ -642,23 +647,23 @@ class TestIngressDeployer(object):
              [u'test.foo.rewrite.example.com', u'testapp.svc.test.example.com', u'testapp.127.0.0.1.xip.io']),
     ))
     @pytest.mark.usefixtures("delete")
-    def test_applies_ingress_tls(self, deployer, ingress_tls, app_spec, hosts):
+    def test_applies_ingress_tls_deployer(self, deployer, ingress_tls_deployer, app_spec, hosts):
         with mock.patch("k8s.models.ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             deployer.deploy(app_spec, LABELS)
-            ingress_tls.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
+            ingress_tls_deployer.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
 
     @pytest.fixture
-    def deployer_issuer_overrides(self, config, ingress_tls, owner_references, default_app_spec, extension_hook):
+    def deployer_issuer_overrides(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
         config.tls_certificate_issuer_type_overrides = {
             "foo.example.com": "certmanager.k8s.io/issuer",
             "bar.example.com": "certmanager.k8s.io/cluster-issuer",
             "foo.bar.example.com": "certmanager.k8s.io/issuer"
         }
-        return IngressDeployer(config, ingress_tls, owner_references, default_app_spec, extension_hook)
+        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
 
     @pytest.mark.usefixtures("delete")
-    def test_applies_ingress_tls_issuser_overrides(self, post, deployer_issuer_overrides, ingress_tls, app_spec):
+    def test_applies_ingress_tls_deployer_issuser_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):
         with mock.patch("k8s.models.ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             app_spec.ingresses[:] = [
@@ -678,17 +683,17 @@ class TestIngressDeployer(object):
             ]
 
             deployer_issuer_overrides.deploy(app_spec, LABELS)
-            host_groups = [sorted(call.args[2]) for call in ingress_tls.apply.call_args_list]
+            host_groups = [sorted(call.args[2]) for call in ingress_tls_deployer.apply.call_args_list]
             expected_host_groups = [
                 ["ann.foo.example.com"],
                 ["bar.example.com", "other.example.com", "sub.bar.example.com", "testapp.127.0.0.1.xip.io", "testapp.svc.test.example.com"],
                 ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"]
             ]
-            assert ingress_tls.apply.call_count == 3
+            assert ingress_tls_deployer.apply.call_count == 3
             assert expected_host_groups == sorted(host_groups)
 
 
-class TestIngressTls(object):
+class TestIngressTLSDeployer(object):
     HOSTS = ["host1", "host2", "host3", "this.host.is.so.long.that.it.is.impossible.to.use.as.the.common.name"]
     COLLAPSED_HOSTS = ["zgwvxk7m22jnzqmofnboadb6kpuri4st.short.suffix"] + HOSTS
     INGRESS_SPEC_TLS = [
@@ -712,57 +717,57 @@ class TestIngressTls(object):
         config.tls_certificate_issuer = request.param["cert_issuer"]
         config.ingress_suffixes = ["short.suffix", "really.quite.long.suffix"]
         config.enable_deprecated_tls_entry_per_host = request.param["enable_deprecated_tls_entry_per_host"]
-        return IngressTls(config)
+        return IngressTLSDeployer(config, IngressTLS)
 
     @pytest.mark.parametrize("tls, app_spec, spec_tls, issuer_type, tls_annotations", [
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS,
          "overwrite-issuer",
          {"overwrite-issuer": "letsencrypt"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
          DEFAULT_TLS_ANNOTATIONS),
         ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer="myoverwrite")),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer="myoverwrite")),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
          {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer="myoverwrite")),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer="myoverwrite")),
          INGRESS_SPEC_TLS,
          DEFAULT_TLS_ISSUER,
          {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)),
          INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
         ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
         ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTlsSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
+         app_spec(ingress_tls=IngressTLSDeployerSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
     ], indirect=['tls'])
     def test_apply_tls(self, tls, app_spec, spec_tls, issuer_type, tls_annotations):
         ingress = Ingress()
@@ -780,7 +785,7 @@ class TestIngressTls(object):
     def test_shorten_name(self, config, suffix, expected):
         config.use_ingress_tls = "default_on"
         config.ingress_suffixes = [suffix]
-        tls = IngressTls(config)
+        tls = IngressTLSDeployer(config, IngressTLS)
         actual = tls._generate_short_host(app_spec())
         assert len(actual) < 64
         assert expected == actual
@@ -788,13 +793,13 @@ class TestIngressTls(object):
     def test_raise_when_suffix_too_long(self, config):
         config.use_ingress_tls = "default_on"
         config.ingress_suffixes = ["this.suffix.is.so.long.that.it.is.impossible.to.generate.a.short.enough.name"]
-        tls = IngressTls(config)
+        tls = IngressTLSDeployer(config, IngressTLS)
         with pytest.raises(ValueError):
             tls._generate_short_host(app_spec())
 
     def test_raise_when_name_starts_with_dot(self, config):
         config.use_ingress_tls = "default_on"
         config.ingress_suffixes = ["really.long.suffix.which.goes.to.the.very.edge.of.the.boundary"]
-        tls = IngressTls(config)
+        tls = IngressTLSDeployer(config, IngressTLS)
         with pytest.raises(ValueError):
             tls._generate_short_host(app_spec())

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -514,13 +514,13 @@ class TestIngressDeployer(object):
         return BetaIngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
 
     @pytest.fixture
-    def deployer(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
-        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+    def deployer(self, config, default_app_spec, ingress_adapter):
+        return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.fixture
-    def deployer_no_suffix(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+    def deployer_no_suffix(self, config, default_app_spec, ingress_adapter):
         config.ingress_suffixes = []
-        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+        return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.fixture
     def default_app_spec(self):
@@ -654,13 +654,13 @@ class TestIngressDeployer(object):
             ingress_tls_deployer.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
 
     @pytest.fixture
-    def deployer_issuer_overrides(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+    def deployer_issuer_overrides(self, config, default_app_spec, ingress_adapter):
         config.tls_certificate_issuer_type_overrides = {
             "foo.example.com": "certmanager.k8s.io/issuer",
             "bar.example.com": "certmanager.k8s.io/cluster-issuer",
             "foo.bar.example.com": "certmanager.k8s.io/issuer"
         }
-        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+        return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.mark.usefixtures("delete")
     def test_applies_ingress_tls_deployer_issuer_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -24,7 +24,7 @@ from requests import Response
 from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
 from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTLSDeployer
-from fiaas_deploy_daemon.deployer.kubernetes.ingress_beta import BetaIngressAdapter
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_v1beta1 import V1Beta1IngressAdapter
 from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
     ResourcesSpec, PrometheusSpec, DatadogSpec, \
     PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
@@ -511,7 +511,7 @@ class TestIngressDeployer(object):
 
     @pytest.fixture
     def ingress_adapter(self, ingress_tls_deployer, owner_references, extension_hook):
-        return BetaIngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
+        return V1Beta1IngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
 
     @pytest.fixture
     def deployer(self, config, default_app_spec, ingress_adapter):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
@@ -23,7 +23,7 @@ from requests import Response
 from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
 from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTLSDeployer
-from fiaas_deploy_daemon.deployer.kubernetes.ingress_stable import StableIngressAdapter
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_networkingv1 import NetworkingV1IngressAdapter
 from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
     ResourcesSpec, PrometheusSpec, DatadogSpec, \
     PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
@@ -279,7 +279,7 @@ class TestIngressDeployer(object):
 
     @pytest.fixture
     def ingress_adapter(self, ingress_tls_deployer, owner_references, extension_hook):
-        return StableIngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
+        return NetworkingV1IngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
 
     @pytest.fixture
     def deployer(self, config, default_app_spec, ingress_adapter):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import mock
+import pytest
+from k8s.models.networking_v1_ingress import Ingress, IngressTLS
+from mock import create_autospec, Mock
+from requests import Response
+
+from fiaas_deploy_daemon import ExtensionHookCaller
+from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
+from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTLSDeployer
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_stable import StableIngressAdapter
+from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
+    ResourcesSpec, PrometheusSpec, DatadogSpec, \
+    PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
+    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec
+
+from utils import TypeMatcher
+
+LABELS = {"ingress_deployer": "pass through", "app": "testapp", "fiaas/deployment_id": "12345"}
+ANNOTATIONS = {"some/annotation": "val"}
+LABEL_SELECTOR_PARAMS = {"labelSelector": "app=testapp,fiaas/deployment_id,fiaas/deployment_id!=12345"}
+INGRESSES_URI = '/apis/networking.k8s.io/v1/namespaces/default/ingresses/'
+DEFAULT_TLS_ISSUER = "certmanager.k8s.io/cluster-issuer"
+DEFAULT_TLS_ANNOTATIONS = {"certmanager.k8s.io/cluster-issuer": "letsencrypt"}
+
+
+def app_spec(**kwargs):
+    default_app_spec = AppSpec(
+        uid="c1f34517-6f54-11ea-8eaf-0ad3d9992c8c",
+        name="testapp",
+        namespace="default",
+        image="finntech/testimage:version",
+        autoscaler=AutoscalerSpec(enabled=False, min_replicas=2, max_replicas=3, cpu_threshold_percentage=50),
+        resources=ResourcesSpec(requests=ResourceRequirementSpec(cpu=None, memory=None),
+                                limits=ResourceRequirementSpec(cpu=None, memory=None)),
+        admin_access=False,
+        secrets_in_environment=False,
+        prometheus=PrometheusSpec(enabled=True, port='http', path='/internal-backstage/prometheus'),
+        datadog=DatadogSpec(enabled=False, tags={}),
+        ports=[
+            PortSpec(protocol="http", name="http", port=80, target_port=8080),
+        ],
+        health_checks=HealthCheckSpec(
+            liveness=CheckSpec(tcp=TcpCheckSpec(port=8080), http=None, execute=None, initial_delay_seconds=10,
+                               period_seconds=10, success_threshold=1, failure_threshold=3, timeout_seconds=1),
+            readiness=CheckSpec(http=HttpCheckSpec(path="/", port=8080, http_headers={}), tcp=None, execute=None,
+                                initial_delay_seconds=10, period_seconds=10, success_threshold=1,
+                                failure_threshold=3, timeout_seconds=1)),
+        teams=[u'foo'],
+        tags=[u'bar'],
+        deployment_id="test_app_deployment_id",
+        labels=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}, {}),
+        annotations=LabelAndAnnotationSpec({}, {}, ANNOTATIONS.copy(), {}, {}, {}, {}),
+        ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
+        strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
+        singleton=False,
+        ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
+        secrets=[],
+        app_config={},
+    )
+
+    return default_app_spec._replace(**kwargs)
+
+
+def _create_rule(host, paths=None):
+    rule = {
+        'host': host,
+        'http': {
+            'paths': [{
+                'path': '/',
+                'pathType': 'ImplementationSpecific',
+                'backend': {
+                    'service': {
+                        'name': "testapp",
+                        'port': {
+                            'number': 80,
+                        },
+                    },
+                }
+            }]
+        }
+    }
+    if paths:
+        rule['http']['paths'] = paths
+    return rule
+
+
+def _create_path(path, svc, port):
+    return {
+        'path': path,
+        'pathType': 'ImplementationSpecific',
+        'backend': {
+            'service': {
+                'name': svc,
+                'port': {
+                    'number': port,
+                },
+            },
+        },
+    }
+
+
+def ingress(rules=None, metadata=None, expose=False, tls=None):
+    default_rules = [
+        _create_rule("testapp.svc.test.example.com"),
+        _create_rule("testapp.127.0.0.1.xip.io"),
+    ]
+    default_metadata = pytest.helpers.create_metadata('testapp', labels=LABELS, annotations=ANNOTATIONS, external=expose)
+
+    expected_ingress = {
+        'spec': {
+            'rules': rules if rules else default_rules,
+            'tls': tls if tls else []
+        },
+        'metadata': metadata if metadata else default_metadata,
+    }
+    return expected_ingress
+
+
+TEST_DATA = (
+    # (test_case_name, provided_app_spec, expected_ingress)
+    ("only_default_hosts", app_spec(), ingress()),
+    ("single_explicit_host",
+     app_spec(ingresses=[
+         IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
+     ingress(expose=True, rules=[
+         _create_rule("foo.example.com"),
+         _create_rule("testapp.svc.test.example.com"),
+         _create_rule("testapp.127.0.0.1.xip.io"),
+     ])),
+    ("single_explicit_host_multiple_paths",
+     app_spec(ingresses=[
+         IngressItemSpec(host="foo.example.com", pathmappings=[
+             IngressPathMappingSpec(path="/", port=80),
+             IngressPathMappingSpec(path="/other", port=5000)], annotations={})],
+         ports=[
+             PortSpec(protocol="http", name="http", port=80, target_port=8080),
+             PortSpec(protocol="http", name="other", port=5000, target_port=8081)]),
+     ingress(expose=True, rules=[
+         _create_rule("foo.example.com", paths=[
+             _create_path("/", "testapp", 80),
+             _create_path("/other", "testapp", 5000)
+         ]),
+         _create_rule("testapp.svc.test.example.com", paths=[
+             _create_path("/", "testapp", 80),
+             _create_path("/other", "testapp", 5000)
+         ]),
+         _create_rule("testapp.127.0.0.1.xip.io", paths=[
+             _create_path("/", "testapp", 80),
+             _create_path("/other", "testapp", 5000)
+         ]),
+     ])),
+    ("multiple_explicit_hosts",
+     app_spec(ingresses=[
+         IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+         IngressItemSpec(host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
+     ingress(expose=True, rules=[
+        _create_rule("foo.example.com"),
+        _create_rule("bar.example.com"),
+        _create_rule("testapp.svc.test.example.com"),
+        _create_rule("testapp.127.0.0.1.xip.io"),
+     ])),
+    ("multiple_explicit_hosts_multiple_paths",
+     app_spec(ingresses=[
+         IngressItemSpec(host="foo.example.com", pathmappings=[
+             IngressPathMappingSpec(path="/one", port=80),
+             IngressPathMappingSpec(path="/two", port=5000)
+         ], annotations={}),
+         IngressItemSpec(host="bar.example.com", pathmappings=[
+             IngressPathMappingSpec(path="/three", port=80),
+             IngressPathMappingSpec(path="/four", port=5000)
+         ], annotations={})],
+         ports=[
+             PortSpec(protocol="http", name="http", port=80, target_port=8080),
+             PortSpec(protocol="http", name="other", port=5000, target_port=8081),
+         ]),
+     ingress(expose=True, rules=[
+        _create_rule("foo.example.com", paths=[
+            _create_path("/one", "testapp", 80),
+            _create_path("/two", "testapp", 5000),
+        ]),
+        _create_rule("bar.example.com", paths=[
+            _create_path("/three", "testapp", 80),
+            _create_path("/four", "testapp", 5000),
+        ]),
+        _create_rule("testapp.svc.test.example.com", paths=[
+            _create_path("/one", "testapp", 80),
+            _create_path("/two", "testapp", 5000),
+            _create_path("/three", "testapp", 80),
+            _create_path("/four", "testapp", 5000),
+        ]),
+        _create_rule("testapp.127.0.0.1.xip.io", paths=[
+            _create_path("/one", "testapp", 80),
+            _create_path("/two", "testapp", 5000),
+            _create_path("/three", "testapp", 80),
+            _create_path("/four", "testapp", 5000),
+        ]),
+     ])),
+    ("rewrite_host_simple",
+     app_spec(ingresses=[
+         IngressItemSpec(host="rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
+     ingress(expose=True, rules=[
+         _create_rule("test.rewrite.example.com"),
+         _create_rule("testapp.svc.test.example.com"),
+         _create_rule("testapp.127.0.0.1.xip.io"),
+     ])),
+    ("rewrite_host_regex_substitution",
+     app_spec(ingresses=[
+         IngressItemSpec(host="foo.rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
+     ingress(expose=True, rules=[
+         _create_rule("test.foo.rewrite.example.com"),
+         _create_rule("testapp.svc.test.example.com"),
+         _create_rule("testapp.127.0.0.1.xip.io"),
+     ])),
+    ("custom_labels_and_annotations",
+     app_spec(labels=LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={},
+                                            ingress={"ingress_deployer": "pass through", "custom": "label"},
+                                            service={}, service_account={}, pod={}, status={}),
+              annotations=LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={},
+                                                 ingress={"custom": "annotation"}, service={}, service_account={}, pod={}, status={})),
+     ingress(metadata=pytest.helpers.create_metadata('testapp', external=False,
+                                                     labels={"ingress_deployer": "pass through", "custom": "label",
+                                                             "app": "testapp", "fiaas/deployment_id": "12345"},
+                                                     annotations={"fiaas/expose": "false", "custom": "annotation"}))),
+    ("regex_path",
+     app_spec(ingresses=[
+         IngressItemSpec(host=None, pathmappings=[
+             IngressPathMappingSpec(
+                 path=r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                 port=80)], annotations={})]),
+     ingress(expose=False, rules=[
+         _create_rule("testapp.svc.test.example.com", paths=[
+             _create_path(r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)", 'testapp', 80),
+         ]),
+         _create_rule("testapp.127.0.0.1.xip.io", paths=[
+             _create_path(r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)", 'testapp', 80),
+         ]),
+     ])),
+)
+
+
+class TestIngressDeployer(object):
+    @pytest.fixture
+    def extension_hook(self):
+        return mock.create_autospec(ExtensionHookCaller, spec_set=True, instance=True)
+
+    @pytest.fixture
+    def ingress_tls_deployer(self, config):
+        return mock.create_autospec(IngressTLSDeployer(config, IngressTLS), spec_set=True, instance=True)
+
+    @pytest.fixture
+    def config(self):
+        config = mock.create_autospec(Configuration([]), spec_set=True)
+        config.ingress_suffixes = ["svc.test.example.com", "127.0.0.1.xip.io"]
+        config.host_rewrite_rules = [
+            HostRewriteRule("rewrite.example.com=test.rewrite.example.com"),
+            HostRewriteRule(r"([a-z0-9](?:[-a-z0-9]*[a-z0-9])?).rewrite.example.com=test.\1.rewrite.example.com"),
+            HostRewriteRule(r"([\w\.\-]+)\.svc.test.example.com=dont-rewrite-suffix-urls.example.com"),
+            HostRewriteRule(r"([\w\.\-]+)\.127.0.0.1.xip.io=dont-rewrite-suffix-urls.example.com"),
+        ]
+        config.tls_certificate_issuer_type_default = DEFAULT_TLS_ISSUER
+        config.tls_certificate_issuer_type_overrides = {}
+        return config
+
+    @pytest.fixture
+    def ingress_adapter(self, ingress_tls_deployer, owner_references, extension_hook):
+        return StableIngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
+
+    @pytest.fixture
+    def deployer(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+
+    @pytest.fixture
+    def deployer_no_suffix(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+        config.ingress_suffixes = []
+        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+
+    @pytest.fixture
+    def default_app_spec(self):
+        default_app_spec = Mock(return_value=app_spec())
+        return default_app_spec
+
+    def pytest_generate_tests(self, metafunc):
+        fixtures = ("app_spec", "expected_ingress")
+        if metafunc.cls == self.__class__ and metafunc.function.__name__ == "test_ingress_deploy" and \
+                all(fixname in metafunc.fixturenames for fixname in fixtures):
+            for test_id, app_spec, expected_ingress in TEST_DATA:
+                params = {"app_spec": app_spec, "expected_ingress": expected_ingress}
+                metafunc.addcall(params, test_id)
+
+    @pytest.mark.usefixtures("get")
+    def test_ingress_deploy(self, post, delete, deployer, app_spec, expected_ingress, owner_references, extension_hook):
+        mock_response = create_autospec(Response)
+        mock_response.json.return_value = expected_ingress
+        post.return_value = mock_response
+
+        deployer.deploy(app_spec, LABELS)
+
+        pytest.helpers.assert_any_call(post, INGRESSES_URI, expected_ingress)
+        owner_references.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec)
+        extension_hook.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec)
+        delete.assert_called_once_with(INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
+
+    @pytest.fixture
+    def dtparse(self):
+        with mock.patch('pyrfc3339.parse') as m:
+            yield m
+
+    @pytest.mark.usefixtures("dtparse", "get")
+    def test_multiple_ingresses(self, post, delete, deployer, app_spec):
+        app_spec.annotations.ingress.update(ANNOTATIONS.copy())
+
+        del app_spec.ingresses[:]  # make sure the default ingress will be re-created
+        app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
+                                                  pathmappings=[IngressPathMappingSpec(path="/", port=8000)],
+                                                  annotations={"some/annotation": "some-value"}))
+        app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
+                                                  pathmappings=[IngressPathMappingSpec(path="/_/ipblocked", port=8000)],
+                                                  annotations={"some/allowlist": "10.0.0.1/12"}))
+
+        expected_ingress = ingress()
+        mock_response = create_autospec(Response)
+        mock_response.json.return_value = expected_ingress
+
+        expected_metadata2 = pytest.helpers.create_metadata('testapp-1', labels=LABELS,
+                                                            annotations={"some/annotation": "some-value"}, external=True)
+        expected_ingress2 = ingress(rules=[
+            _create_rule('extra.example.com', paths=[_create_path('/', app_spec.name, 8000)])
+        ], metadata=expected_metadata2)
+        mock_response2 = create_autospec(Response)
+        mock_response.json.return_value = expected_ingress2
+
+        expected_metadata3 = pytest.helpers.create_metadata('testapp-2', labels=LABELS,
+                                                            annotations={"some/annotation": "val",
+                                                                         "some/allowlist": "10.0.0.1/12"}, external=True)
+        expected_ingress3 = ingress(rules=[
+            _create_rule('extra.example.com', paths=[_create_path('/_/ipblocked', app_spec.name, 8000)])
+        ], metadata=expected_metadata3)
+        mock_response3 = create_autospec(Response)
+        mock_response3.json.return_value = expected_ingress3
+
+        post.side_effect = iter([mock_response, mock_response2, mock_response3])
+
+        deployer.deploy(app_spec, LABELS)
+
+        post.assert_has_calls([mock.call(INGRESSES_URI, expected_ingress), mock.call(INGRESSES_URI, expected_ingress2),
+                               mock.call(INGRESSES_URI, expected_ingress3)])
+        delete.assert_called_once_with(INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
+
+    @pytest.mark.parametrize("spec_name", (
+            "app_spec_thrift",
+            "app_spec_no_ports",
+    ))
+    def test_remove_existing_ingress_if_not_needed(self, request, delete, post, deployer, spec_name):
+        app_spec = request.getfuncargvalue(spec_name)
+
+        deployer.deploy(app_spec, LABELS)
+
+        pytest.helpers.assert_no_calls(post, INGRESSES_URI)
+        pytest.helpers.assert_any_call(delete, INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
+
+    @pytest.mark.usefixtures("get")
+    def test_no_ingress(self, delete, post, deployer_no_suffix, app_spec):
+        deployer_no_suffix.deploy(app_spec, LABELS)
+
+        pytest.helpers.assert_no_calls(post, INGRESSES_URI)
+        pytest.helpers.assert_any_call(delete, INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
+
+    @pytest.mark.parametrize("app_spec, hosts", (
+            (app_spec(), [u'testapp.svc.test.example.com', u'testapp.127.0.0.1.xip.io']),
+            (app_spec(ingresses=[
+                IngressItemSpec(host="foo.rewrite.example.com",
+                                pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
+             [u'test.foo.rewrite.example.com', u'testapp.svc.test.example.com', u'testapp.127.0.0.1.xip.io']),
+    ))
+    @pytest.mark.usefixtures("delete")
+    def test_applies_ingress_tls_deployer(self, deployer, ingress_tls_deployer, app_spec, hosts):
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.get_or_create") as get_or_create:
+            get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
+            deployer.deploy(app_spec, LABELS)
+            ingress_tls_deployer.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
+
+    @pytest.fixture
+    def deployer_issuer_overrides(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+        config.tls_certificate_issuer_type_overrides = {
+            "foo.example.com": "certmanager.k8s.io/issuer",
+            "bar.example.com": "certmanager.k8s.io/cluster-issuer",
+            "foo.bar.example.com": "certmanager.k8s.io/issuer"
+        }
+        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+
+    @pytest.mark.usefixtures("delete")
+    def test_applies_ingress_tls_deployer_issuer_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.get_or_create") as get_or_create:
+            get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
+            app_spec.ingresses[:] = [
+                # has issuer-override
+                IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                # no issuer-override
+                IngressItemSpec(host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(host="foo.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(host="other.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                # suffix has issuer-override
+                IngressItemSpec(host="sub.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                # more specific suffix has issuer-override
+                IngressItemSpec(host="sub.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                # has annotations
+                IngressItemSpec(host="ann.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                                annotations={"some": "annotation"})
+            ]
+
+            deployer_issuer_overrides.deploy(app_spec, LABELS)
+            host_groups = [sorted(call.args[2]) for call in ingress_tls_deployer.apply.call_args_list]
+            expected_host_groups = [
+                ["ann.foo.example.com"],
+                ["bar.example.com", "other.example.com", "sub.bar.example.com", "testapp.127.0.0.1.xip.io", "testapp.svc.test.example.com"],
+                ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"]
+            ]
+            assert ingress_tls_deployer.apply.call_count == 3
+            assert expected_host_groups == sorted(host_groups)

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
@@ -282,13 +282,13 @@ class TestIngressDeployer(object):
         return StableIngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
 
     @pytest.fixture
-    def deployer(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
-        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+    def deployer(self, config, default_app_spec, ingress_adapter):
+        return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.fixture
-    def deployer_no_suffix(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+    def deployer_no_suffix(self, config, default_app_spec, ingress_adapter):
         config.ingress_suffixes = []
-        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+        return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.fixture
     def default_app_spec(self):
@@ -396,13 +396,13 @@ class TestIngressDeployer(object):
             ingress_tls_deployer.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
 
     @pytest.fixture
-    def deployer_issuer_overrides(self, config, owner_references, default_app_spec, extension_hook, ingress_adapter):
+    def deployer_issuer_overrides(self, config, default_app_spec, ingress_adapter):
         config.tls_certificate_issuer_type_overrides = {
             "foo.example.com": "certmanager.k8s.io/issuer",
             "bar.example.com": "certmanager.k8s.io/cluster-issuer",
             "foo.bar.example.com": "certmanager.k8s.io/issuer"
         }
-        return IngressDeployer(config, owner_references, default_app_spec, extension_hook, ingress_adapter)
+        return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.mark.usefixtures("delete")
     def test_applies_ingress_tls_deployer_issuer_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):

--- a/tests/fiaas_deploy_daemon/e2e_expected/exec-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/exec-networkingv1-ingress.yml
@@ -11,32 +11,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
   labels:
-    app: data-v2minimal
+    app: v2-data-examples-exec-config
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v2-data-examples-exec-config
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v2-data-examples-exec-config
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: v2-data-examples-exec-config.svc.test.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v2-data-examples-exec-config
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/host-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/host-networkingv1-ingress.yml
@@ -11,32 +11,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
   labels:
-    app: data-v2minimal
+    app: v2-data-examples-host
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v2-data-examples-host
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v2-data-examples-host
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: some.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v2-data-examples-host
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific
+  - host: v2-data-examples-host.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v2-data-examples-host
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_hosts_multiple_paths-networkingv1-ingress.yml
@@ -1,0 +1,149 @@
+# Copyright 2017-2019 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+  labels:
+    app: v3-data-examples-multiple-hosts-multiple-paths
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-multiple-hosts-multiple-paths
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-multiple-hosts-multiple-paths
+  finalizers: []
+spec:
+  tls: []
+  rules:
+  - host: foo.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /1noport
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /1portname
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /1portnumber
+        pathType: ImplementationSpecific
+  - host: bar.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /2noport
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /2portname
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /2portnumber
+        pathType: ImplementationSpecific
+  - host: v3-data-examples-multiple-hosts-multiple-paths.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /0noport
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /0portname
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /0portnumber
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /1noport
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /1portname
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /1portnumber
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /2noport
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /2portname
+        pathType: ImplementationSpecific
+      - backend:
+          service:
+            name: v3-data-examples-multiple-hosts-multiple-paths
+            port:
+              number: 80
+        path: /2portnumber
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-multiple-ingress
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-multiple-ingress
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-multiple-ingress
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: www.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-multiple-ingress
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific
+  - host: v3-data-examples-multiple-ingress.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-multiple-ingress
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress2.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
+    foo/ingress-class: "internal"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-multiple-ingress
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-multiple-ingress-1
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-multiple-ingress
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: internal.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-multiple-ingress
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress_default_host1.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress_default_host1.yml
@@ -1,4 +1,5 @@
-# Copyright 2017-2019 The FIAAS Authors
+
+# Copyright 2017-2021 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,32 +12,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-multiple-ingress-default-host
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-multiple-ingress-default-host
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-multiple-ingress-default-host
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: v3-data-examples-multiple-ingress-default-host.svc.test.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-multiple-ingress-default-host
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress_default_host2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/multiple_networkingv1-ingress_default_host2.yml
@@ -1,4 +1,5 @@
-# Copyright 2017-2019 The FIAAS Authors
+
+# Copyright 2017-2021 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,32 +12,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
+    foo/ingress-class: "internal"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-multiple-ingress-default-host
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-multiple-ingress-default-host-1
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-multiple-ingress-default-host
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: internal.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-multiple-ingress-default-host
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/partial_override-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/partial_override-networkingv1-ingress.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
   labels:
-    app: data-v2minimal
+    app: v2-data-examples-partial-override
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v2-data-examples-partial-override
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v2-data-examples-partial-override
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: www.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
-        path: /
+          service:
+            name: v2-data-examples-partial-override
+            port:
+              number: 80
+        path: /foo
+        pathType: ImplementationSpecific
+  - host: v2-data-examples-partial-override.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v2-data-examples-partial-override
+            port:
+              number: 80
+        path: /foo
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/strongbox-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/strongbox-networkingv1-ingress.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-strongbox
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-strongbox
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-strongbox
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: v3-data-examples-strongbox.svc.test.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-strongbox
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-networkingv1-ingress-cert-issuer.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-networkingv1-ingress-cert-issuer.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
+    certmanager.k8s.io/cluster-issuer: "myissuer"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-tls-enabled-cert-issuer
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-tls-enabled-cert-issuer
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-tls-enabled-cert-issuer
   finalizers: []
 spec:
-  tls: []
+  tls:
+  - hosts:
+    - cdour67se34teb7c52m2lfjjopq56sbz.svc.test.example.com
+    - v3-data-examples-tls-enabled-cert-issuer.svc.test.example.com
+    secretName: v3-data-examples-tls-enabled-cert-issuer-ingress-tls
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: v3-data-examples-tls-enabled-cert-issuer.svc.test.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-tls-enabled-cert-issuer
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-networkingv1-ingress-multiple.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-networkingv1-ingress-multiple.yml
@@ -1,0 +1,59 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    fiaas/expose: "true"
+    kubernetes.io/tls-acme: "true"
+  labels:
+    app: v3-data-examples-tls-enabled-multiple
+    fiaas/deployed_by: ""
+    fiaas/deployment_id: DEPLOYMENT_ID
+    fiaas/version: VERSION
+  name: v3-data-examples-tls-enabled-multiple
+  namespace: default
+  ownerReferences:
+    - apiVersion: fiaas.schibsted.io/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Application
+      name: v3-data-examples-tls-enabled-multiple
+  finalizers: []
+spec:
+  tls:
+  - hosts:
+    - qp4ouhml4krhfiltuenvy6ilm5pze3n3.svc.test.example.com
+    - example.com
+    - example.org
+    - v3-data-examples-tls-enabled-multiple.svc.test.example.com
+    secretName: v3-data-examples-tls-enabled-multiple-ingress-tls
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-tls-enabled-multiple
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  - host: example.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-tls-enabled-multiple
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific
+  - host: v3-data-examples-tls-enabled-multiple.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-tls-enabled-multiple
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls-networkingv1-ingress.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
+    kubernetes.io/tls-acme: "true"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-tls-enabled
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-tls-enabled
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-tls-enabled
   finalizers: []
 spec:
-  tls: []
+  tls:
+  - hosts:
+    - pckqvxryazy6fkalse7zoudilpf43dkb.svc.test.example.com
+    - v3-data-examples-tls-enabled.svc.test.example.com
+    secretName: v3-data-examples-tls-enabled-ingress-tls
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: v3-data-examples-tls-enabled.svc.test.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-tls-enabled
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_networkingv1_override1.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_networkingv1_override1.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,51 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
+    certmanager.k8s.io/cluster-issuer: "someissuer"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-tls-issuer-override
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-tls-issuer-override
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-tls-issuer-override
   finalizers: []
 spec:
-  tls: []
+  tls:
+  - hosts:
+    - m3gt6a6nipvljp4l4dixj4jhmge5bii5.svc.test.example.com
+    - www.example.com
+    - v3-data-examples-tls-issuer-override.svc.test.example.com
+    secretName: v3-data-examples-tls-issuer-override-ingress-tls
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: www.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-tls-issuer-override
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific
+  - host: v3-data-examples-tls-issuer-override.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-tls-issuer-override
+            port:
+              number: 80
+        path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_networkingv1_override2.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/tls_issuer_networkingv1_override2.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,39 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    fiaas/expose: "true"
+    certmanager.k8s.io/issuer: "someissuer"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-tls-issuer-override
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+  name: v3-data-examples-tls-issuer-override-1
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-tls-issuer-override
   finalizers: []
 spec:
-  tls: []
+  tls:
+  - hosts:
+    - use-issuer.example.com
+    secretName: v3-data-examples-tls-issuer-override-1-ingress-tls
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: use-issuer.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-tls-issuer-override
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v2minimal-networkingv1-ingress.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -37,6 +37,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: data-v2minimal
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-networkingv1-ingress.yml
@@ -1,3 +1,4 @@
+
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,32 +12,51 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    fiaas/expose: "false"
+    e: f
+    fiaas/expose: "true"
+    g: h
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-full
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+    i: j
+    k: l
+    global/label: "true"
+    ingress/label: "true"
+  name: v3-data-examples-full
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-full
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: www.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
-        path: /
+          service:
+            name: v3-data-examples-full
+            port:
+              number: 1337
+        path: /a
+        pathType: ImplementationSpecific
+  - host: v3-data-examples-full.svc.test.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: v3-data-examples-full
+            port:
+              number: 1337
+        path: /a
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-networkingv1-ingress.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3minimal-networkingv1-ingress.yml
@@ -11,32 +11,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
     fiaas/expose: "false"
   labels:
-    app: data-v2minimal
+    app: v3-data-examples-v3minimal
     fiaas/deployed_by: ""
     fiaas/deployment_id: DEPLOYMENT_ID
     fiaas/version: VERSION
-  name: data-v2minimal
+    global/label: "true"
+    ingress/label: "true"
+  name: v3-data-examples-v3minimal
   namespace: default
   ownerReferences:
     - apiVersion: fiaas.schibsted.io/v1
       blockOwnerDeletion: true
       controller: true
       kind: Application
-      name: data-v2minimal
+      name: v3-data-examples-v3minimal
   finalizers: []
 spec:
   tls: []
   rules:
-  - host: data-v2minimal.svc.test.example.com
+  - host: v3-data-examples-v3minimal.svc.test.example.com
     http:
       paths:
       - backend:
-          serviceName: data-v2minimal
-          servicePort: "80"
+          service:
+            name: v3-data-examples-v3minimal
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific

--- a/tests/fiaas_deploy_daemon/utils.py
+++ b/tests/fiaas_deploy_daemon/utils.py
@@ -102,6 +102,10 @@ def skip_if_crd_not_supported(k8s_version):
         pytest.skip("CRD not supported in version %s of kubernetes, skipping this test" % k8s_version)
 
 
+def use_networkingv1_ingress(k8s_version):
+    return StrictVersion(k8s_version[1:]) >= StrictVersion("1.21.0")
+
+
 def read_yml(yml_path):
     with open(yml_path, 'r') as fobj:
         yml = yaml.safe_load(fobj)


### PR DESCRIPTION
With Kubernetes 1.22 on the way and the removal of beta api's for ingresses impending, it's time to implement the possibility for using stable ingresses in fiaas. The models for these have already been implemented in the k8s library. This PR should, when finished, provide a feature flag to operators which tells FDD to use the stable ingresses. Otherwise beta ingresses will be used.