### PR TITLE
Added check for Ingress certificates readiness

### DIFF
--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -278,6 +278,7 @@ class Configuration(Namespace):
         tls_parser.add_argument("--tls-certificate-issuer-type-overrides", help="Issuers to use for specified domain suffixes",
                                 default=[],
                                 action="append", type=KeyValue, dest="tls_certificate_issuer_type_overrides")
+        tls_parser.add_argument("--tls-certificate-ready", help="Check whether certificates are ready", default=False)
 
         parser.parse_args(args, namespace=self)
         self.global_env = {env_var.key: env_var.value for env_var in self.global_env}

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -278,7 +278,7 @@ class Configuration(Namespace):
         tls_parser.add_argument("--tls-certificate-issuer-type-overrides", help="Issuers to use for specified domain suffixes",
                                 default=[],
                                 action="append", type=KeyValue, dest="tls_certificate_issuer_type_overrides")
-        tls_parser.add_argument("--tls-certificate-ready", help="Check whether certificates are ready", default=False)
+        tls_parser.add_argument("--tls-certificate-ready", help="Check whether certificates are ready", default=False, action="store_true")
 
         parser.parse_args(args, namespace=self)
         self.global_env = {env_var.key: env_var.value for env_var in self.global_env}

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -18,7 +18,7 @@
 import logging
 
 from k8s.client import NotFound
-from k8s.models.custom_resource_definition import CustomResourceDefinition
+from k8s.models.certificate import Certificate
 from k8s.models.deployment import Deployment
 from k8s.models.ingress import Ingress
 from monotonic import monotonic as time_monotonic
@@ -81,7 +81,7 @@ class ReadyCheck(object):
             if ingress.spec.tls:
                 for tls_item in ingress.spec.tls:
                     try:
-                        cert = CustomResourceDefinition.get(tls_item.secretName, ingress.metadata.namespace)
+                        cert = Certificate.get(tls_item.secretName, ingress.metadata.namespace)
                     except NotFound:
                         return False
                     if not self._is_certificate_ready(cert):

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -17,6 +17,8 @@
 
 import logging
 
+from datetime import datetime
+
 from k8s.client import NotFound
 from k8s.models.certificate import Certificate
 from k8s.models.deployment import Deployment
@@ -66,6 +68,8 @@ class ReadyCheck(object):
                 dep.status.observedGeneration >= dep.metadata.generation)
 
     def _is_certificate_ready(self, cert):
+        if cert.status.NotAfter < datetime.utcnow():
+            return False
         for condition in cert.status.conditions:
             if condition.type == "Ready":
                 return condition.status == "True"

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -68,7 +68,7 @@ class ReadyCheck(object):
                 dep.status.observedGeneration >= dep.metadata.generation)
 
     def _is_certificate_ready(self, cert):
-        if cert.status.NotAfter < datetime.utcnow():
+        if cert.status.NotAfter and (cert.status.NotAfter < datetime.utcnow()):
             return False
         for condition in cert.status.conditions:
             if condition.type == "Ready":

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -18,7 +18,9 @@
 import logging
 
 from k8s.client import NotFound
+from k8s.models.custom_resource_definition import CustomResourceDefinition
 from k8s.models.deployment import Deployment
+from k8s.models.ingress import Ingress
 from monotonic import monotonic as time_monotonic
 
 LOG = logging.getLogger(__name__)
@@ -36,6 +38,7 @@ class ReadyCheck(object):
             app_spec.health_checks.readiness.initial_delay_seconds
         )
         self._fail_after = time_monotonic() + self._fail_after_seconds
+        self._should_check_ingress = config.tls_certificate_ready
 
     def __call__(self):
         if self._ready():
@@ -50,7 +53,7 @@ class ReadyCheck(object):
             return False
         return True
 
-    def _ready(self):
+    def _deployment_ready(self):
         try:
             dep = Deployment.get(self._app_spec.name, self._app_spec.namespace)
         except NotFound:
@@ -61,6 +64,35 @@ class ReadyCheck(object):
                 dep.status.replicas == expected_value and
                 dep.status.availableReplicas == expected_value and
                 dep.status.observedGeneration >= dep.metadata.generation)
