### PR TITLE
mark releases as prerelease for alphas and betas

### DIFF
--- a/bin/make_release
+++ b/bin/make_release
@@ -111,9 +111,16 @@ tag_push_docker_image "$IMAGE_TARBALL" "${IMAGE}:$IMAGE_VERSION" "${IMAGE}:$RELE
 echo "Packaging and publishing helm chart"
 publish_helm_chart "$RELEASE"
 
+# make prerelease if tag includes '-beta...', '-alpha...' etc after the semver
+PRERELEASE=""
+if [[ "$RELEASE" =~ '^v\d+\.\d+\.\d+-\w+' ]]; then
+    PRERELEASE=--prerelease
+fi
+
 echo "Creating Github release $RELEASE"
 gh release create \
    --title "fiaas-deploy-daemon $RELEASE" \
    --notes-file "$RELEASE_NOTES_FILE" \
    --generate-notes \
+   $PRERELEASE \
    "$RELEASE"

--- a/bin/make_release
+++ b/bin/make_release
@@ -113,7 +113,7 @@ publish_helm_chart "$RELEASE"
 
 # make prerelease if tag includes '-beta...', '-alpha...' etc after the semver
 PRERELEASE=""
-if [[ "$RELEASE" =~ '^v\d+\.\d+\.\d+-\w+' ]]; then
+if echo "$RELEASE" | grep -qP '^v\d+\.\d+\.\d+-\w+'; then
     PRERELEASE=--prerelease
 fi
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -26,4 +26,7 @@ git push origin vMAJOR.MINOR.PATCH
 
 For cases that do not fit into the above, refer to the [semver spec](semver2) (and consider updating this documentation).
 
+### Prereleases
+If the version is alpha or beta, for example `v0.0.1-alpha.2`, the CI should automatically make the release into a prerelease. All that is required for this to occur is that there is some text after the version `v0.0.1`.
+
 [semver2]: https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
This PR is meant to remove the manual step of marking an alpha/beta release as prerelease in Github. If there comes a hyphen and string after the semantic version in the version tag, CI will create the release as a prerelease.