### PR TITLE
Forward $DOCKER_HOST environment variable when running tests in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ setenv =
     PYTHONHASHSEED = 0
 passenv =
     HOME
+    DOCKER_HOST
 commands=
     codestyle: flake8 '--format=%(path)-50s: [%(code)s] %(text)s [line:%(row)d, column:%(col)d]' {posargs}
     test: py.test -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report html --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --html=build/reports/tests.html --disable-warnings {posargs}


### PR DESCRIPTION
This enables running e2e tests with docker engine running in a VM (or elsewhere), which is useful for example when using something else than Docker.app to run docker on macOS.