### PR TITLE
Fix bug with ingress names

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress.py
@@ -114,7 +114,7 @@ class IngressDeployer(object):
         override_issuer_ingresses = {}
         for ingress_item in ingress_items:
             issuer_type = self._get_issuer_type(ingress_item.host)
-            next_name = "{}-{}".format(app_spec.name, len(ingresses))
+            next_name = "{}-{}".format(app_spec.name, len(ingresses) + len(override_issuer_ingresses))
             if ingress_item.annotations:
                 annotated_ingresses = AnnotatedIngress(name=next_name, ingress_items=[ingress_item],
                                                        annotations=ingress_item.annotations,

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -684,13 +684,20 @@ class TestIngressDeployer(object):
 
             deployer_issuer_overrides.deploy(app_spec, LABELS)
             host_groups = [sorted(call.args[2]) for call in ingress_tls_deployer.apply.call_args_list]
+            ingress_names = [call.kwargs['metadata'].name for call in get_or_create.call_args_list]
             expected_host_groups = [
                 ["ann.foo.example.com"],
                 ["bar.example.com", "other.example.com", "sub.bar.example.com", "testapp.127.0.0.1.xip.io", "testapp.svc.test.example.com"],
                 ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"]
             ]
+            expected_ingress_names = [
+                "testapp",
+                "testapp-1",
+                "testapp-2"
+            ]
             assert ingress_tls_deployer.apply.call_count == 3
             assert expected_host_groups == sorted(host_groups)
+            assert expected_ingress_names == sorted(ingress_names)
 
 
 class TestIngressTLSDeployer(object):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
@@ -426,10 +426,17 @@ class TestIngressDeployer(object):
 
             deployer_issuer_overrides.deploy(app_spec, LABELS)
             host_groups = [sorted(call.args[2]) for call in ingress_tls_deployer.apply.call_args_list]
+            ingress_names = [call.kwargs['metadata'].name for call in get_or_create.call_args_list]
             expected_host_groups = [
                 ["ann.foo.example.com"],
                 ["bar.example.com", "other.example.com", "sub.bar.example.com", "testapp.127.0.0.1.xip.io", "testapp.svc.test.example.com"],
                 ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"]
             ]
+            expected_ingress_names = [
+                "testapp",
+                "testapp-1",
+                "testapp-2"
+            ]
             assert ingress_tls_deployer.apply.call_count == 3
             assert expected_host_groups == sorted(host_groups)
+            assert expected_ingress_names == sorted(ingress_names)


### PR DESCRIPTION
During these days we discovered a bug with the ingresses creation.

When you have an ingress with a host configured with a different issue type than default, and then another one with annotations, the ingress name of both ingresses will be the same, as the `ingresses` variable will not be modified by the `override_issuer_ingresses` dictionary ones, being these ones added at the end.