### PR TITLE
Keep Datadog sidecar alive while main container is too

### DIFF
--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -87,6 +87,9 @@ Used to implement an init-container that will get secrets from some backend and 
 
 Used when collecting metrics to DataDog. See [Metrics](#metrics).
 
+### datadog-activate-sleep
+
+Flag to set a Lifecycle in the datadog container with a preStop that will execute a sleep of the pre-stop-delay of the main container plus 5 seconds.  
 
 ### pre-stop-delay
 

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -194,6 +194,9 @@ class Configuration(Namespace):
         datadog_global_tags_parser.add_argument("--datadog-global-tags", default=[],
                                                 help="Various non-essential global tags to send to datadog for all applications",
                                                 action="append", type=KeyValue, dest="datadog_global_tags")
+        parser.add_argument("--datadog-activate-sleep",
+                            help="Flag to activate the sleep in datadog when a pre-stop-delay is in the main container",
+                            action="store_true", default=False)
         parser.add_argument("--pre-stop-delay", type=int,
                             help="Add a pre-stop hook that sleeps for this amount of seconds  (default: %(default)s)",
                             default=0)

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -25,6 +25,7 @@ class DataDog(object):
         self._datadog_container_image = config.datadog_container_image
         self._datadog_container_memory = config.datadog_container_memory
         self._datadog_global_tags = config.datadog_global_tags
+        self._datadog_activate_sleep = config.datadog_activate_sleep
 
     def apply(self, deployment, app_spec, besteffort_qos_is_required, pre_stop_delay):
         if app_spec.datadog.enabled:
@@ -60,7 +61,7 @@ class DataDog(object):
             image_pull_policy = "Always"
 
         lifecycle = None
-        if pre_stop_delay > 0:
+        if pre_stop_delay > 0 and self._datadog_activate_sleep:
             lifecycle = Lifecycle(preStop=Handler(_exec=ExecAction(command=["sleep", str(pre_stop_delay)])))
 
         return Container(

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -14,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from k8s.models.pod import ResourceRequirements, Container, EnvVar, EnvVarSource, SecretKeySelector
+from k8s.models.pod import ResourceRequirements, Container, EnvVar, EnvVarSource, ExecAction, Handler, Lifecycle, \
+    SecretKeySelector
 
 
 class DataDog(object):
@@ -25,18 +26,18 @@ class DataDog(object):
         self._datadog_container_memory = config.datadog_container_memory
         self._datadog_global_tags = config.datadog_global_tags
 
-    def apply(self, deployment, app_spec, besteffort_qos_is_required):
+    def apply(self, deployment, app_spec, besteffort_qos_is_required, pre_stop_delay):
         if app_spec.datadog.enabled:
             containers = deployment.spec.template.spec.containers
             main_container = containers[0]
-            containers.append(self._create_datadog_container(app_spec, besteffort_qos_is_required))
+            containers.append(self._create_datadog_container(app_spec, besteffort_qos_is_required, pre_stop_delay))
             # TODO: Bug in k8s library allows us to mutate the default value here, so we need to take a copy
             env = list(main_container.env)
             env.extend(self._get_env_vars())
             env.sort(key=lambda x: x.name)
             main_container.env = env
 
-    def _create_datadog_container(self, app_spec, besteffort_qos_is_required):
+    def _create_datadog_container(self, app_spec, besteffort_qos_is_required, pre_stop_delay):
         if besteffort_qos_is_required:
             resource_requirements = ResourceRequirements()
         else:
@@ -58,6 +59,10 @@ class DataDog(object):
         if ":" not in self._datadog_container_image or ":latest" in self._datadog_container_image:
             image_pull_policy = "Always"
 
+        lifecycle = None
+        if pre_stop_delay > 0:
+            lifecycle = Lifecycle(preStop=Handler(_exec=ExecAction(command=["sleep", str(pre_stop_delay)])))
+
         return Container(
             name=self.DATADOG_CONTAINER_NAME,
             image=self._datadog_container_image,
@@ -71,6 +76,7 @@ class DataDog(object):
                 EnvVar(name="DD_EXPVAR_PORT", value="42622"),
                 EnvVar(name="DD_CMD_PORT", value="42623"),
             ],
+            lifecycle=lifecycle,
             resources=resource_requirements
         )
 

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -42,15 +42,16 @@ class DeploymentDeployer(object):
         self._secrets = deployment_secrets
         self._owner_references = owner_references
         self._extension_hook = extension_hook
+        self._pre_stop_delay = config.pre_stop_delay
         self._legacy_fiaas_env = _build_fiaas_env(config)
         self._global_env = _build_global_env(config.global_env)
         self._lifecycle = None
         self._grace_period = self.MINIMUM_GRACE_PERIOD
         self._use_in_memory_emptydirs = config.use_in_memory_emptydirs
-        if config.pre_stop_delay > 0:
+        if self._pre_stop_delay > 0:
             self._lifecycle = Lifecycle(preStop=Handler(
-                _exec=ExecAction(command=["sleep", str(config.pre_stop_delay)])))
-            self._grace_period += config.pre_stop_delay
+                _exec=ExecAction(command=["sleep", str(self._pre_stop_delay)])))
+            self._grace_period += self._pre_stop_delay
         self._max_surge = config.deployment_max_surge
         self._max_unavailable = config.deployment_max_unavailable
         self._disable_deprecated_managed_env_vars = config.disable_deprecated_managed_env_vars
