### PR TITLE
Add status field to FIAAS Application resource

### DIFF
--- a/bin/run_fdd_against_rancher_desktop
+++ b/bin/run_fdd_against_rancher_desktop
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+export CLUSTER_NAME="${1:-rancher-desktop}"
+echo "Using kind cluster: $CLUSTER_NAME"
+export NAMESPACE="${NAMESPACE:-default}"
+
+KUBECONFIG_JSON="$(kubectl --context rancher-desktop config view --output json --raw)"
+API_SERVER="$(jq -r ".clusters[] | select(.name == \""${CLUSTER_NAME}"\") | .cluster.server" <<< "$KUBECONFIG_JSON")"
+APISERVER_CERT=$(mktemp)
+CLIENT_CERT=$(mktemp)
+CLIENT_KEY=$(mktemp)
+__cleanup() {
+    rm -f "$APISERVER_CERT"
+    rm -f "$CLIENT_CERT"
+    rm -f "$CLIENT_KEY"
+}
+trap __cleanup EXIT
+
+jq -r ".clusters[] | select(.name == \"${CLUSTER_NAME}\") | .cluster.\"certificate-authority-data\"" <<< "$KUBECONFIG_JSON" | base64 --decode > "$APISERVER_CERT"
+jq -r ".users[] | select(.name == \"${CLUSTER_NAME}\") | .user.\"client-certificate-data\"" <<< "$KUBECONFIG_JSON" | base64 --decode > "$CLIENT_CERT"
+jq -r ".users[] | select(.name == \"${CLUSTER_NAME}\") | .user.\"client-key-data\"" <<< "$KUBECONFIG_JSON" | base64 --decode > "$CLIENT_KEY"
+
+ARGS=(
+'--debug'
+'--api-server' "$API_SERVER"
+'--api-cert' "$APISERVER_CERT"
+'--client-cert' "$CLIENT_CERT"
+'--client-key' "$CLIENT_KEY"
+'--service-type' 'ClusterIP'
+'--environment' 'test'
+'--infrastructure' 'diy' '--port' '5001'
+'--datadog-container-image' 'datadog/docker-dd-agent:12.2.5172-alpine'
+'--enable-crd-support'
+'--enable-service-account-per-app'
+'--use-apiextensionsv1-crd'
+'--use-networkingv1-ingress'
+)
+
+(set -ux; fiaas-deploy-daemon "${ARGS[@]}")

--- a/fiaas_deploy_daemon/crd/crd_resources_syncer_apiextensionsv1.py
+++ b/fiaas_deploy_daemon/crd/crd_resources_syncer_apiextensionsv1.py
@@ -21,8 +21,10 @@ import logging
 from k8s.models.common import ObjectMeta
 from k8s.models.apiextensions_v1_custom_resource_definition import CustomResourceConversion,\
     CustomResourceDefinitionNames, CustomResourceDefinitionSpec, CustomResourceDefinition,\
-    CustomResourceDefinitionVersion, CustomResourceValidation, JSONSchemaProps
+    CustomResourceDefinitionVersion, CustomResourceValidation, JSONSchemaProps,\
+    CustomResourceSubresources, CustomResourceSubresourceScale
 
+from .types import AdditionalCustomResourceSubresources, JSONSchemaPropsForStatus
 from ..retry import retry_on_upsert_conflict
 
 LOG = logging.getLogger(__name__)
@@ -35,8 +37,13 @@ class CrdResourcesSyncerApiextensionsV1(object):
         name = "%s.%s" % (plural, group)
         metadata = ObjectMeta(name=name)
         names = CustomResourceDefinitionNames(kind=kind, plural=plural, shortNames=short_names)
-        schema = CustomResourceValidation(openAPIV3Schema=JSONSchemaProps(type="object", properties=schema_properties))
-        version_v1 = CustomResourceDefinitionVersion(name="v1", served=True, storage=True, schema=schema)
+        if kind == "Application":
+            openAPIV3Schema = JSONSchemaPropsForStatus(type="object", properties=schema_properties)
+        else:
+            openAPIV3Schema = JSONSchemaProps(type="object", properties=schema_properties)
+        schema = CustomResourceValidation(openAPIV3Schema=openAPIV3Schema)
+        subresources = AdditionalCustomResourceSubresources(status = {})
+        version_v1 = CustomResourceDefinitionVersion(name="v1", served=True, storage=True, schema=schema, subresources=subresources)
         spec = CustomResourceDefinitionSpec(
             group=group,
             names=names,
@@ -89,6 +96,25 @@ class CrdResourcesSyncerApiextensionsV1(object):
                             "status": object_with_unknown_fields,
                         }
                     }
