### PR TITLE
Fix versions of ingresses in ready_check method

### DIFF
--- a/fiaas_deploy_daemon/deployer/deploy.py
+++ b/fiaas_deploy_daemon/deployer/deploy.py
@@ -32,13 +32,14 @@ class Deployer(DaemonThread):
     Mainly focused on bookkeeping, and leaving the hard work to the framework-adapter.
     """
 
-    def __init__(self, deploy_queue, bookkeeper, adapter, scheduler, lifecycle, config):
+    def __init__(self, deploy_queue, bookkeeper, adapter, scheduler, lifecycle, ingress_adapter, config):
         super(Deployer, self).__init__()
         self._queue = _make_gen(deploy_queue.get)
         self._bookkeeper = bookkeeper
         self._adapter = adapter
         self._scheduler = scheduler
         self._lifecycle = lifecycle
+        self._ingress_adapter = ingress_adapter
         self._config = config
 
     def __call__(self):
@@ -59,7 +60,7 @@ class Deployer(DaemonThread):
                 self._adapter.deploy(app_spec)
             if app_spec.name != "fiaas-deploy-daemon":
                 self._scheduler.add(ReadyCheck(app_spec, self._bookkeeper, self._lifecycle, lifecycle_subject,
-                                               self._config))
+                                               self._ingress_adapter, self._config))
             else:
                 self._lifecycle.success(lifecycle_subject)
                 self._bookkeeper.success(app_spec)

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_networkingv1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_networkingv1.py
@@ -78,6 +78,9 @@ class NetworkingV1IngressAdapter(object):
         except NotFound:
             pass
 
+    def find(self, name, namespace):
+        return Ingress.find(name, namespace)
+
     def _make_http_ingress_rule_value(self, app_spec, pathmappings):
         http_ingress_paths = [
             HTTPIngressPath(

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
@@ -77,6 +77,9 @@ class V1Beta1IngressAdapter(object):
         except NotFound:
             pass
 
+    def find(self, name, namespace):
+        return Ingress.find(name, namespace)
+
     def _make_http_ingress_rule_value(self, app_spec, pathmappings):
         http_ingress_paths = [
             HTTPIngressPath(path=pm.path, backend=IngressBackend(serviceName=app_spec.name, servicePort=pm.port))

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -20,13 +20,19 @@ import mock
 import pytest
 from monotonic import monotonic as time_monotonic
 
+from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.deployer.bookkeeper import Bookkeeper
+from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressTLSDeployer
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_networkingv1 import NetworkingV1IngressAdapter
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_v1beta1 import V1Beta1IngressAdapter
+from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
 from fiaas_deploy_daemon.config import Configuration
 from fiaas_deploy_daemon.deployer.kubernetes.ready_check import ReadyCheck
 from fiaas_deploy_daemon.lifecycle import Lifecycle, Subject
 from fiaas_deploy_daemon.specs.models import LabelAndAnnotationSpec, IngressTLSSpec
 from k8s.models.certificate import Certificate, CertificateCondition
 from k8s.models.ingress import Ingress, IngressTLS
+from k8s.models.networking_v1_ingress import Ingress as V1Ingress, IngressTLS as V1IngressTLS
 
 REPLICAS = 2
 
@@ -49,14 +55,34 @@ class TestReadyCheck(object):
     def config(self):
         return Configuration([])
 
+    @pytest.fixture
+    def ingress_tls_deployer(self):
+        return mock.create_autospec(IngressTLSDeployer, spec_set=True)
+
+    @pytest.fixture
+    def owner_references(self):
+        return mock.create_autospec(OwnerReferences, spec_set=True)
+
+    @pytest.fixture
+    def extension_hook(self):
+        return mock.create_autospec(ExtensionHookCaller, spec_set=True)
+
+    @pytest.fixture
+    def ingress_adapter(self, ingress_tls_deployer, owner_references, extension_hook):
+        return V1Beta1IngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
+
+    @pytest.fixture
+    def ingress_v1_adapter(self, ingress_tls_deployer, owner_references, extension_hook):
+        return NetworkingV1IngressAdapter(ingress_tls_deployer, owner_references, extension_hook)
+
     @pytest.mark.parametrize("generation,observed_generation", (
             (0, 0),
             (0, 1)
     ))
     def test_deployment_complete(self, get, app_spec, bookkeeper, generation, observed_generation, lifecycle,
-                                 lifecycle_subject, config):
+                                 lifecycle_subject, ingress_adapter, config):
         self._create_response(get, generation=generation, observed_generation=observed_generation)
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
         assert ready() is False
         bookkeeper.success.assert_called_with(app_spec)
@@ -73,9 +99,10 @@ class TestReadyCheck(object):
             (2, 2, 2, 2, 1, 0),
     ))
     def test_deployment_incomplete(self, get, app_spec, bookkeeper, requested, replicas, available, updated,
-                                   generation, observed_generation, lifecycle, lifecycle_subject, config):
+                                   generation, observed_generation, lifecycle, lifecycle_subject, ingress_adapter,
+                                   config):
         self._create_response(get, requested, replicas, available, updated, generation, observed_generation)
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
         assert ready() is True
         bookkeeper.success.assert_not_called()
@@ -91,13 +118,13 @@ class TestReadyCheck(object):
             (2, 1, 1, 1, {"fiaas/source-repository": "xyz"}, "xyz"),
     ))
     def test_deployment_failed(self, get, app_spec, bookkeeper, requested, replicas, available, updated,
-                               lifecycle, lifecycle_subject, annotations, repository, config):
+                               lifecycle, lifecycle_subject, annotations, repository, ingress_adapter, config):
         if annotations:
             app_spec = app_spec._replace(annotations=LabelAndAnnotationSpec(*[annotations] * 7))
 
         self._create_response(get, requested, replicas, available, updated)
 
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
         ready._fail_after = time_monotonic()
 
         assert ready() is False
@@ -106,10 +133,11 @@ class TestReadyCheck(object):
         lifecycle.success.assert_not_called()
         lifecycle.failed.assert_called_with(lifecycle_subject)
 
-    def test_deployment_complete_deactivated(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_deployment_complete_deactivated(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                             ingress_adapter, config):
 
         self._create_response_zero_replicas(get)
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
         assert ready() is False
         bookkeeper.success.assert_called_with(app_spec)
@@ -117,7 +145,8 @@ class TestReadyCheck(object):
         lifecycle.success.assert_called_with(lifecycle_subject)
         lifecycle.failed.assert_not_called()
 
-    def test_tls_ingress_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter,
+                               config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -132,7 +161,7 @@ class TestReadyCheck(object):
                 get_crd.return_value = self._mock_certificate(True, expiration_date)
 
                 self._create_response(get, replicas, replicas, replicas, replicas)
-                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
                 assert ready() is False
                 bookkeeper.success.assert_called_with(app_spec)
@@ -140,7 +169,8 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_called_with(lifecycle_subject)
                 lifecycle.failed.assert_not_called()
 
-    def test_tls_ingress_ready_null_notafter(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_ready_null_notafter(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                             ingress_adapter, config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -154,7 +184,7 @@ class TestReadyCheck(object):
                 get_crd.return_value = self._mock_certificate(True)
 
                 self._create_response(get, replicas, replicas, replicas, replicas)
-                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
                 assert ready() is False
                 bookkeeper.success.assert_called_with(app_spec)
@@ -162,7 +192,8 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_called_with(lifecycle_subject)
                 lifecycle.failed.assert_not_called()
 
-    def test_tls_ingress_ready_expired_certificate(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_ready_expired_certificate(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                                   ingress_adapter, config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -177,7 +208,7 @@ class TestReadyCheck(object):
                 get_crd.return_value = self._mock_certificate(True, expiration_date)
 
                 self._create_response(get, replicas, replicas, replicas, replicas)
-                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
                 ready._fail_after = time_monotonic()
 
                 assert ready() is False
@@ -186,7 +217,8 @@ class TestReadyCheck(object):
                 lifecycle.failed.assert_called_with(lifecycle_subject)
                 lifecycle.success.assert_not_called()
 
-    def test_tls_ingress_not_ready_timeout(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_not_ready_timeout(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                           ingress_adapter, config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -200,7 +232,7 @@ class TestReadyCheck(object):
                 get_crd.return_value = self._mock_certificate(False)
 
                 self._create_response(get, replicas, replicas, replicas, replicas)
-                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
                 ready._fail_after = time_monotonic()
 
                 assert ready() is False
@@ -209,7 +241,8 @@ class TestReadyCheck(object):
                 lifecycle.failed.assert_called_with(lifecycle_subject)
                 lifecycle.success.assert_not_called()
 
-    def test_tls_ingress_not_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, config):
+    def test_tls_ingress_not_ready(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter,
+                                   config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -223,7 +256,7 @@ class TestReadyCheck(object):
                 get_crd.return_value = self._mock_certificate(False)
 
                 self._create_response(get, replicas, replicas, replicas, replicas)
-                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
                 assert ready() is True
                 bookkeeper.failed.assert_not_called()
@@ -232,10 +265,141 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_not_called()
 
     def test_deployment_tls_config_no_tls_extension(self, get, app_spec, bookkeeper, lifecycle,
-                                                    lifecycle_subject, config):
+                                                    lifecycle_subject, ingress_adapter, config):
         config.tls_certificate_ready = True
         self._create_response(get)
-        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, config)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
+
+        assert ready() is False
+        bookkeeper.success.assert_called_with(app_spec)
+        bookkeeper.failed.assert_not_called()
+        lifecycle.success.assert_called_with(lifecycle_subject)
+        lifecycle.failed.assert_not_called()
+
+    def test_tls_ingress_ready_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter,
+                               config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(V1Ingress, spec_set=True)
+            ingress.spec.tls = [V1IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
+                expiration_date = datetime.now() + timedelta(days=5)
+                get_crd.return_value = self._mock_certificate(True, expiration_date)
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)
+
+                assert ready() is False
+                bookkeeper.success.assert_called_with(app_spec)
+                bookkeeper.failed.assert_not_called()
+                lifecycle.success.assert_called_with(lifecycle_subject)
+                lifecycle.failed.assert_not_called()
+
+    def test_tls_ingress_ready_null_notafter_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                             ingress_v1_adapter, config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(V1Ingress, spec_set=True)
+            ingress.spec.tls = [V1IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
+                get_crd.return_value = self._mock_certificate(True)
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)
+
+                assert ready() is False
+                bookkeeper.success.assert_called_with(app_spec)
+                bookkeeper.failed.assert_not_called()
+                lifecycle.success.assert_called_with(lifecycle_subject)
+                lifecycle.failed.assert_not_called()
+
+    def test_tls_ingress_ready_expired_certificate_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                                   ingress_v1_adapter, config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(V1Ingress, spec_set=True)
+            ingress.spec.tls = [V1IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
+                expiration_date = datetime.now() - timedelta(days=5)
+                get_crd.return_value = self._mock_certificate(True, expiration_date)
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)
+                ready._fail_after = time_monotonic()
+
+                assert ready() is False
+                bookkeeper.failed.assert_called_with(app_spec)
+                bookkeeper.success.assert_not_called()
+                lifecycle.failed.assert_called_with(lifecycle_subject)
+                lifecycle.success.assert_not_called()
+
+    def test_tls_ingress_not_ready_timeout_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
+                                           ingress_v1_adapter, config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(V1Ingress)
+            ingress.spec.tls = [V1IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
+                get_crd.return_value = self._mock_certificate(False)
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)
+                ready._fail_after = time_monotonic()
+
+                assert ready() is False
+                bookkeeper.failed.assert_called_with(app_spec)
+                bookkeeper.success.assert_not_called()
+                lifecycle.failed.assert_called_with(lifecycle_subject)
+                lifecycle.success.assert_not_called()
+
+    def test_tls_ingress_not_ready_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter,
+                                   config):
+        config.tls_certificate_ready = True
+        app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
+        replicas = 2
+
+        with mock.patch("k8s.models.networking_v1_ingress.Ingress.find") as find:
+            ingress = mock.create_autospec(V1Ingress)
+            ingress.spec.tls = [V1IngressTLS(hosts=["extra1.example.com"], secretName="secret1")]
+            find.return_value = [ingress]
+
+            with mock.patch("k8s.models.certificate.Certificate.get") as get_crd:
+                get_crd.return_value = self._mock_certificate(False)
+
+                self._create_response(get, replicas, replicas, replicas, replicas)
+                ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)
+
+                assert ready() is True
+                bookkeeper.failed.assert_not_called()
+                bookkeeper.success.assert_not_called()
+                lifecycle.failed.assert_not_called()
+                lifecycle.success.assert_not_called()
+
+    def test_deployment_tls_config_no_tls_extension_v1(self, get, app_spec, bookkeeper, lifecycle,
+                                                    lifecycle_subject, ingress_v1_adapter, config):
+        config.tls_certificate_ready = True
+        self._create_response(get)
+        ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)
 
         assert ready() is False
         bookkeeper.success.assert_called_with(app_spec)

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -277,7 +277,7 @@ class TestReadyCheck(object):
         lifecycle.failed.assert_not_called()
 
     def test_tls_ingress_ready_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter,
-                               config):
+                                  config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -301,7 +301,7 @@ class TestReadyCheck(object):
                 lifecycle.failed.assert_not_called()
 
     def test_tls_ingress_ready_null_notafter_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
-                                             ingress_v1_adapter, config):
+                                                ingress_v1_adapter, config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -324,7 +324,7 @@ class TestReadyCheck(object):
                 lifecycle.failed.assert_not_called()
 
     def test_tls_ingress_ready_expired_certificate_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
-                                                   ingress_v1_adapter, config):
+                                                      ingress_v1_adapter, config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -349,7 +349,7 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_not_called()
 
     def test_tls_ingress_not_ready_timeout_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
-                                           ingress_v1_adapter, config):
+                                              ingress_v1_adapter, config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -373,7 +373,7 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_not_called()
 
     def test_tls_ingress_not_ready_v1(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter,
-                                   config):
+                                      config):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -396,7 +396,7 @@ class TestReadyCheck(object):
                 lifecycle.success.assert_not_called()
 
     def test_deployment_tls_config_no_tls_extension_v1(self, get, app_spec, bookkeeper, lifecycle,
-                                                    lifecycle_subject, ingress_v1_adapter, config):
+                                                       lifecycle_subject, ingress_v1_adapter, config):
         config.tls_certificate_ready = True
         self._create_response(get)
         ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_v1_adapter, config)


### PR DESCRIPTION
During the deployment in newer versions of K8s we found out that the ingress version we were retrieving was the v1beta1. We changed the code to use ingress_adapter and get the correct version depending on the fiaas configuration.