@@ -121,7 +122,7 @@ class DeploymentDeployer(object):
                               strategy=deployment_strategy)
 
         deployment = Deployment.get_or_create(metadata=metadata, spec=spec)
-        self._datadog.apply(deployment, app_spec, besteffort_qos_is_required)
+        self._datadog.apply(deployment, app_spec, besteffort_qos_is_required, self._pre_stop_delay + 5)
         self._prometheus.apply(deployment, app_spec)
         self._secrets.apply(deployment, app_spec)
         self._owner_references.apply(deployment, app_spec)

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -35,6 +35,7 @@ LOG = logging.getLogger(__name__)
 
 class DeploymentDeployer(object):
     MINIMUM_GRACE_PERIOD = 30
+    DATADOG_PRE_STOP_DELAY = 5
 
     def __init__(self, config, datadog, prometheus, deployment_secrets, owner_references, extension_hook):
         self._datadog = datadog
@@ -122,7 +123,7 @@ class DeploymentDeployer(object):
                               strategy=deployment_strategy)
 
         deployment = Deployment.get_or_create(metadata=metadata, spec=spec)
-        self._datadog.apply(deployment, app_spec, besteffort_qos_is_required, self._pre_stop_delay + 5)
+        self._datadog.apply(deployment, app_spec, besteffort_qos_is_required, self._pre_stop_delay + self.DATADOG_PRE_STOP_DELAY)
         self._prometheus.apply(deployment, app_spec)
         self._secrets.apply(deployment, app_spec)
         self._owner_references.apply(deployment, app_spec)

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ TESTS_REQ = [
 
 DEV_TOOLS = [
     "tox==3.14.5",
-    "virtualenv==20.4.2"
+    "virtualenv==20.13.0"
 ]
 
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_datadog.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_datadog.py
@@ -55,14 +55,14 @@ class TestDataDog(object):
 
     def test_noop_when_not_enabled(self, datadog, app_spec, deployment):
         expected = deepcopy(deployment)
-        datadog.apply(deployment, app_spec, False)
+        datadog.apply(deployment, app_spec, False, 0)
         assert expected == deployment
 
     @pytest.mark.parametrize("best_effort_required", (False, True))
     def test_adds_env_when_enabled(self, datadog, app_spec, deployment, best_effort_required):
         datadog_spec = app_spec.datadog._replace(enabled=True, tags={})
         app_spec = app_spec._replace(datadog=datadog_spec)
-        datadog.apply(deployment, app_spec, best_effort_required)
+        datadog.apply(deployment, app_spec, best_effort_required, 0)
         expected = [
             {"name": "DUMMY", "value": "CANARY"},
             {"name": "STATSD_HOST", "value": "localhost"},
@@ -73,7 +73,7 @@ class TestDataDog(object):
     def test_adds_global_tags_when_enabled(self, datadog, app_spec, deployment, best_effort_required):
         datadog_spec = app_spec.datadog._replace(enabled=True, tags={})
         app_spec = app_spec._replace(datadog=datadog_spec)
-        datadog.apply(deployment, app_spec, best_effort_required)
+        datadog.apply(deployment, app_spec, best_effort_required, 0)
         expected = {
                     'name': 'DD_TAGS',
                     'value': "app:{},k8s_namespace:{},tag:test".format(app_spec.name, app_spec.namespace)
@@ -92,7 +92,7 @@ class TestDataDog(object):
         app_spec = app_spec._replace(datadog=datadog_spec)
         app_spec = app_spec._replace(datadog=datadog_spec)
         app_spec = app_spec._replace(name=name, namespace=namespace)
-        datadog.apply(deployment, app_spec, best_effort_required)
+        datadog.apply(deployment, app_spec, best_effort_required, 0)
         expected = {
             'name': DataDog.DATADOG_CONTAINER_NAME,
             'image': CONTAINER_IMAGE,
@@ -130,8 +130,29 @@ class TestDataDog(object):
         )
         app_spec = app_spec._replace(datadog=datadog_spec)
 
-        datadog.apply(deployment, app_spec, False)
+        datadog.apply(deployment, app_spec, False, 0)
 
         actual = deployment.as_dict()["spec"]["template"]["spec"]["containers"][-1]
         assert actual['image'] == CONTAINER_IMAGE_LATEST
         assert actual['imagePullPolicy'] == "Always"
+
+    def test_adds_lifecycle_when_pre_stop_delay_is_set(self, config, app_spec, deployment):
+        config.datadog_container_image = CONTAINER_IMAGE_LATEST
+        datadog = DataDog(config)
+
+        datadog_spec = app_spec.datadog._replace(
+            enabled=True
+        )
+        app_spec = app_spec._replace(datadog=datadog_spec)
+
+        datadog.apply(deployment, app_spec, False, 5)
+
+        expected = {
+            'preStop': {
+                'exec': {
+                    'command': ['sleep', '5']
+                }
+            }
+        }
+
+        assert expected == deployment.as_dict()["spec"]["template"]["spec"]["containers"][-1]["lifecycle"]

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -210,7 +210,7 @@ class TestDeploymentDeployer(object):
         deployer.deploy(app_spec, SELECTOR, LABELS, False)
 
         pytest.helpers.assert_any_call(post, DEPLOYMENTS_URI, expected_deployment)
-        datadog.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec, False)
+        datadog.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec, False, 6)
         prometheus.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
         secrets.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
         owner_references.apply.assert_called_with(TypeMatcher(Deployment), app_spec)
@@ -236,7 +236,7 @@ class TestDeploymentDeployer(object):
         deployer.deploy(app_spec, SELECTOR, LABELS, False)
 
         pytest.helpers.assert_any_call(put, DEPLOYMENTS_URI + "testapp", expected_deployment)
-        datadog.apply.assert_called_once_with(DeploymentMatcher(), app_spec, False)
+        datadog.apply.assert_called_once_with(DeploymentMatcher(), app_spec, False, 6)
         prometheus.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
         secrets.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
         extension_hook.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
@@ -349,7 +349,7 @@ class TestDeploymentDeployer(object):
 
         pytest.helpers.assert_no_calls(post)
         pytest.helpers.assert_any_call(put, DEPLOYMENTS_URI + "testapp", expected_deployment)
-        datadog.apply.assert_called_once_with(DeploymentMatcher(), app_spec, False)
+        datadog.apply.assert_called_once_with(DeploymentMatcher(), app_spec, False, 6)
         prometheus.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
         secrets.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
         extension_hook.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
@@ -211,10 +211,6 @@ spec:
         image: DATADOG_IMAGE:tag
         volumeMounts: []
         imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            exec:
-              command: [sleep, '5']
         name: fiaas-datadog-container
         ports: []
         resources:

--- a/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
+++ b/tests/fiaas_deploy_daemon/e2e_expected/v3full-deployment.yml
@@ -211,6 +211,10 @@ spec:
         image: DATADOG_IMAGE:tag
         volumeMounts: []
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command: [sleep, '5']
         name: fiaas-datadog-container
         ports: []
         resources:


### PR DESCRIPTION
While the main application is given a grace period to terminate, and has
the termination signal delayed using a preStop action, the datadog
sidecar would be immediately terminated. This would lead to a loss of
metrics from before the pod received the termination signal, and to the
point it actually exited.

~With this change, the full grace period for the main container is
extended to the sidecar, allowing the main container to continue
producing metrics through its very end.~

With this change, the application's pre-stop delay is extended to the
sidecar, with an additional 5 seconds to give the main container a
chance to exit gracefully while metrics are still being collected. No
guarantees, regarding metrics collection, are offered to applications
that take longer to exit.