+                }
+            },
+            "status": {
+                "type": "object",
+                "properties": {
+                    "result": {
+                        "type": "string"
+                    },
+                    "observedGeneration": {
+                        "type": "integer"
+                    }
+
+                    # ,
+                    # "logs": {
+                    #     "type": "array",
+                    #     "items": {
+                    #         "type": "string"
+                    #     }
+                    # }
                 }
             }
         }

--- a/fiaas_deploy_daemon/crd/crd_resources_syncer_apiextensionsv1.py
+++ b/fiaas_deploy_daemon/crd/crd_resources_syncer_apiextensionsv1.py
@@ -36,13 +36,15 @@ class CrdResourcesSyncerApiextensionsV1(object):
     def _create_or_update(kind, plural, short_names, group, schema_properties):
         name = "%s.%s" % (plural, group)
         metadata = ObjectMeta(name=name)
+        subresources = None
         names = CustomResourceDefinitionNames(kind=kind, plural=plural, shortNames=short_names)
+        # This might be unnecessary we can enable status on both to save logic 
         if kind == "Application":
             openAPIV3Schema = JSONSchemaPropsForStatus(type="object", properties=schema_properties)
+            subresources = AdditionalCustomResourceSubresources(status = {})
         else:
             openAPIV3Schema = JSONSchemaProps(type="object", properties=schema_properties)
         schema = CustomResourceValidation(openAPIV3Schema=openAPIV3Schema)
-        subresources = AdditionalCustomResourceSubresources(status = {})
         version_v1 = CustomResourceDefinitionVersion(name="v1", served=True, storage=True, schema=schema, subresources=subresources)
         spec = CustomResourceDefinitionSpec(
             group=group,
@@ -106,15 +108,13 @@ class CrdResourcesSyncerApiextensionsV1(object):
                     },
                     "observedGeneration": {
                         "type": "integer"
+                    },
+                    "logs": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
-
-                    # ,
-                    # "logs": {
-                    #     "type": "array",
-                    #     "items": {
-                    #         "type": "string"
-                    #     }
-                    # }
                 }
             }
         }

--- a/fiaas_deploy_daemon/crd/status.py
+++ b/fiaas_deploy_daemon/crd/status.py
@@ -63,9 +63,7 @@ def _save_status_inline(result,subject):
     status = FiaasApplicationStatusInline.get(app_name, namespace)
     generation = int(status.metadata.generation)
 
-    # We always want to get running logs here.
-    # If we do a call to _get_logs here then logs will be empty
-    # when _save_status tries to get them.
+    # We only want to get error logs here.
     logs = _get_error_logs(app_name, namespace, deployment_id, result)
 
     LOG.info("Saving inline result %s for %s/%s generation %s", result,namespace, app_name, generation)

--- a/fiaas_deploy_daemon/crd/status.py
+++ b/fiaas_deploy_daemon/crd/status.py
@@ -68,7 +68,7 @@ def _save_status_inline(result,subject):
     # when _save_status tries to get them.
     logs = get_running_logs(app_name, namespace, deployment_id)
 
-    LOG.info("Saving inline result %s for %s/%s generation %s Logs: %s", result,namespace, app_name, generation, logs)
+    LOG.info("Saving inline result %s for %s/%s generation %s", result,namespace, app_name, generation)
     status.status = FiaasApplicationStatusResult(observedGeneration=generation, result=result, logs=logs)
     status.save()
 

--- a/fiaas_deploy_daemon/crd/status.py
+++ b/fiaas_deploy_daemon/crd/status.py
@@ -25,7 +25,7 @@ from blinker import signal
 from k8s.client import NotFound
 from k8s.models.common import ObjectMeta, OwnerReference
 
-from .types import FiaasApplicationStatus
+from .types import FiaasApplicationStatus, FiaasApplicationStatusInline, FiaasApplicationStatusResult
 from ..lifecycle import DEPLOY_STATUS_CHANGED, STATUS_STARTED
 from ..log_extras import get_final_logs, get_running_logs
 from ..retry import retry_on_upsert_conflict
