### PR TITLE
Fixed typo in field notAfter (lowercase n)

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -68,7 +68,7 @@ class ReadyCheck(object):
                 dep.status.observedGeneration >= dep.metadata.generation)
 
     def _is_certificate_ready(self, cert):
-        if cert.status.NotAfter and (cert.status.NotAfter < datetime.utcnow()):
+        if cert.status.notAfter and (cert.status.notAfter < datetime.utcnow()):
             return False
         for condition in cert.status.conditions:
             if condition.type == "Ready":

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -252,9 +252,9 @@ class TestReadyCheck(object):
         cert.status.conditions = [condition]
 
         if expiration:
-            cert.status.NotAfter = expiration
+            cert.status.notAfter = expiration
         else:
-            cert.status.NotAfter = None
+            cert.status.notAfter = None
 
         return cert
 


### PR DESCRIPTION
After releasing a new option to check certificate readiness, we discovered during the tests there's a small typo 