### PR TITLE
add documentation on annotations/labels for serviceaccounts

### DIFF
--- a/docs/v3_spec.md
+++ b/docs/v3_spec.md
@@ -600,6 +600,7 @@ annotations:
   horizontal_pod_autoscaler: {}
   ingress: {}
   service: {}
+  service_account: {}
   pod: {}
 ```
 
@@ -633,6 +634,7 @@ labels:
   horizontal_pod_autoscaler: {}
   ingress: {}
   service: {}
+  service_account: {}
   pod: {}
 ```
 


### PR DESCRIPTION
This adds service_accounts to the list of resource types which may be annotated/labeled via fiaas.yml in the v3 spec documentation.