### PR TITLE
Upgrade monotonic; fix scheduler logic on Apple arm64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ GENERIC_REQ = [
     "six == 1.12.0",
     "dnspython == 1.16.0",
     "k8s == 0.20.0",
-    "monotonic == 1.5",
+    "monotonic == 1.6",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",
     "backoff == 1.8.0",


### PR DESCRIPTION
Upgrade monotonic to 1.6, which includes a fix for monotonic.monotonic
[not correctly returning fractional seconds on Apple arm64](https://github.com/atdt/monotonic/releases/tag/1.6). This fixes
an issue where when running fiaas-deploy-daemon on Apple arm64, the
Scheduler thread would not execute ReadyChecks when it was supposed
to (never?). In practice, this fixes an issue with running the bootstrap
e2e tests on Apple silicon, as these tests verify that deployments
complete successfully (i.e. waits for ReadyCheck).