@@ -54,6 +54,23 @@ def _handle_signal(sender, status, subject):
 
     _save_status(status, subject)
     _cleanup(subject.app_name, subject.namespace)
+    _save_status_inline(status, subject)
+
+@retry_on_upsert_conflict
+def _save_status_inline(result,subject):
+    (uid, app_name, namespace, deployment_id, repository, labels, annotations) = subject
+    LOG.info("Saving FiaasApplication.status result %s for %s/%s deployment_id=%s", result, namespace, app_name, deployment_id)
+    # logs = _get_logs(app_name, namespace, deployment_id, result)
+
+    status = FiaasApplicationStatusInline.get(app_name, namespace)
+    generation = int(status.metadata.generation)
+    
+    status.status = FiaasApplicationStatusResult(result=result)
+    if result == "SUCCESS":
+        status.status.observedGeneration = generation
+    status.save()
+        
+    
 
 
 @retry_on_upsert_conflict

--- a/fiaas_deploy_daemon/crd/status.py
+++ b/fiaas_deploy_daemon/crd/status.py
@@ -52,24 +52,26 @@ def _handle_signal(sender, status, subject):
     else:
         status = status.upper()
 
+    _save_status_inline(status, subject)
     _save_status(status, subject)
     _cleanup(subject.app_name, subject.namespace)
-    _save_status_inline(status, subject)
 
 @retry_on_upsert_conflict
 def _save_status_inline(result,subject):
     (uid, app_name, namespace, deployment_id, repository, labels, annotations) = subject
-    LOG.info("Saving FiaasApplication.status result %s for %s/%s deployment_id=%s", result, namespace, app_name, deployment_id)
-    # logs = _get_logs(app_name, namespace, deployment_id, result)
-
+    
     status = FiaasApplicationStatusInline.get(app_name, namespace)
     generation = int(status.metadata.generation)
-    
-    status.status = FiaasApplicationStatusResult(result=result)
-    if result == "SUCCESS":
-        status.status.observedGeneration = generation
+
+    # We always want to get running logs here.
+    # If we do a call to _get_logs here then logs will be empty
+    # when _save_status tries to get them.
+    logs = get_running_logs(app_name, namespace, deployment_id)
+
+    LOG.info("Saving inline result %s for %s/%s generation %s Logs: %s", result,namespace, app_name, generation, logs)
+    status.status = FiaasApplicationStatusResult(observedGeneration=generation, result=result, logs=logs)
     status.save()
-        
+
     
 
 

--- a/fiaas_deploy_daemon/crd/types.py
+++ b/fiaas_deploy_daemon/crd/types.py
@@ -17,8 +17,10 @@
 from __future__ import absolute_import
 
 import six
-from k8s.base import Model
-from k8s.fields import Field, RequiredField, ListField
+from k8s.base import Model, SelfModel
+from k8s.fields import Field, RequiredField, ListField, JSONField
+from k8s.models.apiextensions_v1_custom_resource_definition import CustomResourceSubresourceScale,\
+    ExternalDocumentation
 from k8s.models.common import ObjectMeta
 
 
@@ -56,6 +58,24 @@ class FiaasApplication(Model):
     spec = Field(FiaasApplicationSpec)
 
 
+class FiaasApplicationStatusResult(Model):
+    result = RequiredField(six.text_type)
+    observedGeneration = Field(int, 0)
+    # logs = ListField(six.text_type)
+
+
+class FiaasApplicationStatusInline(Model):
+    class Meta:
+        list_url = "/apis/fiaas.schibsted.io/v1/applications"
+        url_template = "/apis/fiaas.schibsted.io/v1/namespaces/{namespace}/applications/{name}/status"
+        # watch_list_url = "/apis/fiaas.schibsted.io/v1/watch/applications"
+        # watch_list_url_template = "/apis/fiaas.schibsted.io/v1/watch/namespaces/{namespace}/applications"
+    apiVersion = Field(six.text_type, "fiaas.schibsted.io/v1")  # NOQA
+    kind = Field(six.text_type, "Application")
+    metadata = Field(ObjectMeta)
+    status = Field(FiaasApplicationStatusResult)
+
+
 class FiaasApplicationStatus(Model):
     class Meta:
         list_url = "/apis/fiaas.schibsted.io/v1/application-statuses"
@@ -70,3 +90,63 @@ class FiaasApplicationStatus(Model):
     metadata = Field(ObjectMeta)
     result = Field(six.text_type)
     logs = ListField(six.text_type)
