### PR TITLE
Use port number from values in ingress

### DIFF
--- a/helm/fiaas-deploy-daemon/templates/ingress.yaml
+++ b/helm/fiaas-deploy-daemon/templates/ingress.yaml
@@ -32,10 +32,10 @@ spec:
               service:
                 name: {{ .Values.name }}
                 port:
-                  name: http
+                  number: {{ .Values.service.port }}
             {{- else }}
             backend:
               serviceName: {{ .Values.name }}
-              servicePort: http              
+              servicePort: {{ .Values.service.port }}
             {{- end }}
 {{- end }}


### PR DESCRIPTION
This fixes an issue in some ingress controllers, and also matches what fiaas-deploy-daemon itself does so that the ingress should look the same as when fiaas-deploy-daemon is deployed with skipper/by itself (same as before).