### PR TITLE
Add deactivate-crd-creation config flag

### DIFF
--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -187,6 +187,10 @@ As we decided to treat the 404 as a valid response, we have no way to differenti
 
 Used to create a serviceaccount for each deployed application, using the application name. If there are imagePullSecrets set on the 'default' service account, these are propagated the per-application service accounts. If a service account with the same name as the application already exists, the application will run under that service account but FIAAS will not overwrite/manage the service account.
 
+### deactivate-crd-creation
+
+Used to deactivate the crd creation in the Crd Watcher.
+
 Deploying an application
 ------------------------
 

--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -187,9 +187,10 @@ As we decided to treat the 404 as a valid response, we have no way to differenti
 
 Used to create a serviceaccount for each deployed application, using the application name. If there are imagePullSecrets set on the 'default' service account, these are propagated the per-application service accounts. If a service account with the same name as the application already exists, the application will run under that service account but FIAAS will not overwrite/manage the service account.
 
-### deactivate-crd-creation
+### disable-crd-creation
 
-Used to deactivate the crd creation in the Crd Watcher.
+By default fiaas-deploy-daemon updates the Application and ApplicationStatus CRDs on startup. CRDs are cluster scoped, so it is only necessary for one fiaas-deploy-daemon instance in a cluster to manage the CRDs. This flag can be used to disable updating of the CRDs per fiaas-deploy-daemon instance when not needed.
+It is a good idea to keep the flag enabled on at least one fiaas-deploy-daemon instance in a cluster, otherwise you have to manually ensure that the Application and ApplicationStatus CRDs are present and up to date in the cluster.
 
 Deploying an application
 ------------------------

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -228,6 +228,9 @@ class Configuration(Namespace):
         parser.add_argument("--use-apiextensionsv1-crd",
                             help="Use apiextensions/v1 CustomResourceDefinition instead of apiextensions/v1beta1",
                             action="store_true", default=False)
+        parser.add_argument("--deactivate-crd-creation",
+                            help="Crd Watcher will skip the crd creation and it will go directly to watch the events",
+                            action="store_true", default=False)
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)
         usage_reporting_parser.add_argument("--usage-reporting-cluster-name",
                                             help="Name of the cluster where the fiaas-deploy-daemon instance resides")

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -228,7 +228,7 @@ class Configuration(Namespace):
         parser.add_argument("--use-apiextensionsv1-crd",
                             help="Use apiextensions/v1 CustomResourceDefinition instead of apiextensions/v1beta1",
                             action="store_true", default=False)
