### PR TITLE
Add Kubernetes 1.23 to e2e test Kubernetes version CI targets

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,6 +59,8 @@ blocks:
           - tox -e integration_test -- -n 2 --use-docker-for-e2e --e2e-k8s-version "$K8S_VERSION"
         matrix:
           # e2e tests are run vs. these Kubernetes version
+          # When changing the most recent Kubernetes version here, also update the default value for
+          # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
               - v1.15.12
@@ -68,6 +70,7 @@ blocks:
               - v1.20.7
               - v1.21.2
               - v1.22.4
+              - v1.23.13
 promotions:
   - name: Push container image
     pipeline_file: push-container-image.yml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,8 +157,10 @@ def pytest_xdist_make_scheduler(config, log):
 def pytest_addoption(parser):
     parser.addoption(DOCKER_FOR_E2E_OPTION, action="store_true",
                      help="Run FDD using the development container image when executing E2E tests")
+    # When changing the most recent Kubernetes version here, also update the most recent Kubernetes version used in CI
+    # in .semaphore/semaphore.yml, as these should point to the same version.
     parser.addoption(E2E_K8S_VERSION_OPTION, action="store",
-                     default="v1.22.4",
+                     default="v1.23.13",
                      help="Run e2e tests against a kind cluster using this Kubernetes version")
 
 


### PR DESCRIPTION
Also set the default target for e2e tests to the same version.