### PR TITLE
Fix ingress created by fiaas-deploy-daemon helm chart when tls is enabled

### DIFF
--- a/helm/fiaas-deploy-daemon/templates/ingress.yaml
+++ b/helm/fiaas-deploy-daemon/templates/ingress.yaml
@@ -18,7 +18,8 @@ metadata:
 spec:
 {{- if .Values.ingress.tls.enabled }}
   tls:
-    - hosts: {{ .Values.ingress.host | quote }}
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
       secretName: {{ .Values.ingress.tls.secretName }}
 {{- end }}
   rules:


### PR DESCRIPTION
The ingress template created an invalid resource when `ingress.tls.enabled` value was set to `true`, because `.spec.tls.hosts` in the ingress resource was used as a string (the hostname) when should be an array containing the hostname as an item. This should fix the issue