### PR TITLE
Use fiaas/k8s built-in in-cluster configuration to support time-based/refreshing service account tokens (BoundServiceAccountTokenVolume)

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -98,15 +98,28 @@ class Main(object):
         self._webapp.run("0.0.0.0", self._config.port)
 
 
-def init_k8s_client(config):
-    k8s_config.api_server = config.api_server
-    k8s_config.api_token = config.api_token
-    if config.api_cert:
-        k8s_config.verify_ssl = config.api_cert
-    else:
-        k8s_config.verify_ssl = not config.debug
+def init_k8s_client(config, log):
     if config.client_cert:
         k8s_config.cert = (config.client_cert, config.client_key)
+
+    if config.api_token:
+        k8s_config.api_token = config.api_token
+    else:
+        # use default in-cluster config if api_token is not explicitly set
+        try:
+            # sets api_token_source and verify_ssl
+            k8s_config.use_in_cluster_config()
+        except IOError as e:
+            if not config.client_cert:
+                log.warn("No apiserver auth config was specified, and in-cluster config could not be set up: " + str(e))
+
+    # if api_cert or debug is explicitly set, override in-cluster config setting (if used)
+    if config.api_cert:
+        k8s_config.verify_ssl = config.api_cert
+    elif config.debug:
+        k8s_config.verify_ssl = not config.debug
+
+    k8s_config.api_server = config.api_server
     k8s_config.debug = config.debug
 
 
@@ -182,8 +195,8 @@ def expose_fdd_version(config):
 def main():
     cfg = Configuration()
     init_logging(cfg)
-    init_k8s_client(cfg)
     log = logging.getLogger(__name__)
+    init_k8s_client(cfg, log)
     warn_if_env_variable_config(cfg, log)
     expose_fdd_version(cfg)
     signal.signal(signal.SIGUSR2, thread_dump_logger(log))

--- a/fiaas_deploy_daemon/bootstrap/__init__.py
+++ b/fiaas_deploy_daemon/bootstrap/__init__.py
@@ -71,8 +71,8 @@ class Main(object):
 def main():
     cfg = Configuration()
     init_logging(cfg)
-    init_k8s_client(cfg)
     log = logging.getLogger(__name__)
+    init_k8s_client(cfg, log)
     try:
         log.info("fiaas-deploy-daemon starting with configuration {!r}".format(cfg))
         binding_specs = [

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -151,7 +151,6 @@ class Configuration(Namespace):
         self.image = ""
         self.version = ""
         self._parse_args(args)
-        self._resolve_api_config()
         self._resolve_env()
         self.namespace = self._resolve_namespace()
 
@@ -274,13 +273,6 @@ class Configuration(Namespace):
         self.secret_init_containers = {provider.key: provider.value for provider in self.secret_init_containers}
         self.tls_certificate_issuer_type_overrides = {issuer_type.key: issuer_type.value
                                                       for issuer_type in self.tls_certificate_issuer_type_overrides}
-
-    def _resolve_api_config(self):
-        token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        if os.path.exists(token_file):
-            with open(token_file) as fobj:
-                self.api_token = fobj.read().strip()
-            self.api_cert = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
     def _resolve_env(self):
         image = os.getenv("IMAGE")

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -288,14 +288,6 @@ class Configuration(Namespace):
             self.version = version
 
     @staticmethod
-    def _resolve_required_variable(key, service_name):
-        value = os.getenv(key)
-        if not value:
-            raise InvalidConfigurationException(
-                "{} is not set in environment, unable to resolve service {}".format(key, service_name))
-        return value
-
-    @staticmethod
     def _resolve_namespace():
         namespace_file_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
         namespace_env_variable = "NAMESPACE"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ GENERIC_REQ = [
     "decorator < 5.0.0",  # 5.0.0 and later drops py2 support (transitive dep from pinject)
     "six == 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.17.0",
+    "k8s == 0.20.0",
     "monotonic == 1.5",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",


### PR DESCRIPTION
This needs https://github.com/fiaas/k8s/pull/104 before merging.

This is mainly to support regularly re-reading the service account token
from file when in-cluster configuration is used.

This also introduces the option to explicitly override the default
in-cluster configuration by setting the api-token or api-cert config
flags. Currently these flags are ignored if
`/var/run/secrets/kubernetes.io/serviceaccount/token` exists, which
could be surprising behaviour.

If neither api-token or client-cert is set, and in-cluster configuration
can not be set up (service account token can not be read), log a warning
indicating potentially missing apiserver authentication configuration.