+
+    def _is_certificate_ready(self, cert):
+        conditions = cert.status.conditions
+        for condition in conditions:
+            if condition.type == "Ready":
+                return condition.status == "True"
+        return False
+
+    def _ingress_ready(self):
+        try:
+            ing_list = Ingress.find(self._app_spec.name, self._app_spec.namespace)
+        except NotFound:
+            return False
+
+        for ingress in ing_list:
+            try:
+                cert = CustomResourceDefinition.get(ingress.spec.tls.secretName, ingress.metadata.namespace)
+            except NotFound:
+                return False
+            if not self._is_certificate_ready(cert):
+                return False
+
+        return True
+
+    def _ready(self):
+        if not self._should_check_ingress:
+            return self._deployment_ready()
+
+        return self._deployment_ready() and self._ingress_ready()
 
     def __eq__(self, other):
         return other._app_spec == self._app_spec and other._bookkeeper == self._bookkeeper \

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ GENERIC_REQ = [
     "decorator < 5.0.0",  # 5.0.0 and later drops py2 support (transitive dep from pinject)
     "six == 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.21.0",
+    "k8s == 0.21.4",
     "monotonic == 1.6",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",
@@ -47,7 +47,7 @@ WEB_REQ = [
 ]
 
 DEPLOY_REQ = [
-    "requests == 2.22.0",
+    "requests == 2.27.1",
     "ipaddress == 1.0.22"  # Required by requests for resolving IP address in SSL cert
 ]
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -199,7 +199,7 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_not_called()
 
     def test_deployment_tls_config_no_tls_extension(self, get, app_spec, bookkeeper, lifecycle,
-                                 lifecycle_subject, config):
+                                                    lifecycle_subject, config):
         config.tls_certificate_ready = True
         self._create_response(get)
         ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -198,6 +198,18 @@ class TestReadyCheck(object):
                 lifecycle.failed.assert_not_called()
                 lifecycle.success.assert_not_called()
 
+    def test_deployment_tls_config_no_tls_extension(self, get, app_spec, bookkeeper, lifecycle,
+                                 lifecycle_subject, config):
+        config.tls_certificate_ready = True
+        self._create_response(get)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+
+        assert ready() is False
+        bookkeeper.success.assert_called_with(app_spec)
+        bookkeeper.failed.assert_not_called()
+        lifecycle.success.assert_called_with(lifecycle_subject)
+        lifecycle.failed.assert_not_called()
+
     @staticmethod
     def _create_response(get, requested=REPLICAS, replicas=REPLICAS, available=REPLICAS, updated=REPLICAS,
                          generation=0, observed_generation=0):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime, timedelta
 import mock
 import pytest
 from monotonic import monotonic as time_monotonic
@@ -127,7 +128,8 @@ class TestReadyCheck(object):
             find.return_value = [ingress]
 
             with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
-                get_crd.return_value = self._mock_certificate(True)
+                expiration_date = datetime.now() + timedelta(days=5)
+                get_crd.return_value = self._mock_certificate(True, expiration_date)
 
                 self._create_response(get, replicas, replicas, replicas, replicas)
                 ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
@@ -137,6 +139,30 @@ class TestReadyCheck(object):
                 bookkeeper.failed.assert_not_called()
                 lifecycle.success.assert_called_with(lifecycle_subject)
                 lifecycle.failed.assert_not_called()
