### PR TITLE
Remove older kubernetes versions in e2e test configuration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,11 +63,6 @@ blocks:
           # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
-              - v1.15.12
-              - v1.16.15
-              - v1.18.19
-              - v1.19.11
-              - v1.20.7
               - v1.21.2
               - v1.22.4
               - v1.23.13

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -63,6 +63,7 @@ blocks:
           # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
+              - v1.15.12
               - v1.21.2
               - v1.22.4
               - v1.23.13


### PR DESCRIPTION
We are running e2e-tests on a lot of older versions of Kubernetes. To avoid spending unneccessary resources on the build step, I have removed most of them. I kept the three last entries, just in case.

If anyone is using an older version, please comment here, so I can put it back in.