+
+
+# Workaround to enable status on CRD we need to return {} 
+# The default field returns {} as none
+class EmptyField(Field):
+    def _as_dict(self, value):
+        return {}
+
+class AdditionalCustomResourceSubresources(Model):
+    scale = Field(CustomResourceSubresourceScale)
+    # CustomResourceSubresourceStatus contains no fields,
+    # so we use the dict type instead
+    status = EmptyField(dict)
+
+# When status is enabled there are other rules to,
+# allowed root elements
+class JSONSchemaPropsForStatus(Model):
+    ref = Field(six.text_type, name='$ref')
+    schema = Field(six.text_type, name='$schema')
+    additionalItems = Field(SelfModel, alt_type=bool)
+    additionalProperties = Field(SelfModel, alt_type=bool)
+    # allOf = ListField(SelfModel)
+    # anyOf = ListField(SelfModel)
+    default = JSONField()
+    definitions = Field(dict)
+    dependencies = Field(dict)
+    description = Field(six.text_type)
+    enum = JSONField()
+    example = JSONField()
+    exclusiveMaximum = Field(bool)
+    exclusiveMinimum = Field(bool)
+    externalDocs = Field(ExternalDocumentation)
+    format = Field(six.text_type)
+    id = Field(six.text_type)
+    items = Field(SelfModel, alt_type=list)
+    maxItems = Field(int)
+    maxLength = Field(int)
+    maxProperties = Field(int)
+    maximum = Field(int, alt_type=float)
+    minItems = Field(int)
+    minLength = Field(int)
+    minProperties = Field(int)
+    minimum = Field(int, alt_type=float)
+    multipleOf = Field(int, alt_type=float)
+    _not = Field(SelfModel)
+    nullable = Field(bool)
+    # oneOf = ListField(SelfModel)
+    pattern = Field(six.text_type)
+    patternProperties = Field(dict)
+    properties = Field(dict)
+    required = ListField(six.text_type)
+    title = Field(six.text_type)
+    type = Field(six.text_type)
+    uniqueItems = Field(bool)
+    x_kubernetes_embedded_resource = Field(bool, name='x-kubernetes-embedded-resource')
+    x_kubernetes_int_or_string = Field(bool, name='x-kubernetes-int-or-string')
+    # x_kubernetes_list_map_keys = ListField(six.text_type, name='x-kubernetes-list-map-keys')
+    x_kubernetes_list_type = Field(six.text_type, name="x-kubernetes-list-type")
+    x_kubernetes_map_type = Field(six.text_type, name='x-kubernetes-map-type')
+    x_kubernetes_preserve_unknown_fields = Field(bool, name="x-kubernetes-preserve-unknown-fields")

--- a/fiaas_deploy_daemon/crd/types.py
+++ b/fiaas_deploy_daemon/crd/types.py
@@ -61,7 +61,7 @@ class FiaasApplication(Model):
 class FiaasApplicationStatusResult(Model):
     result = RequiredField(six.text_type)
     observedGeneration = Field(int, 0)
-    # logs = ListField(six.text_type)
+    logs = ListField(six.text_type)
 
 
 class FiaasApplicationStatusInline(Model):

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -78,7 +78,7 @@ class CrdWatcher(DaemonThread):
         status = FiaasApplicationStatusInline.get(app_name, namespace)
         generation = int(status.metadata.generation)
         observed_generation = int(status.status.observedGeneration)
-        if observed_generation < generation:
+        if observed_generation == generation:
             LOG.debug("Event created from status update %s for app %s", deployment_id, app_name)
             return True
         return False

--- a/fiaas_deploy_daemon/crd/watcher.py
+++ b/fiaas_deploy_daemon/crd/watcher.py
@@ -24,7 +24,7 @@ from k8s.watcher import Watcher
 from yaml import YAMLError
 
 from .status import create_name
-from .types import FiaasApplication, FiaasApplicationStatus
+from .types import FiaasApplication, FiaasApplicationStatus, FiaasApplicationStatusInline
 from ..base_thread import DaemonThread
 from ..deployer import DeployerEvent
 from ..log_extras import set_extras
@@ -69,7 +69,23 @@ class CrdWatcher(DaemonThread):
         else:
             raise ValueError("Unknown WatchEvent type {}".format(event.type))
 