-        parser.add_argument("--deactivate-crd-creation",
+        parser.add_argument("--disable-crd-creation",
                             help="Crd Watcher will skip the crd creation and it will go directly to watch the events",
                             action="store_true", default=False)
         usage_reporting_parser = parser.add_argument_group("Usage Reporting", USAGE_REPORTING_LONG_HELP)

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -43,7 +43,7 @@ class CrdWatcher(DaemonThread):
         self.namespace = config.namespace
         self.enable_deprecated_multi_namespace_support = config.enable_deprecated_multi_namespace_support
         self.crd_resources_syncer = crd_resources_syncer
-        self.deactivate_crd_creation = config.deactivate_crd_creation
+        self.disable_crd_creation = config.disable_crd_creation
 
     def __call__(self):
         while True:
@@ -53,7 +53,7 @@ class CrdWatcher(DaemonThread):
                 self._watch(namespace=self.namespace)
 
     def _watch(self, namespace):
-        if not self.deactivate_crd_creation:
+        if not self.disable_crd_creation:
             self.crd_resources_syncer.update_crd_resources()
         try:
             for event in self._watcher.watch(namespace=namespace):

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -43,6 +43,7 @@ class CrdWatcher(DaemonThread):
         self.namespace = config.namespace
         self.enable_deprecated_multi_namespace_support = config.enable_deprecated_multi_namespace_support
         self.crd_resources_syncer = crd_resources_syncer
+        self.deactivate_crd_creation = config.deactivate_crd_creation
 
     def __call__(self):
         while True:
@@ -52,7 +53,8 @@ class CrdWatcher(DaemonThread):
                 self._watch(namespace=self.namespace)
 
     def _watch(self, namespace):
-        self.crd_resources_syncer.update_crd_resources()
+        if not self.deactivate_crd_creation:
+            self.crd_resources_syncer.update_crd_resources()
         try:
             for event in self._watcher.watch(namespace=namespace):
                 self._handle_watch_event(event)

--- a/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
@@ -99,11 +99,28 @@ class TestWatcher(object):
         crd_watcher._watcher = watcher
         return crd_watcher
 
+    @pytest.fixture
+    def crd_resources_syncer(self):
+        return FakeCrdResourcesSyncer()
+
+    @pytest.fixture
+    def crd_watcher_creation_deactivated(self, spec_factory, deploy_queue, lifecycle, crd_resources_syncer, watcher):
+        config = Configuration([])
+        config.deactivate_crd_creation = True
+        crd_watcher = CrdWatcher(spec_factory, deploy_queue, config, lifecycle, crd_resources_syncer)
+        crd_watcher._watcher = watcher
+        return crd_watcher
+
     @pytest.fixture(autouse=True)
     def status_get(self):
         with mock.patch("fiaas_deploy_daemon.crd.status.FiaasApplicationStatus.get", spec_set=True) as m:
             m.side_effect = NotFound
             yield m
+
+    def test_does_not_update_crd_when_deactivated(self, crd_watcher_creation_deactivated, crd_resources_syncer):
+        with mock.patch.object(crd_resources_syncer, "update_crd_resources") as m:
+            crd_watcher_creation_deactivated._watch(None)
+            assert not m.called
 
     def test_updates_crd_resources_when_watching_it(self, crd_watcher):
         with mock.patch.object(FakeCrdResourcesSyncer, "update_crd_resources", return_value=None) as m:

--- a/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_watcher.py
@@ -104,9 +104,9 @@ class TestWatcher(object):
         return FakeCrdResourcesSyncer()
 
     @pytest.fixture
-    def crd_watcher_creation_deactivated(self, spec_factory, deploy_queue, lifecycle, crd_resources_syncer, watcher):
+    def crd_watcher_creation_disabled(self, spec_factory, deploy_queue, lifecycle, crd_resources_syncer, watcher):
         config = Configuration([])
-        config.deactivate_crd_creation = True
+        config.disable_crd_creation = True
         crd_watcher = CrdWatcher(spec_factory, deploy_queue, config, lifecycle, crd_resources_syncer)
         crd_watcher._watcher = watcher
         return crd_watcher
@@ -117,9 +117,9 @@ class TestWatcher(object):
             m.side_effect = NotFound
             yield m
 
-    def test_does_not_update_crd_when_deactivated(self, crd_watcher_creation_deactivated, crd_resources_syncer):
+    def test_does_not_update_crd_when_disabled(self, crd_watcher_creation_disabled, crd_resources_syncer):
         with mock.patch.object(crd_resources_syncer, "update_crd_resources") as m:
-            crd_watcher_creation_deactivated._watch(None)
+            crd_watcher_creation_disabled._watch(None)
             assert not m.called
 
     def test_updates_crd_resources_when_watching_it(self, crd_watcher):

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -81,7 +81,7 @@ class TestConfig(object):
         "enable_crd_support",
         "enable_deprecated_multi_namespace_support",
         "enable_deprecated_tls_entry_per_host",
-        "deactivate_crd_creation",
+        "disable_crd_creation",
         "datadog_activate_sleep"
     ))
     def test_flags(self, key):

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -81,6 +81,8 @@ class TestConfig(object):
         "enable_crd_support",
         "enable_deprecated_multi_namespace_support",
         "enable_deprecated_tls_entry_per_host",
+        "deactivate_crd_creation",
+        "datadog_activate_sleep"
     ))
     def test_flags(self, key):
         flag = "--{}".format(key.replace("_", "-"))


### PR DESCRIPTION
The new behaviour of the watcher is breaking the fiaas-deploy-daemon in some namespaces of our current architecture. 

We have not the permissions of creating crd in all the namespaces, meaning that fiaas-deploy-daemon crashes and it is not able to start.

This is an implementation to fix the issue #174 