+
+    def test_tls_ingress_ready_expired_certificate(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(Ingress, spec_set=True)
+            ingress.spec.tls = [IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
+                expiration_date = datetime.now() - timedelta(days=5)
+                get_crd.return_value = self._mock_certificate(True, expiration_date)
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready._fail_after = time_monotonic()
+
+                assert ready() is False
+                bookkeeper.failed.assert_called_with(app_spec)
+                bookkeeper.success.assert_not_called()
+                lifecycle.failed.assert_called_with(lifecycle_subject)
+                lifecycle.success.assert_not_called()
 
     def test_tls_ingress_not_ready_timeout(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
         config.tls_certificate_ready = True
@@ -196,12 +222,15 @@ class TestReadyCheck(object):
         lifecycle.failed.assert_not_called()
 
     @staticmethod
-    def _mock_certificate(desired_status=True):
+    def _mock_certificate(desired_status=True, expiration=None):
         cert = mock.create_autospec(Certificate, spec_set=True)
         condition = mock.create_autospec(CertificateCondition)
         condition.type = "Ready"
         condition.status = str(desired_status)
         cert.status.conditions = [condition]
+
+        if expiration:
+            cert.status.NotAfter = expiration
         return cert
 
     @staticmethod

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -23,9 +23,9 @@ from fiaas_deploy_daemon.deployer.bookkeeper import Bookkeeper
 from fiaas_deploy_daemon.config import Configuration
 from fiaas_deploy_daemon.deployer.kubernetes.ready_check import ReadyCheck
 from fiaas_deploy_daemon.lifecycle import Lifecycle, Subject
-from fiaas_deploy_daemon.specs.models import LabelAndAnnotationSpec
+from fiaas_deploy_daemon.specs.models import LabelAndAnnotationSpec, IngressTLSSpec
 from k8s.models.custom_resource_definition import CustomResourceDefinition, CustomResourceDefinitionCondition
-from k8s.models.ingress import Ingress
+from k8s.models.ingress import Ingress, IngressTLS
 
 REPLICAS = 2
 
@@ -116,38 +116,87 @@ class TestReadyCheck(object):
         lifecycle.success.assert_called_with(lifecycle_subject)
         lifecycle.failed.assert_not_called()
 
-    def test_ingress_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
         config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(Ingress, spec_set=True)
+            ingress.spec.tls = [IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.custom_resource_definition.CustomResourceDefinition.get") as get_crd:
+                cert = CustomResourceDefinition()
+                condition = CustomResourceDefinitionCondition()
+                condition.type = "Ready"
+                condition.status = "True"
+                cert.status.conditions = [condition]
+                get_crd.return_value = cert
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+
+                assert ready() is False
+                bookkeeper.success.assert_called_with(app_spec)
+                bookkeeper.failed.assert_not_called()
+                lifecycle.success.assert_called_with(lifecycle_subject)
+                lifecycle.failed.assert_not_called()
+
+    def test_tls_ingress_not_ready_timeout(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
 
         with mock.patch("k8s.models.ingress.Ingress.find") as find:
             ingress = mock.create_autospec(Ingress)
-            ingress.spec.tls.secretName = "secret1"
+            ingress.spec.tls = [IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
             find.return_value = [ingress]
 
-            with mock.patch("k8s.models.custom_resource_definition.CustomResourceDefinition.get") as get:
+            with mock.patch("k8s.models.custom_resource_definition.CustomResourceDefinition.get") as get_crd:
                 cert = mock.create_autospec(CustomResourceDefinition)
                 condition = mock.create_autospec(CustomResourceDefinitionCondition)
                 condition.type = "Ready"
-                condition.status = "True"
+                condition.status = "False"
                 cert.status.conditions = [condition]
+                get_crd.return_value = cert
 
-            self._create_response(get, replicas, replicas, replicas, replicas)
-            ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready._fail_after = time_monotonic()
 
-            assert ready() is True
+                assert ready() is False
+                bookkeeper.failed.assert_called_with(app_spec)
+                bookkeeper.success.assert_not_called()
+                lifecycle.failed.assert_called_with(lifecycle_subject)
+                lifecycle.success.assert_not_called()
 
-    def test_ingress_not_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_not_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
         config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
 
         with mock.patch("k8s.models.ingress.Ingress.find") as find:
-            find.return_value = []
+            ingress = mock.create_autospec(Ingress)
+            ingress.spec.tls = [IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
 
-            self._create_response(get, replicas, replicas, replicas, replicas)
-            ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+            with mock.patch("k8s.models.custom_resource_definition.CustomResourceDefinition.get") as get_crd:
+                cert = mock.create_autospec(CustomResourceDefinition)
+                condition = mock.create_autospec(CustomResourceDefinitionCondition)
+                condition.type = "Ready"
+                condition.status = "False"
+                cert.status.conditions = [condition]
+                get_crd.return_value = cert
 
-            assert ready() is False
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+
+                assert ready() is True
+                bookkeeper.failed.assert_not_called()
+                bookkeeper.success.assert_not_called()
+                lifecycle.failed.assert_not_called()
+                lifecycle.success.assert_not_called()
 
     @staticmethod
     def _create_response(get, requested=REPLICAS, replicas=REPLICAS, available=REPLICAS, updated=REPLICAS,

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -57,6 +57,7 @@ class TestConfig(object):
         assert config.enable_deprecated_multi_namespace_support is False
         assert config.enable_deprecated_tls_entry_per_host is False
         assert config.disable_deprecated_managed_env_vars is False
+        assert config.tls_certificate_ready is False
 
     @pytest.mark.parametrize("arg,key", [
         ("--api-server", "api_server"),


### PR DESCRIPTION
We keep working around the issues we have with how Ingress objects are managed (see #178 and #182 ).

In this case, we want to check if the TLS certificates are ready before we start to send traffic to the related Ingress, avoiding connection errors.

This PR will add a new parameter to check certificates status (default being False to keep backwards compatibility)