+    # When we receive update event on FiaasApplication
+    # don't deploy if it's a status update
+    def _skip_status_event(self, application):
+        app_name = application.spec.application
+        namespace = application.metadata.namespace
+        deployment_id = application.metadata.labels["fiaas/deployment_id"]
+        status = FiaasApplicationStatusInline.get(app_name, namespace)
+        generation = int(status.metadata.generation)
+        observed_generation = int(status.status.observedGeneration)
+        if observed_generation < generation:
+            LOG.debug("Event created from status update %s for app %s", deployment_id, app_name)
+            return True
+        return False
+
     def _deploy(self, application):
+        if self._skip_status_event(application):
+            return 
         app_name = application.spec.application
         LOG.debug("Deploying %s", app_name)
         try:

--- a/fiaas_deploy_daemon/log_extras.py
+++ b/fiaas_deploy_daemon/log_extras.py
@@ -20,6 +20,7 @@ import threading
 from collections import defaultdict
 
 _LOGS = defaultdict(list)
+_ERROR_LOGS = defaultdict(list)
 _LOG_EXTRAS = threading.local()
 _LOG_FORMAT = u"[%(asctime)s|%(levelname)7s] %(message)s " \
               u"[%(name)s|%(threadName)s|%(extras_namespace)s/%(extras_app_name)s]"
@@ -33,6 +34,16 @@ class ExtraFilter(logging.Filter):
         record.extras = extras
         return 1
 
+
+class ExtraErrorFilter(logging.Filter):
+    def filter(self, record):
+        extras = {}
+        for key in ("app_name", "namespace", "deployment_id"):
+            extras[key] = getattr(_LOG_EXTRAS, key, "")
+        record.extras = extras
+
+        return record.levelno >= logging.ERROR
+    
 
 class StatusFormatter(logging.Formatter):
     def __init__(self):
@@ -73,6 +84,16 @@ class StatusHandler(logging.Handler):
         append_log(record, self.format(record))
 
 
+class StatusErrorHandler(logging.Handler):
+    def __init__(self):
+        super(StatusErrorHandler, self).__init__(logging.ERROR)
+        self.addFilter(ExtraErrorFilter())
+        self.setFormatter(StatusFormatter())
+
+    def emit(self, record):
+        append_error_log(record, self.format(record))
+
+
 def set_extras(app_spec=None, app_name=None, namespace=None, deployment_id=None):
     if app_spec:
         app_name = app_spec.name
@@ -100,3 +121,19 @@ def append_log(record, message):
     if hasattr(record, "extras"):
         key = (record.extras.get("app_name"), record.extras.get("namespace"), record.extras.get("deployment_id"))
         _LOGS[key].append(message)
+
+
+def get_running_error_logs(app_name, namespace, deployment_id):
+    key = (app_name, namespace, deployment_id)
+    return _ERROR_LOGS.get(key, [])
+
+
+def get_final_error_logs(app_name, namespace, deployment_id):
+    key = (app_name, namespace, deployment_id)
+    return _ERROR_LOGS.pop(key, [])
+
+
+def append_error_log(record, message):
+    if hasattr(record, "extras"):
+        key = (record.extras.get("app_name"), record.extras.get("namespace"), record.extras.get("deployment_id"))
+        _ERROR_LOGS[key].append(message)

--- a/fiaas_deploy_daemon/logsetup.py
+++ b/fiaas_deploy_daemon/logsetup.py
@@ -21,7 +21,7 @@ import json
 import logging
 import sys
 
-from fiaas_deploy_daemon.log_extras import StatusHandler
+from fiaas_deploy_daemon.log_extras import StatusHandler, StatusErrorHandler
 from .log_extras import ExtraFilter
 
 
@@ -92,6 +92,7 @@ def init_logging(config):
         root.setLevel(logging.DEBUG)
     root.addHandler(_create_default_handler(config))
     root.addHandler(StatusHandler())
+    root.addHandler(StatusErrorHandler())
     _set_special_levels()
 
 


### PR DESCRIPTION
Early PR to get feedback on adding status field to FIAAS Application resource.
This PR will only add the status field and continue to use ApplicationStatus resource as well.

The status field is similar to ApplicationStatus but only logs error, to not bloat the Application resource.

Ref. the roadmap where this feature is highlighted.
https://github.com/fiaas/fiaas-deploy-daemon/blob/master/docs/roadmap.md