### PR TITLE
Format bin/, tests/ and top level files with black

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Format with `black -l 120 .`
+a41d495b1c393004611bd3cab0b7036f8327087f
+# Reformat remaining files with black
+866a28870f80353bde8fde1b693231acbe15e7a9

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/ingress_check.py
+++ b/bin/ingress_check.py
@@ -34,6 +34,7 @@ from requests.packages.urllib3.contrib import pyopenssl as reqs
 try:
     from tqdm import tqdm
 except ImportError:
+
     def tqdm(it, *args, **kwargs):
         return it
 
@@ -91,10 +92,7 @@ def _has_selected_ingress_class(ingress):
 
 def _get_certificate_issuer_cn(secret):
     crt = base64.b64decode(secret.data["tls.crt"])
-    x509 = reqs.OpenSSL.crypto.load_certificate(
-        reqs.OpenSSL.crypto.FILETYPE_PEM,
-        crt
-    )
+    x509 = reqs.OpenSSL.crypto.load_certificate(reqs.OpenSSL.crypto.FILETYPE_PEM, crt)
     issuer = x509.get_issuer()
     return issuer.CN
 
@@ -108,8 +106,9 @@ def _has_invalid_certificate(ingress):
             secret = Secret.get(secret_name, ingress.metadata.namespace)
             issuer_cn = _get_certificate_issuer_cn(secret)
             if "Let's Encrypt Authority X3" != issuer_cn:
-                invalid_certs.append(Problem(secret_name, "Incorrect issuer: {}".format(issuer_cn),
-                                             ProblemType.WRONG_CA))
+                invalid_certs.append(
+                    Problem(secret_name, "Incorrect issuer: {}".format(issuer_cn), ProblemType.WRONG_CA)
+                )
         except NotFound:
             invalid_certs.append(Problem(secret_name, "No certificate provisioned", ProblemType.NO_CERTIFICATE))
     return invalid_certs
@@ -162,9 +161,12 @@ def _collect_problems(ingresses):
         if invalid_certificates:
             for ic in invalid_certificates:
                 if len(ic.host) > 63:
-                    problems.append(ic._replace(
-                        reason="Host is too long ({}) to be a CommonName".format(len(ic.host)),
-                        type=ProblemType.TOO_LONG))
+                    problems.append(
+                        ic._replace(
+                            reason="Host is too long ({}) to be a CommonName".format(len(ic.host)),
+                            type=ProblemType.TOO_LONG,
+                        )
+                    )
                 else:
                     problems.append(ic)
         if unreachable_hosts:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -21,7 +21,7 @@ fiaas-deploy-daemon is released by pushing an [annotated git tag](https://git-sc
 ```shell
 git tag -a vMAJOR.MINOR.PATCH [git ref]
 ```
-The version number must follow [semantic versioning](semver2). git ref must be a commit on the master branch.
+The version number must follow [semantic versioning][semver2]. git ref must be a commit on the master branch.
 
 The message of the annotated tag should contain the release notes, describing the changes included in the release. A header will be added automatically by the release tooling, so you don't need to include one in the release notes. These release notes end up on the resulting release in Github.
 
@@ -38,6 +38,6 @@ git push origin vMAJOR.MINOR.PATCH
 - If a new feature is added, but backwards compatibility is preserved, increase the minor version.
 - For bug fixes and similar, increase the patch version.
 
-For cases that do not fit into the above, refer to the [semver spec](semver2) (and consider updating this documentation).
+For cases that do not fit into the above, refer to the [semver spec][semver2] (and consider updating this documentation).
 
 [semver2]: https://semver.org/spec/v2.0.0.html

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,5 +1,19 @@
 # Developer Documentation
 
+## Code Style
+
+Use [`black`](https://black.readthedocs.io/en/stable/index.html) to format the code when making changes:
+
+```shell
+$ black $(git rev-parse --show-toplevel)
+```
+
+Refer to the [black docs](https://black.readthedocs.io/en/stable/integrations/editors.html) for how to set up your editor to format code for you automatically.
+
+### Ignore code reformatting changes in `git blame`
+
+There are a few commits that introduce the `black` code style which touch almost all files. These are listed in the `.git-blame-ignore-revs` file at the top level of the repo.  See [here](https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html#avoiding-ruining-git-blame) for how to use this file to make it easier to inspect git history with `git blame` by ignoring the commits that only introduce formatting changes.
+
 ## Creating a Release
 
 fiaas-deploy-daemon is released by pushing an [annotated git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_annotated_tags) (a tag containing a message) named `v$SEMVER_VERSION`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -53,25 +53,25 @@ WEB_REQ = [
 
 DEPLOY_REQ = [
     "requests == 2.27.1",
-    "ipaddress == 1.0.22"  # Required by requests for resolving IP address in SSL cert
+    "ipaddress == 1.0.22",  # Required by requests for resolving IP address in SSL cert
 ]
 
 FLAKE8_REQ = [
-    'flake8-print == 3.1.4',
-    'flake8-comprehensions == 1.4.1',
-    'pep8-naming == 0.11.1',
-    'flake8 == 3.9.0'
+    "flake8-print == 3.1.4",
+    "flake8-comprehensions == 1.4.1",
+    "pep8-naming == 0.11.1",
+    "flake8 == 3.9.0",
 ]
 
 TESTS_REQ = [
-    'pytest-xdist == 1.27.0',
-    'pytest-sugar == 0.9.2',
-    'pytest-html == 1.22.0',
-    'pytest-cov == 2.7.1',
-    'pytest-helpers-namespace == 2019.1.8',
-    'pytest == 3.10.1',
-    'requests-file == 1.4.3',
-    'callee == 0.3',
+    "pytest-xdist == 1.27.0",
+    "pytest-sugar == 0.9.2",
+    "pytest-html == 1.22.0",
+    "pytest-cov == 2.7.1",
+    "pytest-helpers-namespace == 2019.1.8",
+    "pytest == 3.10.1",
+    "requests-file == 1.4.3",
+    "callee == 0.3",
 ]
 
 DEV_TOOLS = [
@@ -90,25 +90,22 @@ if __name__ == "__main__":
         packages=find_packages(exclude=("tests",)),
         zip_safe=True,
         include_package_data=True,
-
         # Requirements
         install_requires=GENERIC_REQ + WEB_REQ + DEPLOY_REQ,
-        setup_requires=['pytest-runner', 'wheel', 'setuptools_git >= 0.3'],
+        setup_requires=["pytest-runner", "wheel", "setuptools_git >= 0.3"],
         extras_require={
             "dev": TESTS_REQ + FLAKE8_REQ + DEV_TOOLS,
-            "ci": DEV_TOOLS
+            "ci": DEV_TOOLS,
         },
-
         # Metadata
         description="Deploy applications to Kubernetes",
         long_description=read("README.md"),
         url="https://github.schibsted.io/finn/fiaas-deploy-daemon",
-
         # Entrypoints
         entry_points={
             "console_scripts": [
                 "fiaas-deploy-daemon = fiaas_deploy_daemon:main",
                 "fiaas-deploy-daemon-bootstrap = fiaas_deploy_daemon.bootstrap:main",
             ]
-        }
+        },
     )

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ TESTS_REQ = [
 
 DEV_TOOLS = [
     "tox==3.14.5",
-    "virtualenv==20.13.0"
+    "virtualenv==20.13.0",
+    "black ~= 22.0",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from xdist.scheduler import LoadScopeScheduling
 DOCKER_FOR_E2E_OPTION = "--use-docker-for-e2e"
 E2E_K8S_VERSION_OPTION = "--e2e-k8s-version"
 
-pytest_plugins = ['helpers_namespace']
+pytest_plugins = ["helpers_namespace"]
 
 
 def uuid():
@@ -36,6 +36,7 @@ def uuid():
 @pytest.fixture(autouse=True)
 def prometheus_registry():
     from prometheus_client.core import REGISTRY
+
     yield REGISTRY
     for c in list(REGISTRY._collector_to_names.keys()):
         REGISTRY.unregister(c)
@@ -83,8 +84,9 @@ def _add_useful_error_message(assertion, mockk, first, args):
     except AssertionError:
         other_calls = [call[0] for call in mockk.call_args_list if (first is None or call[0][0] == first)]
         if other_calls:
-            extra_info = '\n\nURI {} got the following other calls:\n{}\n'.format(first, '\n'.join(
-                _format_call(call) for call in other_calls))
+            extra_info = "\n\nURI {} got the following other calls:\n{}\n".format(
+                first, "\n".join(_format_call(call) for call in other_calls)
+            )
             if len(other_calls) == 1 and len(other_calls[0]) == 2 and args is not None:
                 extra_info += _add_argument_diff(other_calls[0][1], args[0])
             raise AssertionError(extra_info)
@@ -119,9 +121,9 @@ def _add_argument_diff(actual, expected, indent=0, acc=None):
 
 def _format_call(call):
     if len(call) > 1:
-        return 'call({}, {})'.format(call[0], call[1])
+        return "call({}, {})".format(call[0], call[1])
     else:
-        return 'call({})'.format(call[0])
+        return "call({})".format(call[0])
 
 
 class FixtureScheduling(LoadScopeScheduling):
@@ -167,8 +169,8 @@ class FixtureScheduling(LoadScopeScheduling):
         - if none of those apply, use the previous behavior of grouping by the two first fixture names (this is just
         as a fallback and might lead to suboptimal scheduling).
         """
-        if 'test_custom_resource_definition_deploy_with_service_account' in nodeid:
-            return 'serviceaccount'
+        if "test_custom_resource_definition_deploy_with_service_account" in nodeid:
+            return "serviceaccount"
 
         for service_type in ("NodePort", "ClusterIP"):
             if service_type in fixture_values:
@@ -183,13 +185,19 @@ def pytest_xdist_make_scheduler(config, log):
 
 
 def pytest_addoption(parser):
-    parser.addoption(DOCKER_FOR_E2E_OPTION, action="store_true",
-                     help="Run FDD using the development container image when executing E2E tests")
+    parser.addoption(
+        DOCKER_FOR_E2E_OPTION,
+        action="store_true",
+        help="Run FDD using the development container image when executing E2E tests",
+    )
     # When changing the most recent Kubernetes version here, also update the most recent Kubernetes version used in CI
     # in .semaphore/semaphore.yml, as these should point to the same version.
-    parser.addoption(E2E_K8S_VERSION_OPTION, action="store",
-                     default="v1.23.13",
-                     help="Run e2e tests against a kind cluster using this Kubernetes version")
+    parser.addoption(
+        E2E_K8S_VERSION_OPTION,
+        action="store",
+        default="v1.23.13",
+        help="Run e2e tests against a kind cluster using this Kubernetes version",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -203,15 +211,22 @@ def use_docker_for_e2e(request):
         container_name = "fdd_{}_{}_{}".format(service_type, k8s_version, uuid())
         test_request.addfinalizer(lambda: subprocess.call(["docker", "stop", container_name]))
         args = [
-            "docker", "run",
-            "-i", "--rm",
-            "-e", "NAMESPACE",
-            "--name", container_name,
+            "docker",
+            "run",
+            "-i",
+            "--rm",
+            "-e",
+            "NAMESPACE",
+            "--name",
+            container_name,
             "--network=kind",
-            "--publish", "{port}:{port}".format(port=port),
-            "--mount", "type=bind,src={},dst={},ro".format(cert_path, cert_path),
+            "--publish",
+            "{port}:{port}".format(port=port),
+            "--mount",
+            "type=bind,src={},dst={},ro".format(cert_path, cert_path),
             # make `kubernetes` resolve to the apiserver's IP to make it possible to validate its TLS cert
-            "--add-host", "kubernetes:{}".format(apiserver_ip),
+            "--add-host",
+            "kubernetes:{}".format(apiserver_ip),
         ]
         return args + ["fiaas/fiaas-deploy-daemon:development"]
 
@@ -222,4 +237,4 @@ def use_docker_for_e2e(request):
 
 
 def _is_macos():
-    return os.uname()[0] == 'Darwin'
+    return os.uname()[0] == "Darwin"

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -19,20 +19,36 @@ import pytest
 from k8s import config
 from k8s.client import NotFound
 
-from fiaas_deploy_daemon.specs.models import AppSpec, \
-    ResourceRequirementSpec, ResourcesSpec, PrometheusSpec, DatadogSpec, \
-    PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, \
-    AutoscalerSpec, ExecCheckSpec, LabelAndAnnotationSpec, \
-    IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec
+from fiaas_deploy_daemon.specs.models import (
+    AppSpec,
+    ResourceRequirementSpec,
+    ResourcesSpec,
+    PrometheusSpec,
+    DatadogSpec,
+    PortSpec,
+    CheckSpec,
+    HttpCheckSpec,
+    TcpCheckSpec,
+    HealthCheckSpec,
+    AutoscalerSpec,
+    ExecCheckSpec,
+    LabelAndAnnotationSpec,
+    IngressItemSpec,
+    IngressPathMappingSpec,
+    StrongboxSpec,
+    IngressTLSSpec,
+)
 
-PROMETHEUS_SPEC = PrometheusSpec(enabled=True, port='http', path='/internal-backstage/prometheus')
+PROMETHEUS_SPEC = PrometheusSpec(enabled=True, port="http", path="/internal-backstage/prometheus")
 DATADOG_SPEC = DatadogSpec(enabled=False, tags={})
 AUTOSCALER_SPEC = AutoscalerSpec(enabled=False, min_replicas=2, max_replicas=3, cpu_threshold_percentage=50)
-EMPTY_RESOURCE_SPEC = ResourcesSpec(requests=ResourceRequirementSpec(cpu=None, memory=None),
-                                    limits=ResourceRequirementSpec(cpu=None, memory=None))
+EMPTY_RESOURCE_SPEC = ResourcesSpec(
+    requests=ResourceRequirementSpec(cpu=None, memory=None), limits=ResourceRequirementSpec(cpu=None, memory=None)
+)
 
 
 # App specs
+
 
 @pytest.fixture
 def app_spec():
@@ -51,22 +67,40 @@ def app_spec():
             PortSpec(protocol="http", name="http", port=80, target_port=8080),
         ],
         health_checks=HealthCheckSpec(
-            liveness=CheckSpec(tcp=TcpCheckSpec(port=8080), http=None, execute=None, initial_delay_seconds=10,
-                               period_seconds=10, success_threshold=1, failure_threshold=3, timeout_seconds=1),
-            readiness=CheckSpec(http=HttpCheckSpec(path="/", port=8080, http_headers={}), tcp=None, execute=None,
-                                initial_delay_seconds=10, period_seconds=10, success_threshold=1, failure_threshold=3,
-                                timeout_seconds=1)),
-        teams=['foo'],
-        tags=['bar'],
+            liveness=CheckSpec(
+                tcp=TcpCheckSpec(port=8080),
+                http=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+            readiness=CheckSpec(
+                http=HttpCheckSpec(path="/", port=8080, http_headers={}),
+                tcp=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+        ),
+        teams=["foo"],
+        tags=["bar"],
         deployment_id="test_app_deployment_id",
         labels=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}, {}),
         annotations=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}, {}),
-        ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
+        ingresses=[
+            IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})
+        ],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
         ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
         secrets=[],
-        app_config={}
+        app_config={},
     )
 
 
@@ -77,13 +111,28 @@ def app_spec_thrift(app_spec):
             PortSpec(protocol="tcp", name="thrift", port=7999, target_port=7999),
         ],
         health_checks=HealthCheckSpec(
-            liveness=CheckSpec(tcp=TcpCheckSpec(port=7999), http=None, execute=None, initial_delay_seconds=10,
-                               period_seconds=10, success_threshold=1, failure_threshold=3, timeout_seconds=1),
-            readiness=CheckSpec(tcp=TcpCheckSpec(port=7999), http=None, execute=None,
-                                initial_delay_seconds=10, period_seconds=10, success_threshold=1, failure_threshold=3,
-                                timeout_seconds=1)
+            liveness=CheckSpec(
+                tcp=TcpCheckSpec(port=7999),
+                http=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+            readiness=CheckSpec(
+                tcp=TcpCheckSpec(port=7999),
+                http=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
         ),
-        ingresses=[]
+        ingresses=[],
     )
 
 
@@ -104,11 +153,27 @@ def app_spec_thrift_and_http(app_spec):
             PortSpec(protocol="tcp", name="thrift", port=7999, target_port=7999),
         ],
         health_checks=HealthCheckSpec(
-            liveness=CheckSpec(tcp=TcpCheckSpec(port=7999), http=None, execute=None, initial_delay_seconds=10,
-                               period_seconds=10, success_threshold=1, failure_threshold=3, timeout_seconds=1),
-            readiness=CheckSpec(http=HttpCheckSpec(path="/", port=8080, http_headers={}), tcp=None, execute=None,
-                                initial_delay_seconds=10, period_seconds=10, success_threshold=1, failure_threshold=3,
-                                timeout_seconds=1)),
+            liveness=CheckSpec(
+                tcp=TcpCheckSpec(port=7999),
+                http=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+            readiness=CheckSpec(
+                http=HttpCheckSpec(path="/", port=8080, http_headers={}),
+                tcp=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+        ),
     )
 
 
@@ -117,19 +182,26 @@ def app_spec_teams_and_tags(app_spec):
     return app_spec._replace(
         ports=None,
         health_checks=None,
-        teams=['Order Produkt Betaling'],
-        tags=['høyt-i-stacken', 'ad-in', 'Anonnseinnlegging']
+        teams=["Order Produkt Betaling"],
+        tags=["høyt-i-stacken", "ad-in", "Anonnseinnlegging"],
     )
 
 
 @pytest.fixture
 def app_spec_no_ports(app_spec):
-    exec_check = CheckSpec(http=None, tcp=None, execute=ExecCheckSpec(command="/app/check.sh"),
-                           initial_delay_seconds=10, period_seconds=10, success_threshold=1, failure_threshold=3,
-                           timeout_seconds=1)
-    return app_spec._replace(ports=[],
-                             health_checks=HealthCheckSpec(liveness=exec_check, readiness=exec_check),
-                             ingresses=[])
+    exec_check = CheckSpec(
+        http=None,
+        tcp=None,
+        execute=ExecCheckSpec(command="/app/check.sh"),
+        initial_delay_seconds=10,
+        period_seconds=10,
+        success_threshold=1,
+        failure_threshold=3,
+        timeout_seconds=1,
+    )
+    return app_spec._replace(
+        ports=[], health_checks=HealthCheckSpec(liveness=exec_check, readiness=exec_check), ingresses=[]
+    )
 
 
 # k8s client library mocks
@@ -145,26 +217,26 @@ def k8s_config(monkeypatch):
 
 @pytest.fixture()
 def get():
-    with mock.patch('k8s.client.Client.get') as mockk:
+    with mock.patch("k8s.client.Client.get") as mockk:
         mockk.side_effect = NotFound()
         yield mockk
 
 
 @pytest.fixture()
 def post():
-    with mock.patch('k8s.client.Client.post') as mockk:
+    with mock.patch("k8s.client.Client.post") as mockk:
         yield mockk
 
 
 @pytest.fixture()
 def put():
-    with mock.patch('k8s.client.Client.put') as mockk:
+    with mock.patch("k8s.client.Client.put") as mockk:
         yield mockk
 
 
 @pytest.fixture()
 def delete():
-    with mock.patch('k8s.client.Client.delete') as mockk:
+    with mock.patch("k8s.client.Client.delete") as mockk:
         yield mockk
 
 

--- a/tests/fiaas_deploy_daemon/crd/test_crd_resources_syncer_apiextensionsv1.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_resources_syncer_apiextensionsv1.py
@@ -28,133 +28,121 @@ object_with_unknown_fields = {"type": "object", "x-kubernetes-preserve-unknown-f
 
 
 EXPECTED_APPLICATION = {
-    'metadata': {
-        'namespace': 'default',
-        'name': 'applications.fiaas.schibsted.io',
-        'ownerReferences': [],
-        'finalizers': [],
+    "metadata": {
+        "namespace": "default",
+        "name": "applications.fiaas.schibsted.io",
+        "ownerReferences": [],
+        "finalizers": [],
     },
-    'spec': {
-        'group': 'fiaas.schibsted.io',
-        'names': {
-            'shortNames': ['app', 'fa'],
-            'kind': 'Application',
-            'plural': 'applications',
-            'categories': []
-        },
-        'preserveUnknownFields': False,
-        'scope': 'Namespaced',
-        'conversion': {
-            'strategy': 'None'
-        },
-        'versions': [{
-            'additionalPrinterColumns': [],
-            'name': 'v1',
-            'served': True,
-            'storage': True,
-            'schema': {
-                'openAPIV3Schema': {
-                    'type': 'object',
-                    'properties': {
-                        'spec': {
-                            'type': 'object',
-                            'properties': {
-                                "application": {
-                                    "type": "string",
+    "spec": {
+        "group": "fiaas.schibsted.io",
+        "names": {"shortNames": ["app", "fa"], "kind": "Application", "plural": "applications", "categories": []},
+        "preserveUnknownFields": False,
+        "scope": "Namespaced",
+        "conversion": {"strategy": "None"},
+        "versions": [
+            {
+                "additionalPrinterColumns": [],
+                "name": "v1",
+                "served": True,
+                "storage": True,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "spec": {
+                                "type": "object",
+                                "properties": {
+                                    "application": {
+                                        "type": "string",
+                                    },
+                                    "image": {
+                                        "type": "string",
+                                    },
+                                    "config": object_with_unknown_fields,
+                                    "additional_labels": {
+                                        "type": "object",
+                                        "properties": {
+                                            "global": object_with_unknown_fields,
+                                            "deployment": object_with_unknown_fields,
+                                            "horizontal_pod_autoscaler": object_with_unknown_fields,
+                                            "ingress": object_with_unknown_fields,
+                                            "service": object_with_unknown_fields,
+                                            "service_account": object_with_unknown_fields,
+                                            "pod": object_with_unknown_fields,
+                                            "status": object_with_unknown_fields,
+                                        },
+                                    },
+                                    "additional_annotations": {
+                                        "type": "object",
+                                        "properties": {
+                                            "global": object_with_unknown_fields,
+                                            "deployment": object_with_unknown_fields,
+                                            "horizontal_pod_autoscaler": object_with_unknown_fields,
+                                            "ingress": object_with_unknown_fields,
+                                            "service": object_with_unknown_fields,
+                                            "service_account": object_with_unknown_fields,
+                                            "pod": object_with_unknown_fields,
+                                            "status": object_with_unknown_fields,
+                                        },
+                                    },
                                 },
-                                "image": {
-                                    "type": "string",
-                                },
-                                "config": object_with_unknown_fields,
-                                "additional_labels": {
-                                    "type": "object",
-                                    "properties": {
-                                        "global": object_with_unknown_fields,
-                                        "deployment": object_with_unknown_fields,
-                                        "horizontal_pod_autoscaler": object_with_unknown_fields,
-                                        "ingress": object_with_unknown_fields,
-                                        "service": object_with_unknown_fields,
-                                        "service_account": object_with_unknown_fields,
-                                        "pod": object_with_unknown_fields,
-                                        "status": object_with_unknown_fields,
-                                    }
-                                },
-                                "additional_annotations": {
-                                    "type": "object",
-                                    "properties": {
-                                        "global": object_with_unknown_fields,
-                                        "deployment": object_with_unknown_fields,
-                                        "horizontal_pod_autoscaler": object_with_unknown_fields,
-                                        "ingress": object_with_unknown_fields,
-                                        "service": object_with_unknown_fields,
-                                        "service_account": object_with_unknown_fields,
-                                        "pod": object_with_unknown_fields,
-                                        "status": object_with_unknown_fields,
-                                    }
-                                }
                             }
-                        }
-                    },
-                    'oneOf': [],
-                    'allOf': [],
-                    'required': [],
-                    'x-kubernetes-list-map-keys': [],
-                    'anyOf': []
-                }
+                        },
+                        "oneOf": [],
+                        "allOf": [],
+                        "required": [],
+                        "x-kubernetes-list-map-keys": [],
+                        "anyOf": [],
+                    }
+                },
             }
-        }]
-    }
+        ],
+    },
 }
 
 
 EXPECTED_STATUS = {
-    'metadata': {
-        'namespace': 'default',
-        'name': 'application-statuses.fiaas.schibsted.io',
-        'ownerReferences': [],
-        'finalizers': [],
+    "metadata": {
+        "namespace": "default",
+        "name": "application-statuses.fiaas.schibsted.io",
+        "ownerReferences": [],
+        "finalizers": [],
     },
-    'spec': {
-        'group': 'fiaas.schibsted.io',
-        'names': {
-            'shortNames': ['status', 'appstatus', 'fs'],
-            'kind': 'ApplicationStatus',
-            'plural': 'application-statuses',
-            'categories': []
+    "spec": {
+        "group": "fiaas.schibsted.io",
+        "names": {
+            "shortNames": ["status", "appstatus", "fs"],
+            "kind": "ApplicationStatus",
+            "plural": "application-statuses",
+            "categories": [],
         },
-        'preserveUnknownFields': False,
-        'scope': 'Namespaced',
-        'conversion': {
-            'strategy': 'None'
-        },
-        'versions': [{
-            'additionalPrinterColumns': [],
-            'name': 'v1',
-            'served': True,
-            'storage': True,
-            'schema': {
-                'openAPIV3Schema': {
-                    'type': 'object',
-                    'properties': {
-                        "result": {
-                            "type": "string"
+        "preserveUnknownFields": False,
+        "scope": "Namespaced",
+        "conversion": {"strategy": "None"},
+        "versions": [
+            {
+                "additionalPrinterColumns": [],
+                "name": "v1",
+                "served": True,
+                "storage": True,
+                "schema": {
+                    "openAPIV3Schema": {
+                        "type": "object",
+                        "properties": {
+                            "result": {"type": "string"},
+                            "logs": {"type": "array", "items": {"type": "string"}},
                         },
-                        "logs": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    'oneOf': [],
-                    'allOf': [],
-                    'required': [],
-                    'x-kubernetes-list-map-keys': [],
-                    'anyOf': []
-                }
+                        "oneOf": [],
+                        "allOf": [],
+                        "required": [],
+                        "x-kubernetes-list-map-keys": [],
+                        "anyOf": [],
+                    }
+                },
             }
-        }]
-    }
+        ],
+    },
 }
 
 
@@ -173,7 +161,7 @@ class TestCrdResourcesSyncerV1(object):
 
         calls = [
             mock.call("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/", EXPECTED_APPLICATION),
-            mock.call("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/", EXPECTED_STATUS)
+            mock.call("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/", EXPECTED_STATUS),
         ]
         assert post.call_args_list == calls
 
@@ -189,7 +177,13 @@ class TestCrdResourcesSyncerV1(object):
         CrdResourcesSyncerApiextensionsV1.update_crd_resources()
 
         calls = [
-            mock.call("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/applications.fiaas.schibsted.io", EXPECTED_APPLICATION),
-            mock.call("/apis/apiextensions.k8s.io/v1/customresourcedefinitions/application-statuses.fiaas.schibsted.io", EXPECTED_STATUS)
+            mock.call(
+                "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/applications.fiaas.schibsted.io",
+                EXPECTED_APPLICATION,
+            ),
+            mock.call(
+                "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/application-statuses.fiaas.schibsted.io",
+                EXPECTED_STATUS,
+            ),
         ]
         assert put.call_args_list == calls

--- a/tests/fiaas_deploy_daemon/crd/test_crd_resources_syncer_apiextensionsv1beta1.py
+++ b/tests/fiaas_deploy_daemon/crd/test_crd_resources_syncer_apiextensionsv1beta1.py
@@ -25,40 +25,36 @@ from fiaas_deploy_daemon.crd.crd_resources_syncer_apiextensionsv1beta1 import Cr
 
 
 EXPECTED_APPLICATION = {
-    'metadata': {
-        'namespace': 'default',
-        'name': 'applications.fiaas.schibsted.io',
-        'ownerReferences': [],
-        'finalizers': [],
+    "metadata": {
+        "namespace": "default",
+        "name": "applications.fiaas.schibsted.io",
+        "ownerReferences": [],
+        "finalizers": [],
     },
-    'spec': {
-        'version': 'v1',
-        'group': 'fiaas.schibsted.io',
-        'names': {
-            'shortNames': ['app', 'fa'],
-            'kind': 'Application',
-            'plural': 'applications'
-        }
-    }
+    "spec": {
+        "version": "v1",
+        "group": "fiaas.schibsted.io",
+        "names": {"shortNames": ["app", "fa"], "kind": "Application", "plural": "applications"},
+    },
 }
 
 
 EXPECTED_STATUS = {
-    'metadata': {
-        'namespace': 'default',
-        'name': 'application-statuses.fiaas.schibsted.io',
-        'ownerReferences': [],
-        'finalizers': [],
+    "metadata": {
+        "namespace": "default",
+        "name": "application-statuses.fiaas.schibsted.io",
+        "ownerReferences": [],
+        "finalizers": [],
     },
-    'spec': {
-        'version': 'v1',
-        'group': 'fiaas.schibsted.io',
-        'names': {
-            'shortNames': ['status', 'appstatus', 'fs'],
-            'kind': 'ApplicationStatus',
-            'plural': 'application-statuses'
-        }
-    }
+    "spec": {
+        "version": "v1",
+        "group": "fiaas.schibsted.io",
+        "names": {
+            "shortNames": ["status", "appstatus", "fs"],
+            "kind": "ApplicationStatus",
+            "plural": "application-statuses",
+        },
+    },
 }
 
 
@@ -77,7 +73,7 @@ class TestCrdResourcesSyncerV1beta1(object):
 
         calls = [
             mock.call("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/", EXPECTED_APPLICATION),
-            mock.call("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/", EXPECTED_STATUS)
+            mock.call("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/", EXPECTED_STATUS),
         ]
         assert post.call_args_list == calls
 
@@ -93,8 +89,13 @@ class TestCrdResourcesSyncerV1beta1(object):
         CrdResourcesSyncerApiextensionsV1Beta1.update_crd_resources()
 
         calls = [
-            mock.call("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/applications.fiaas.schibsted.io", EXPECTED_APPLICATION),
-            mock.call("/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/application-statuses.fiaas.schibsted.io",
-                      EXPECTED_STATUS)
+            mock.call(
+                "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/applications.fiaas.schibsted.io",
+                EXPECTED_APPLICATION,
+            ),
+            mock.call(
+                "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/application-statuses.fiaas.schibsted.io",
+                EXPECTED_STATUS,
+            ),
         ]
         assert put.call_args_list == calls

--- a/tests/fiaas_deploy_daemon/crd/test_fiaasapplication.py
+++ b/tests/fiaas_deploy_daemon/crd/test_fiaasapplication.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +22,10 @@ from requests import Response
 
 from fiaas_deploy_daemon.crd.types import FiaasApplication, FiaasApplicationSpec
 
-RESOURCE = 'applications'
-NAMESPACE = 'my-namespace'
-NAME = 'my_name'
-API_VERSION = 'fiaas.schibsted.io/v1'
+RESOURCE = "applications"
+NAMESPACE = "my-namespace"
+NAME = "my_name"
+API_VERSION = "fiaas.schibsted.io/v1"
 API_BASE_PATH = "/apis/{api_version}/namespaces/{namespace}/{resource}/".format(
     api_version=API_VERSION, resource=RESOURCE, namespace=NAMESPACE
 )
@@ -53,21 +52,21 @@ class TestService(object):
             "kind": "Application",
             "apiVersion": API_VERSION,
             "metadata": _create_default_metadata().as_dict(),
-            "spec": _create_default_fiaasapplicationspec().as_dict()
+            "spec": _create_default_fiaasapplicationspec().as_dict(),
         }
         get.return_value = get_response
         get.side_effect = None
 
         spec = _create_default_fiaasapplicationspec(
-            replicas=2, host='example.org', ports=[{"protocol": 'tcp', "target_port": 1992}]
+            replicas=2, host="example.org", ports=[{"protocol": "tcp", "target_port": 1992}]
         )
         fiaas_app = FiaasApplication.get_or_create(metadata=_create_default_metadata(), spec=spec)
 
         assert not fiaas_app._new
         assert fiaas_app.spec.config["namespace"] == NAMESPACE
         assert fiaas_app.spec.config["replicas"] == 2
-        assert fiaas_app.spec.config["host"] == 'example.org'
-        assert fiaas_app.spec.config["ports"][0]["protocol"] == 'tcp'
+        assert fiaas_app.spec.config["host"] == "example.org"
+        assert fiaas_app.spec.config["ports"][0]["protocol"] == "tcp"
         assert fiaas_app.spec.config["ports"][0]["target_port"] == 1992
         expected_call = fiaas_app.as_dict()
         mock_response = mock.create_autospec(Response)
@@ -85,57 +84,26 @@ class TestService(object):
 
 def _create_default_fiaasapplicationspec(**kwargs):
     config = {
-        'version':
-            '2',
-        'namespace':
-            NAMESPACE,
-        'admin_access':
-            False,
-        'has_secrets':
-            True,
-        'secrets_in_environment':
-            False,
-        'replicas':
-            10,
-        'autoscaler': {
+        "version": "2",
+        "namespace": NAMESPACE,
+        "admin_access": False,
+        "has_secrets": True,
+        "secrets_in_environment": False,
+        "replicas": 10,
+        "autoscaler": {
             "enabled": True,
             "min_replicas": 2,
             "cpu_threshold_percentage": 75,
         },
-        'host':
-            'example.com',
-        'prometheus': {
-            'enabled': True, 'port': 'http', 'path': '/metrics/be/here'
-        },
-        'resources': {
-            'limits': {
-                'memory': '256M', 'cpu': '200m'
-            },
-            'requests': {
-                'memory': '128M', 'cpu': '100m'
-            }
-        },
-        'ports': [{
-            'protocol': 'http', 'target_port': 1337, 'path': '/my_name'
-        }],
-        'healthchecks': {
-            'liveness': {
-                'http': {
-                    'path': '/healthz', 'port': 'http', 'http_headers': {
-                        'X-Foo': 'bar'
-                    }
-                }
-            }
-        },
-        'config': {
-            'volume': False, 'envs': [
-                'CONFIG_THING',
-                'ANOTHER_CONFIG_THING'
-            ]
-        }
+        "host": "example.com",
+        "prometheus": {"enabled": True, "port": "http", "path": "/metrics/be/here"},
+        "resources": {"limits": {"memory": "256M", "cpu": "200m"}, "requests": {"memory": "128M", "cpu": "100m"}},
+        "ports": [{"protocol": "http", "target_port": 1337, "path": "/my_name"}],
+        "healthchecks": {"liveness": {"http": {"path": "/healthz", "port": "http", "http_headers": {"X-Foo": "bar"}}}},
+        "config": {"volume": False, "envs": ["CONFIG_THING", "ANOTHER_CONFIG_THING"]},
     }
     config.update(kwargs)
-    return FiaasApplicationSpec(application=NAME, image='example.com/group/image:tag', config=config)
+    return FiaasApplicationSpec(application=NAME, image="example.com/group/image:tag", config=config)
 
 
 def _create_default_metadata():

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/conftest.py
@@ -21,31 +21,28 @@ from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerRefere
 
 
 @pytest.helpers.register
-def create_metadata(app_name, namespace='default', labels=None, external=None,
-                    annotations=None, generation=None, owner_references=None):
+def create_metadata(
+    app_name, namespace="default", labels=None, external=None, annotations=None, generation=None, owner_references=None
+):
     if not labels:
-        labels = {
-            'app': app_name,
-            'fiaas/version': 'version',
-            'fiaas/deployed_by': '1'
-        }
+        labels = {"app": app_name, "fiaas/version": "version", "fiaas/deployed_by": "1"}
     metadata = {
-        'labels': labels,
-        'namespace': namespace,
-        'name': app_name,
-        'ownerReferences': [] if owner_references is None else owner_references,
-        'finalizers': [],
+        "labels": labels,
+        "namespace": namespace,
+        "name": app_name,
+        "ownerReferences": [] if owner_references is None else owner_references,
+        "finalizers": [],
     }
 
     if annotations is not None:
-        metadata['annotations'] = annotations.copy()
+        metadata["annotations"] = annotations.copy()
 
     if external is not None:
-        expose_annotations = {'fiaas/expose': str(external).lower()}
-        metadata.setdefault('annotations', {}).update(expose_annotations)
+        expose_annotations = {"fiaas/expose": str(external).lower()}
+        metadata.setdefault("annotations", {}).update(expose_annotations)
 
     if generation is not None:
-        metadata['generation'] = generation
+        metadata["generation"] = generation
     return metadata
 
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_prometheus.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_prometheus.py
@@ -44,21 +44,20 @@ class TestPrometheus(object):
         prometheus.apply(deployment, app_spec)
         assert expected == deployment
 
-    @pytest.mark.parametrize("port,expected_port,path", (
+    @pytest.mark.parametrize(
+        "port,expected_port,path",
+        (
             ("9999", "9999", "/_/metrics"),
             ("8080", "8080", "/internal-backstage/prometheus"),
             ("http", "8080", "/awesome"),
-    ))
+        ),
+    )
     def test_adds_annotations_when_enabled(self, prometheus, app_spec, deployment, port, expected_port, path):
         prometheus_spec = app_spec.prometheus._replace(port=port, path=path)
         app_spec = app_spec._replace(prometheus=prometheus_spec)
         original_annotations = deepcopy(deployment.spec.template.metadata.annotations)
         prometheus.apply(deployment, app_spec)
-        expected = {
-            "prometheus.io/scrape": "true",
-            "prometheus.io/port": expected_port,
-            "prometheus.io/path": path
-        }
+        expected = {"prometheus.io/scrape": "true", "prometheus.io/port": expected_port, "prometheus.io/path": path}
         annotations = deployment.spec.template.metadata.annotations
         for key in expected:
             assert expected[key] == annotations[key]

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_secrets.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/deployment/test_secrets.py
@@ -21,23 +21,32 @@ from k8s.models.deployment import Deployment, DeploymentSpec
 from k8s.models.pod import Container, PodSpec, PodTemplateSpec, EnvVar
 
 from fiaas_deploy_daemon import Configuration
-from fiaas_deploy_daemon.deployer.kubernetes.deployment import GenericInitSecrets, KubernetesSecrets, \
-    Secrets
+from fiaas_deploy_daemon.deployer.kubernetes.deployment import GenericInitSecrets, KubernetesSecrets, Secrets
 from fiaas_deploy_daemon.specs.models import StrongboxSpec, SecretsSpec
 
 CANARY_NAME = "DUMMY"
 CANARY_VALUE = "CANARY"
 SECRET_IMAGE = "fiaas/secret_image:version"
-STRONGBOX_IMAGE = 'fiaas/strongbox_image:version'
+STRONGBOX_IMAGE = "fiaas/strongbox_image:version"
 DEFAULT_IMAGE = "some/image:version"
 
-APP_SPEC_SECRETS = [SecretsSpec(type='some-provider', parameters={}, annotations={})]
+APP_SPEC_SECRETS = [SecretsSpec(type="some-provider", parameters={}, annotations={})]
 
 
 def _secrets_mode_ids(fixture_value):
-    generic_enabled, strongbox_enabled, app_strongbox_enabled, app_spec_secrets_enabled, default_enabled, _ = fixture_value
-    return "Generic:{!r:^5}, Strongbox: {!r:^5}, app_strongbox:{!r:^5}, app_spec_secrets:{!r:^5}, default:{!r:^5}".format(
-        generic_enabled, strongbox_enabled, app_strongbox_enabled, app_spec_secrets_enabled, default_enabled)
+    (
+        generic_enabled,
+        strongbox_enabled,
+        app_strongbox_enabled,
+        app_spec_secrets_enabled,
+        default_enabled,
+        _,
+    ) = fixture_value
+    return (
+        "Generic:{!r:^5}, Strongbox: {!r:^5}, app_strongbox:{!r:^5}, app_spec_secrets:{!r:^5}, default:{!r:^5}".format(
+            generic_enabled, strongbox_enabled, app_strongbox_enabled, app_spec_secrets_enabled, default_enabled
+        )
+    )
 
 
 @pytest.fixture
@@ -51,41 +60,44 @@ def deployment():
 
 
 class TestSecrets(object):
-    @pytest.fixture(params=[
-        # (Enable generic, Enable strongbox, app strongbox, app-spec secrets, default_secret Name of called mock)
-        (True, True, True, False, False, "generic_init_secrets"),
-        (True, True, True, False, True, "generic_init_secrets"),
-        (True, True, True, True, False, "generic_init_secrets"),
-        (True, True, True, True, True, "generic_init_secrets"),
-        (True, True, False, False, False, "generic_init_secrets"),
-        (True, True, False, False, True, "generic_init_secrets"),
-        (True, True, False, True, False, "generic_init_secrets"),
-        (True, True, False, True, True, "generic_init_secrets"),
-        (True, False, True, False, False, "generic_init_secrets"),
-        (True, False, True, False, True, "generic_init_secrets"),
-        (True, False, True, True, False, "generic_init_secrets"),
-        (True, False, True, True, True, "generic_init_secrets"),
-        (True, False, False, False, False, "generic_init_secrets"),
-        (True, False, False, False, True, "generic_init_secrets"),
-        (True, False, False, True, False, "generic_init_secrets"),
-        (True, False, False, True, True, "generic_init_secrets"),
-        (False, True, True, False, False, "generic_init_secrets"),
-        (False, True, True, False, True, "generic_init_secrets"),
-        (False, True, True, True, False, "generic_init_secrets"),
-        (False, True, True, True, True, "generic_init_secrets"),
-        (False, True, False, False, False, "kubernetes_secrets"),
-        (False, True, False, False, True, "generic_init_secrets"),
-        (False, True, False, True, False, "generic_init_secrets"),
-        (False, True, False, True, True, "generic_init_secrets"),
-        (False, False, True, False, False, "kubernetes_secrets"),
-        (False, False, True, False, True, "generic_init_secrets"),
-        (False, False, True, True, False, "generic_init_secrets"),
-        (False, False, True, True, True, "generic_init_secrets"),
-        (False, False, False, False, False, "kubernetes_secrets"),
-        (False, False, False, False, True, "generic_init_secrets"),
-        (False, False, False, True, False, "generic_init_secrets"),
-        (False, False, False, True, True, "generic_init_secrets"),
-    ], ids=_secrets_mode_ids)
+    @pytest.fixture(
+        params=[
+            # (Enable generic, Enable strongbox, app strongbox, app-spec secrets, default_secret Name of called mock)
+            (True, True, True, False, False, "generic_init_secrets"),
+            (True, True, True, False, True, "generic_init_secrets"),
+            (True, True, True, True, False, "generic_init_secrets"),
+            (True, True, True, True, True, "generic_init_secrets"),
+            (True, True, False, False, False, "generic_init_secrets"),
+            (True, True, False, False, True, "generic_init_secrets"),
+            (True, True, False, True, False, "generic_init_secrets"),
+            (True, True, False, True, True, "generic_init_secrets"),
+            (True, False, True, False, False, "generic_init_secrets"),
+            (True, False, True, False, True, "generic_init_secrets"),
+            (True, False, True, True, False, "generic_init_secrets"),
+            (True, False, True, True, True, "generic_init_secrets"),
+            (True, False, False, False, False, "generic_init_secrets"),
+            (True, False, False, False, True, "generic_init_secrets"),
+            (True, False, False, True, False, "generic_init_secrets"),
+            (True, False, False, True, True, "generic_init_secrets"),
+            (False, True, True, False, False, "generic_init_secrets"),
+            (False, True, True, False, True, "generic_init_secrets"),
+            (False, True, True, True, False, "generic_init_secrets"),
+            (False, True, True, True, True, "generic_init_secrets"),
+            (False, True, False, False, False, "kubernetes_secrets"),
+            (False, True, False, False, True, "generic_init_secrets"),
+            (False, True, False, True, False, "generic_init_secrets"),
+            (False, True, False, True, True, "generic_init_secrets"),
+            (False, False, True, False, False, "kubernetes_secrets"),
+            (False, False, True, False, True, "generic_init_secrets"),
+            (False, False, True, True, False, "generic_init_secrets"),
+            (False, False, True, True, True, "generic_init_secrets"),
+            (False, False, False, False, False, "kubernetes_secrets"),
+            (False, False, False, False, True, "generic_init_secrets"),
+            (False, False, False, True, False, "generic_init_secrets"),
+            (False, False, False, True, True, "generic_init_secrets"),
+        ],
+        ids=_secrets_mode_ids,
+    )
     def secrets_mode(self, request):
         yield request.param
 
@@ -122,18 +134,29 @@ class TestSecrets(object):
 
         return wrapped
 
-    def test_secret_selection(self, request, secrets_mode, secrets, deployment, app_spec,
-                              kubernetes_secrets, generic_init_secrets, config):
-        generic_enabled, strongbox_enabled, app_strongbox_enabled, app_spec_secrets_enabled, default_enabled, \
-            wanted_mock_name = secrets_mode
+    def test_secret_selection(
+        self, request, secrets_mode, secrets, deployment, app_spec, kubernetes_secrets, generic_init_secrets, config
+    ):
+        (
+            generic_enabled,
+            strongbox_enabled,
+            app_strongbox_enabled,
+            app_spec_secrets_enabled,
+            default_enabled,
+            wanted_mock_name,
+        ) = secrets_mode
 
-        generic_init_secrets.supports.side_effect = self.mock_supports(generic_enabled, strongbox_enabled, default_enabled)
+        generic_init_secrets.supports.side_effect = self.mock_supports(
+            generic_enabled, strongbox_enabled, default_enabled
+        )
 
         if not generic_enabled:
             assert config.secrets_init_container_image is None
 
         if app_strongbox_enabled:
-            strongbox = StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"])
+            strongbox = StrongboxSpec(
+                enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"]
+            )
         else:
             strongbox = StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None)
 
@@ -161,13 +184,13 @@ class TestSecrets(object):
         config.secrets_service_account_name = "secretsmanager"
 
         generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
-        generic_init_secrets.supports.side_effect = lambda _type: _type == 'default'
+        generic_init_secrets.supports.side_effect = lambda _type: _type == "default"
 
-        secrets = Secrets(config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets)
+        secrets = Secrets(
+            config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets
+        )
 
-        expected_spec = SecretsSpec(type="default",
-                                    parameters={},
-                                    annotations={})
+        expected_spec = SecretsSpec(type="default", parameters={}, annotations={})
 
         secrets.apply(deployment, app_spec)
 
@@ -178,16 +201,23 @@ class TestSecrets(object):
         config.strongbox_init_container_image = STRONGBOX_IMAGE
 
         app_spec = app_spec._replace(
-            strongbox=StrongboxSpec(enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"]))
+            strongbox=StrongboxSpec(
+                enabled=True, iam_role="iam_role", aws_region="eu-west-1", groups=["group1", "group2"]
+            )
+        )
 
         generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
-        generic_init_secrets.supports.side_effect = lambda _type: _type == 'strongbox'
+        generic_init_secrets.supports.side_effect = lambda _type: _type == "strongbox"
 
-        secrets = Secrets(config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets)
+        secrets = Secrets(
+            config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets
+        )
 
-        expected_spec = SecretsSpec(type="strongbox",
-                                    parameters={"AWS_REGION": "eu-west-1", "SECRET_GROUPS": "group1,group2"},
-                                    annotations={"iam.amazonaws.com/role": "iam_role"})
+        expected_spec = SecretsSpec(
+            type="strongbox",
+            parameters={"AWS_REGION": "eu-west-1", "SECRET_GROUPS": "group1,group2"},
+            annotations={"iam.amazonaws.com/role": "iam_role"},
+        )
 
         secrets.apply(deployment, app_spec)
 
@@ -197,7 +227,9 @@ class TestSecrets(object):
         config = mock.create_autospec(Configuration([]), spec_set=True)
         app_spec = app_spec._replace(secrets=APP_SPEC_SECRETS)
         generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
-        secrets = Secrets(config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets)
+        secrets = Secrets(
+            config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets
+        )
         expected_spec = APP_SPEC_SECRETS[0]
 
         secrets.apply(deployment, app_spec)
@@ -209,13 +241,13 @@ class TestSecrets(object):
         config.secret_init_containers = {"default": DEFAULT_IMAGE}
 
         generic_init_secrets = mock.create_autospec(GenericInitSecrets(config), spec_set=True, instance=True)
-        generic_init_secrets.supports.side_effect = lambda _type: _type == 'default'
+        generic_init_secrets.supports.side_effect = lambda _type: _type == "default"
 
-        secrets = Secrets(config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets)
+        secrets = Secrets(
+            config, mock.create_autospec(KubernetesSecrets(), spec_set=True, instance=True), generic_init_secrets
+        )
 
-        expected_spec = SecretsSpec(type="default",
-                                    parameters={},
-                                    annotations={})
+        expected_spec = SecretsSpec(type="default", parameters={}, annotations={})
 
         secrets.apply(deployment, app_spec)
 
@@ -248,17 +280,12 @@ class TestRegisteredInitSecrets(object):
     @pytest.fixture
     def generic_init_secrets(self):
         config = mock.create_autospec(Configuration([]), spec_set=True)
-        config.secret_init_containers = {
-            "default": "default-image",
-            "some-provider": "some-secret-container-image"
-        }
+        config.secret_init_containers = {"default": "default-image", "some-provider": "some-secret-container-image"}
         return GenericInitSecrets(config)
 
     @pytest.fixture
     def secrets_spec(self):
-        return SecretsSpec(type="some-provider",
-                           parameters={},
-                           annotations={})
+        return SecretsSpec(type="some-provider", parameters={}, annotations={})
 
     def test_init_container(self, deployment, app_spec, generic_init_secrets, secrets_spec):
         generic_init_secrets.apply(deployment, app_spec, secrets_spec)
@@ -289,11 +316,11 @@ class TestDefaultGenericInitSecrets(object):
 
     @pytest.fixture
     def secrets_spec(self):
-        return SecretsSpec(type="default",
-                           parameters={},
-                           annotations={})
+        return SecretsSpec(type="default", parameters={}, annotations={})
 
-    def test_main_container_volumes(self, deployment, app_spec, generic_init_secrets, use_in_memory_emptydirs, secrets_spec):
+    def test_main_container_volumes(
+        self, deployment, app_spec, generic_init_secrets, use_in_memory_emptydirs, secrets_spec
+    ):
         assert generic_init_secrets.supports("default")
         generic_init_secrets.apply(deployment, app_spec, secrets_spec)
 
@@ -343,9 +370,11 @@ class TestStrongboxSecrets(object):
 
     @pytest.fixture
     def secrets_spec(self, app_spec):
-        return SecretsSpec(type="strongbox",
-                           parameters={"AWS_REGION": self.AWS_REGION, "SECRET_GROUPS": self.GROUPS},
-                           annotations={"iam.amazonaws.com/role": self.IAM_ROLE})
+        return SecretsSpec(
+            type="strongbox",
+            parameters={"AWS_REGION": self.AWS_REGION, "SECRET_GROUPS": self.GROUPS},
+            annotations={"iam.amazonaws.com/role": self.IAM_ROLE},
+        )
 
     def test_environment(self, deployment, app_spec, strongbox_secrets, secrets_spec):
         assert strongbox_secrets.supports("strongbox")
@@ -366,7 +395,4 @@ class TestStrongboxSecrets(object):
         strongbox_secrets.apply(deployment, app_spec, secrets_spec)
 
         pod_metadata = deployment.spec.template.metadata
-        assert pod_metadata.annotations == {
-            CANARY_NAME: CANARY_VALUE,
-            "iam.amazonaws.com/role": self.IAM_ROLE
-        }
+        assert pod_metadata.annotations == {CANARY_NAME: CANARY_VALUE, "iam.amazonaws.com/role": self.IAM_ROLE}

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -27,22 +27,37 @@ from fiaas_deploy_daemon.extension_hook_caller import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration
 from fiaas_deploy_daemon.deployer.kubernetes.deployment import DeploymentDeployer, DataDog, Prometheus, Secrets
 from fiaas_deploy_daemon.deployer.kubernetes.deployment.deployer import _make_probe
-from fiaas_deploy_daemon.specs.models import CheckSpec, HttpCheckSpec, TcpCheckSpec, AutoscalerSpec, \
-    ResourceRequirementSpec, ResourcesSpec, ExecCheckSpec, HealthCheckSpec, LabelAndAnnotationSpec
+from fiaas_deploy_daemon.specs.models import (
+    CheckSpec,
+    HttpCheckSpec,
+    TcpCheckSpec,
+    AutoscalerSpec,
+    ResourceRequirementSpec,
+    ResourcesSpec,
+    ExecCheckSpec,
+    HealthCheckSpec,
+    LabelAndAnnotationSpec,
+)
 from fiaas_deploy_daemon.tools import merge_dicts
 
 from utils import TypeMatcher
 
-SELECTOR = {'app': 'testapp'}
+SELECTOR = {"app": "testapp"}
 LABELS = {"deployment_deployer": "pass through", "global_label": "impossible to override"}
-DEPLOYMENTS_URI = '/apis/apps/v1/namespaces/default/deployments/'
+DEPLOYMENTS_URI = "/apis/apps/v1/namespaces/default/deployments/"
 
 
 def test_make_http_probe():
-    check_spec = CheckSpec(http=HttpCheckSpec(path="/", port=8080,
-                                              http_headers={"Authorization": "ZmlubjpqdXN0aW5iaWViZXJfeG94bw=="}),
-                           tcp=None, execute=None, initial_delay_seconds=30, period_seconds=60, success_threshold=3,
-                           failure_threshold=3, timeout_seconds=10)
+    check_spec = CheckSpec(
+        http=HttpCheckSpec(path="/", port=8080, http_headers={"Authorization": "ZmlubjpqdXN0aW5iaWViZXJfeG94bw=="}),
+        tcp=None,
+        execute=None,
+        initial_delay_seconds=30,
+        period_seconds=60,
+        success_threshold=3,
+        failure_threshold=3,
+        timeout_seconds=10,
+    )
     probe = _make_probe(check_spec)
     assert probe.httpGet.path == "/"
     assert probe.httpGet.port == 8080
@@ -57,8 +72,16 @@ def test_make_http_probe():
 
 
 def test_make_tcp_probe():
-    check_spec = CheckSpec(tcp=TcpCheckSpec(port=31337), http=None, execute=None, initial_delay_seconds=30,
-                           period_seconds=60, success_threshold=3, failure_threshold=3, timeout_seconds=10)
+    check_spec = CheckSpec(
+        tcp=TcpCheckSpec(port=31337),
+        http=None,
+        execute=None,
+        initial_delay_seconds=30,
+        period_seconds=60,
+        success_threshold=3,
+        failure_threshold=3,
+        timeout_seconds=10,
+    )
     probe = _make_probe(check_spec)
     assert probe.tcpSocket.port == 31337
     assert probe.initialDelaySeconds == 30
@@ -68,8 +91,16 @@ def test_make_tcp_probe():
 
 
 def test_make_probe_should_fail_when_no_healthcheck_is_defined():
-    check_spec = CheckSpec(tcp=None, execute=None, http=None, initial_delay_seconds=30, period_seconds=60,
-                           success_threshold=3, failure_threshold=3, timeout_seconds=10)
+    check_spec = CheckSpec(
+        tcp=None,
+        execute=None,
+        http=None,
+        initial_delay_seconds=30,
+        period_seconds=60,
+        success_threshold=3,
+        failure_threshold=3,
+        timeout_seconds=10,
+    )
     with pytest.raises(RuntimeError):
         _make_probe(check_spec)
 
@@ -81,43 +112,61 @@ class Feature(enum.Enum):
 
 
 class TestDeploymentDeployer(object):
-    @pytest.fixture(params=(
-            None,
-            "test"
-    ))
+    @pytest.fixture(params=(None, "test"))
     def environment(self, request):
         yield request.param
 
-    @pytest.fixture(params=(
-        # key: (infrastructure, global_env, set[Feature]
-        ("gke", {}, {Feature.USE_IN_MEMORY_EMPTYDIRS, Feature.DISABLE_DEPRECATED_MANAGED_ENV_VARS}),
-        ("gke-w/service-per-acct", {}, {Feature.USE_IN_MEMORY_EMPTYDIRS, Feature.DISABLE_DEPRECATED_MANAGED_ENV_VARS,
-         Feature.ENABLE_SERVICE_ACCOUNT_PER_APP}),
-        ("diy", {
-            'A_GLOBAL_DIGIT': '0.01',
-            'A_GLOBAL_STRING': 'test',
-        }, {Feature.USE_IN_MEMORY_EMPTYDIRS, Feature.DISABLE_DEPRECATED_MANAGED_ENV_VARS}),
-        ("gke", {
-            'A_GLOBAL_DIGIT': '0.01',
-            'A_GLOBAL_STRING': 'test',
-            # Variables currently managed by FIAAS which should be possible to override via global_env
-            'CONSTRETTO_TAGS': 'override_constretto',
-            'FINN_ENV': 'override_finn_env',
-            'LOG_FORMAT': 'override_log_format',
-            'LOG_STDOUT': 'false',
-            'FIAAS_ENVIRONMENT': 'override_environment',
-            'FIAAS_INFRASTRUCTURE': 'override_infrastructure',
-        }, set()),
-        ("diy", {
-            'A_GLOBAL_DIGIT': '0.01',
-            'A_GLOBAL_STRING': 'test',
-            # global_env variables are added as is and also with the key prefix FIAAS_ - ensure it works to override
-            # the following variables even if FIAAS_ prefixed keys clash with the environment and infrastructure
-            # derived FIAAS_INFRASTRUCTURE and FIAAS_ENVIRONMENT
-            'ENVIRONMENT': 'override_fiaas_environment',
-            'INFRASTRUCTURE': 'override_fiaas_infrastructure',
-        }, {Feature.USE_IN_MEMORY_EMPTYDIRS})
-    ))
+    @pytest.fixture(
+        params=(
+            # key: (infrastructure, global_env, set[Feature]
+            ("gke", {}, {Feature.USE_IN_MEMORY_EMPTYDIRS, Feature.DISABLE_DEPRECATED_MANAGED_ENV_VARS}),
+            (
+                "gke-w/service-per-acct",
+                {},
+                {
+                    Feature.USE_IN_MEMORY_EMPTYDIRS,
+                    Feature.DISABLE_DEPRECATED_MANAGED_ENV_VARS,
+                    Feature.ENABLE_SERVICE_ACCOUNT_PER_APP,
+                },
+            ),
+            (
+                "diy",
+                {
+                    "A_GLOBAL_DIGIT": "0.01",
+                    "A_GLOBAL_STRING": "test",
+                },
+                {Feature.USE_IN_MEMORY_EMPTYDIRS, Feature.DISABLE_DEPRECATED_MANAGED_ENV_VARS},
+            ),
+            (
+                "gke",
+                {
+                    "A_GLOBAL_DIGIT": "0.01",
+                    "A_GLOBAL_STRING": "test",
+                    # Variables currently managed by FIAAS which should be possible to override via global_env
+                    "CONSTRETTO_TAGS": "override_constretto",
+                    "FINN_ENV": "override_finn_env",
+                    "LOG_FORMAT": "override_log_format",
+                    "LOG_STDOUT": "false",
+                    "FIAAS_ENVIRONMENT": "override_environment",
+                    "FIAAS_INFRASTRUCTURE": "override_infrastructure",
+                },
+                set(),
+            ),
+            (
+                "diy",
+                {
+                    "A_GLOBAL_DIGIT": "0.01",
+                    "A_GLOBAL_STRING": "test",
+                    # global_env variables are added as is and also with the key prefix FIAAS_ - ensure it works to override
+                    # the following variables even if FIAAS_ prefixed keys clash with the environment and infrastructure
+                    # derived FIAAS_INFRASTRUCTURE and FIAAS_ENVIRONMENT
+                    "ENVIRONMENT": "override_fiaas_environment",
+                    "INFRASTRUCTURE": "override_fiaas_infrastructure",
+                },
+                {Feature.USE_IN_MEMORY_EMPTYDIRS},
+            ),
+        )
+    )
     def config(self, request, environment):
         infra, global_env, features = request.param
         config = mock.create_autospec(Configuration([]), spec_set=True)
@@ -134,29 +183,65 @@ class TestDeploymentDeployer(object):
         config.enable_service_account_per_app = Feature.ENABLE_SERVICE_ACCOUNT_PER_APP in features
         yield config
 
-    @pytest.fixture(params=(
-            (True, {"foo": "bar", "global_label": "attempt to override"}, {"bar": "baz"},
-             {"bar": "foo", "global_label": "attempt to override"}, {"quux": "bax"}, False),
+    @pytest.fixture(
+        params=(
+            (
+                True,
+                {"foo": "bar", "global_label": "attempt to override"},
+                {"bar": "baz"},
+                {"bar": "foo", "global_label": "attempt to override"},
+                {"quux": "bax"},
+                False,
+            ),
             (True, {}, {"bar": "baz"}, {"foo": "bar"}, {}, False),
-            (True, {"foo": "bar"}, {}, {}, {"bar": "baz"}, True,),
+            (
+                True,
+                {"foo": "bar"},
+                {},
+                {},
+                {"bar": "baz"},
+                True,
+            ),
             (False, {}, {}, {}, {}, True),
-    ))
+        )
+    )
     def app_spec(self, request, app_spec):
         generic_toggle, deploy_labels, deploy_annotations, pod_labels, pod_annotations, singleton = request.param
 
-        labels = LabelAndAnnotationSpec(deployment=deploy_labels, horizontal_pod_autoscaler={}, ingress={},
-                                        service={}, service_account={}, pod=pod_labels, status={})
-        annotations = LabelAndAnnotationSpec(deployment=deploy_annotations, horizontal_pod_autoscaler={}, ingress={},
-                                             service={}, service_account={}, pod=pod_annotations, status={})
+        labels = LabelAndAnnotationSpec(
+            deployment=deploy_labels,
+            horizontal_pod_autoscaler={},
+            ingress={},
+            service={},
+            service_account={},
+            pod=pod_labels,
+            status={},
+        )
+        annotations = LabelAndAnnotationSpec(
+            deployment=deploy_annotations,
+            horizontal_pod_autoscaler={},
+            ingress={},
+            service={},
+            service_account={},
+            pod=pod_annotations,
+            status={},
+        )
 
         if generic_toggle:
             ports = app_spec.ports
             health_checks = app_spec.health_checks
         else:
             ports = []
-            exec_check = CheckSpec(http=None, tcp=None, execute=ExecCheckSpec(command="/app/check.sh"),
-                                   initial_delay_seconds=10, period_seconds=10, success_threshold=1,
-                                   failure_threshold=3, timeout_seconds=1)
+            exec_check = CheckSpec(
+                http=None,
+                tcp=None,
+                execute=ExecCheckSpec(command="/app/check.sh"),
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            )
             health_checks = HealthCheckSpec(liveness=exec_check, readiness=exec_check)
 
         yield app_spec._replace(
@@ -185,21 +270,23 @@ class TestDeploymentDeployer(object):
         return mock.create_autospec(ExtensionHookCaller, spec_set=True, instance=True)
 
     @pytest.mark.usefixtures("get")
-    def test_managed_environment_variables(self, post, config, app_spec, datadog, prometheus, secrets,
-                                           owner_references, extension_hook):
+    def test_managed_environment_variables(
+        self, post, config, app_spec, datadog, prometheus, secrets, owner_references, extension_hook
+    ):
         deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references, extension_hook)
         env = deployer._make_env(app_spec)
         env_keys = [var.name for var in env]
-        assert 'FIAAS_ARTIFACT_NAME' in env_keys
-        assert 'FIAAS_IMAGE' in env_keys
-        assert 'FIAAS_VERSION' in env_keys
-        assert ('ARTIFACT_NAME' not in env_keys) == config.disable_deprecated_managed_env_vars
-        assert ('IMAGE' not in env_keys) == config.disable_deprecated_managed_env_vars
-        assert ('VERSION' not in env_keys) == config.disable_deprecated_managed_env_vars
+        assert "FIAAS_ARTIFACT_NAME" in env_keys
+        assert "FIAAS_IMAGE" in env_keys
+        assert "FIAAS_VERSION" in env_keys
+        assert ("ARTIFACT_NAME" not in env_keys) == config.disable_deprecated_managed_env_vars
+        assert ("IMAGE" not in env_keys) == config.disable_deprecated_managed_env_vars
+        assert ("VERSION" not in env_keys) == config.disable_deprecated_managed_env_vars
 
     @pytest.mark.usefixtures("get")
-    def test_deploy_new_deployment(self, post, config, app_spec, datadog, prometheus, secrets, owner_references,
-                                   extension_hook):
+    def test_deploy_new_deployment(
+        self, post, config, app_spec, datadog, prometheus, secrets, owner_references, extension_hook
+    ):
         expected_deployment = create_expected_deployment(config, app_spec)
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_deployment
@@ -216,8 +303,9 @@ class TestDeploymentDeployer(object):
         owner_references.apply.assert_called_with(TypeMatcher(Deployment), app_spec)
         extension_hook.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
 
-    def test_deploy_clears_alpha_beta_annotations(self, put, get, config, app_spec, datadog, prometheus, secrets,
-                                                  owner_references, extension_hook):
+    def test_deploy_clears_alpha_beta_annotations(
+        self, put, get, config, app_spec, datadog, prometheus, secrets, owner_references, extension_hook
+    ):
         old_strongbox_spec = app_spec.strongbox._replace(enabled=True, groups=["group1", "group2"])
         old_app_spec = app_spec._replace(strongbox=old_strongbox_spec)
         old_deployment = create_expected_deployment(config, old_app_spec, add_init_container_annotations=True)
@@ -241,105 +329,123 @@ class TestDeploymentDeployer(object):
         secrets.apply.assert_called_once_with(DeploymentMatcher(), app_spec)
         extension_hook.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
 
-    @pytest.mark.parametrize("previous_replicas,max_replicas,min_replicas,cpu_request,expected_replicas", (
+    @pytest.mark.parametrize(
+        "previous_replicas,max_replicas,min_replicas,cpu_request,expected_replicas",
+        (
             (5, 3, 2, None, 2),
             (5, 3, 2, "1", 5),
             (0, 3, 2, "1", 2),
-    ))
-    def test_replicas_when_autoscaler_enabled(self, previous_replicas, max_replicas, min_replicas, cpu_request,
-                                              expected_replicas, config, app_spec, get, put, post, datadog, prometheus,
-                                              secrets, owner_references, extension_hook):
+        ),
+    )
+    def test_replicas_when_autoscaler_enabled(
+        self,
+        previous_replicas,
+        max_replicas,
+        min_replicas,
+        cpu_request,
+        expected_replicas,
+        config,
+        app_spec,
+        get,
+        put,
+        post,
+        datadog,
+        prometheus,
+        secrets,
+        owner_references,
+        extension_hook,
+    ):
         deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references, extension_hook)
 
         image = "finntech/testimage:version2"
         version = "version2"
         app_spec = app_spec._replace(
-            autoscaler=AutoscalerSpec(enabled=True, min_replicas=min_replicas, max_replicas=max_replicas, cpu_threshold_percentage=50),
-            image=image)
+            autoscaler=AutoscalerSpec(
+                enabled=True, min_replicas=min_replicas, max_replicas=max_replicas, cpu_threshold_percentage=50
+            ),
+            image=image,
+        )
         if cpu_request:
             app_spec = app_spec._replace(
                 resources=ResourcesSpec(
                     requests=ResourceRequirementSpec(cpu=cpu_request, memory=None),
-                    limits=ResourceRequirementSpec(cpu=None, memory=None)))
+                    limits=ResourceRequirementSpec(cpu=None, memory=None),
+                )
+            )
 
         expected_volumes = _get_expected_volumes(app_spec)
         expected_volume_mounts = _get_expected_volume_mounts(app_spec)
 
         mock_response = create_autospec(Response)
         mock_response.json.return_value = {
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS),
-            'spec': {
-                'selector': {'matchLabels': SELECTOR},
-                'template': {
-                    'spec': {
-                        'dnsPolicy': 'ClusterFirst',
-                        'automountServiceAccountToken': False,
-                        'serviceAccountName': 'default',
-                        'terminationGracePeriodSeconds': 31,
-                        'restartPolicy': 'Always',
-                        'volumes': expected_volumes,
-                        'imagePullSecrets': [],
-                        'strategy': {
-                            'type': 'rollingUpdate',
-                            'rollingUpdate': {
-                                'maxSurge': '25%',
-                                'maxUnavailable': 0
-                            },
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
+            "spec": {
+                "selector": {"matchLabels": SELECTOR},
+                "template": {
+                    "spec": {
+                        "dnsPolicy": "ClusterFirst",
+                        "automountServiceAccountToken": False,
+                        "serviceAccountName": "default",
+                        "terminationGracePeriodSeconds": 31,
+                        "restartPolicy": "Always",
+                        "volumes": expected_volumes,
+                        "imagePullSecrets": [],
+                        "strategy": {
+                            "type": "rollingUpdate",
+                            "rollingUpdate": {"maxSurge": "25%", "maxUnavailable": 0},
                         },
-                        'containers': [{
-                            'livenessProbe': {
-                                'initialDelaySeconds': 10,
-                                'periodSeconds': 10,
-                                'successThreshold': 1,
-                                'failureThreshold': 3,
-                                'timeoutSeconds': 1,
-                                'tcpSocket': {
-                                    'port': 8080
-                                }
-                            },
-                            'name': 'testapp',
-                            'image': 'finntech/testimage:version',
-                            'volumeMounts': expected_volume_mounts,
-                            'command': [],
-                            'args': [],
-                            'env': create_environment_variables(config,
-                                                                global_env=config.global_env,
-                                                                environment=config.environment),
-                            'envFrom': [{
-                                'configMapRef': {
-                                    'name': app_spec.name,
-                                    'optional': True,
-                                }
-                            }],
-                            'imagePullPolicy': 'IfNotPresent',
-                            'readinessProbe': {
-                                'initialDelaySeconds': 10,
-                                'periodSeconds': 10,
-                                'successThreshold': 1,
-                                'failureThreshold': 3,
-                                'timeoutSeconds': 1,
-                                'httpGet': {
-                                    'path': '/',
-                                    'scheme': 'HTTP',
-                                    'port': 8080,
-                                    'httpHeaders': []
-                                }
-                            },
-                            'ports': [{'protocol': 'TCP', 'containerPort': 8080, 'name': 'http'}],
-                            'resources': {}
-                        }]
+                        "containers": [
+                            {
+                                "livenessProbe": {
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3,
+                                    "timeoutSeconds": 1,
+                                    "tcpSocket": {"port": 8080},
+                                },
+                                "name": "testapp",
+                                "image": "finntech/testimage:version",
+                                "volumeMounts": expected_volume_mounts,
+                                "command": [],
+                                "args": [],
+                                "env": create_environment_variables(
+                                    config, global_env=config.global_env, environment=config.environment
+                                ),
+                                "envFrom": [
+                                    {
+                                        "configMapRef": {
+                                            "name": app_spec.name,
+                                            "optional": True,
+                                        }
+                                    }
+                                ],
+                                "imagePullPolicy": "IfNotPresent",
+                                "readinessProbe": {
+                                    "initialDelaySeconds": 10,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3,
+                                    "timeoutSeconds": 1,
+                                    "httpGet": {"path": "/", "scheme": "HTTP", "port": 8080, "httpHeaders": []},
+                                },
+                                "ports": [{"protocol": "TCP", "containerPort": 8080, "name": "http"}],
+                                "resources": {},
+                            }
+                        ],
                     },
-                    'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS)
+                    "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
                 },
-                'replicas': previous_replicas,
-                'revisionHistoryLimit': 5
-            }
+                "replicas": previous_replicas,
+                "revisionHistoryLimit": 5,
+            },
         }
         get.side_effect = None
         get.return_value = mock_response
 
-        expected_deployment = create_expected_deployment(config, app_spec, image=image, version=version,
-                                                         replicas=expected_replicas)
+        expected_deployment = create_expected_deployment(
+            config, app_spec, image=image, version=version, replicas=expected_replicas
+        )
         put_mock_response = create_autospec(Response)
         put_mock_response.json.return_value = expected_deployment
         put.side_effect = None
@@ -355,52 +461,50 @@ class TestDeploymentDeployer(object):
         extension_hook.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
 
 
-def create_expected_deployment(config,
-                               app_spec,
-                               image='finntech/testimage:version',
-                               version="version",
-                               replicas=None,
-                               add_init_container_annotations=False):
+def create_expected_deployment(
+    config,
+    app_spec,
+    image="finntech/testimage:version",
+    version="version",
+    replicas=None,
+    add_init_container_annotations=False,
+):
     expected_volumes = _get_expected_volumes(app_spec, config.use_in_memory_emptydirs)
     expected_volume_mounts = _get_expected_volume_mounts(app_spec)
     service_account = app_spec.name if config.enable_service_account_per_app else "default"
 
     base_expected_health_check = {
-        'initialDelaySeconds': 10,
-        'periodSeconds': 10,
-        'successThreshold': 1,
-        'failureThreshold': 3,
-        'timeoutSeconds': 1,
+        "initialDelaySeconds": 10,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+        "timeoutSeconds": 1,
     }
     if app_spec.ports:
-        expected_liveness_check = merge_dicts(base_expected_health_check, {
-            'tcpSocket': {
-                'port': 8080
-            }
-        })
-        expected_readiness_check = merge_dicts(base_expected_health_check, {
-            'httpGet': {
-                'path': '/',
-                'scheme': 'HTTP',
-                'port': 8080,
-                'httpHeaders': []
-            }
-        })
+        expected_liveness_check = merge_dicts(base_expected_health_check, {"tcpSocket": {"port": 8080}})
+        expected_readiness_check = merge_dicts(
+            base_expected_health_check, {"httpGet": {"path": "/", "scheme": "HTTP", "port": 8080, "httpHeaders": []}}
+        )
     else:
-        exec_check = merge_dicts(base_expected_health_check, {
-            'exec': {
-                'command': ['/app/check.sh'],
-            }
-        })
+        exec_check = merge_dicts(
+            base_expected_health_check,
+            {
+                "exec": {
+                    "command": ["/app/check.sh"],
+                }
+            },
+        )
         expected_liveness_check = exec_check
         expected_readiness_check = exec_check
 
-    expected_env_from = [{
-        'configMapRef': {
-            'name': app_spec.name,
-            'optional': True,
+    expected_env_from = [
+        {
+            "configMapRef": {
+                "name": app_spec.name,
+                "optional": True,
+            }
         }
-    }]
+    ]
 
     resources = defaultdict(dict)
     if app_spec.resources.limits.cpu:
@@ -413,35 +517,33 @@ def create_expected_deployment(config,
         resources["requests"]["memory"] = app_spec.resources.requests.memory
     resources = dict(resources)
 
-    containers = [{
-        'livenessProbe': expected_liveness_check,
-        'name': app_spec.name,
-        'image': image,
-        'volumeMounts': expected_volume_mounts,
-        'lifecycle': {
-            'preStop': {
-                'exec': {
-                    'command': ['sleep', '1']
-                }
-            }
-        },
-        'command': [],
-        'args': [],
-        'env': create_environment_variables(config, global_env=config.global_env,
-                                            version=version, environment=config.environment),
-        'envFrom': expected_env_from,
-        'imagePullPolicy': 'IfNotPresent',
-        'readinessProbe': expected_readiness_check,
-        'ports': [{'protocol': 'TCP', 'containerPort': 8080, 'name': 'http'}] if app_spec.ports else [],
-        'resources': resources,
-    }]
+    containers = [
+        {
+            "livenessProbe": expected_liveness_check,
+            "name": app_spec.name,
+            "image": image,
+            "volumeMounts": expected_volume_mounts,
+            "lifecycle": {"preStop": {"exec": {"command": ["sleep", "1"]}}},
+            "command": [],
+            "args": [],
+            "env": create_environment_variables(
+                config, global_env=config.global_env, version=version, environment=config.environment
+            ),
+            "envFrom": expected_env_from,
+            "imagePullPolicy": "IfNotPresent",
+            "readinessProbe": expected_readiness_check,
+            "ports": [{"protocol": "TCP", "containerPort": 8080, "name": "http"}] if app_spec.ports else [],
+            "resources": resources,
+        }
+    ]
     deployment_annotations = app_spec.annotations.deployment if app_spec.annotations.deployment else None
 
     pod_annotations = app_spec.annotations.pod if app_spec.annotations.pod else {}
-    init_container_annotations = {
-        "pod.alpha.kubernetes.io/init-containers": 'some data',
-        "pod.beta.kubernetes.io/init-containers": 'some data'
-    } if add_init_container_annotations else {}
+    init_container_annotations = (
+        {"pod.alpha.kubernetes.io/init-containers": "some data", "pod.beta.kubernetes.io/init-containers": "some data"}
+        if add_init_container_annotations
+        else {}
+    )
     pod_annotations = _none_if_empty(merge_dicts(pod_annotations, init_container_annotations))
 
     max_surge = "25%"
@@ -451,84 +553,105 @@ def create_expected_deployment(config,
         max_unavailable = 1
 
     deployment = {
-        'metadata': pytest.helpers.create_metadata(app_spec.name,
-                                                   labels=merge_dicts(app_spec.labels.deployment, LABELS),
-                                                   annotations=deployment_annotations),
-        'spec': {
-            'selector': {'matchLabels': SELECTOR},
-            'template': {
-                'spec': {
-                    'dnsPolicy': 'ClusterFirst',
-                    'automountServiceAccountToken': app_spec.admin_access,
-                    'serviceAccountName': service_account,
-                    'terminationGracePeriodSeconds': 31,
-                    'restartPolicy': 'Always',
-                    'volumes': expected_volumes,
-                    'imagePullSecrets': [],
-                    'containers': containers,
-                    'initContainers': []
+        "metadata": pytest.helpers.create_metadata(
+            app_spec.name, labels=merge_dicts(app_spec.labels.deployment, LABELS), annotations=deployment_annotations
+        ),
+        "spec": {
+            "selector": {"matchLabels": SELECTOR},
+            "template": {
+                "spec": {
+                    "dnsPolicy": "ClusterFirst",
+                    "automountServiceAccountToken": app_spec.admin_access,
+                    "serviceAccountName": service_account,
+                    "terminationGracePeriodSeconds": 31,
+                    "restartPolicy": "Always",
+                    "volumes": expected_volumes,
+                    "imagePullSecrets": [],
+                    "containers": containers,
+                    "initContainers": [],
                 },
-                'metadata': pytest.helpers.create_metadata(app_spec.name,
-                                                           labels=_get_expected_template_labels(app_spec.labels.pod),
-                                                           annotations=pod_annotations)
+                "metadata": pytest.helpers.create_metadata(
+                    app_spec.name,
+                    labels=_get_expected_template_labels(app_spec.labels.pod),
+                    annotations=pod_annotations,
+                ),
             },
-            'replicas': replicas if replicas else app_spec.autoscaler.min_replicas,
-            'revisionHistoryLimit': 5,
-            'strategy': {
-                'type': 'RollingUpdate',
-                'rollingUpdate': {
-                    'maxSurge': max_surge,
-                    'maxUnavailable': max_unavailable
-                }
-            }
-        }
+            "replicas": replicas if replicas else app_spec.autoscaler.min_replicas,
+            "revisionHistoryLimit": 5,
+            "strategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"maxSurge": max_surge, "maxUnavailable": max_unavailable},
+            },
+        },
     }
     return deployment
 
 
 def create_environment_variables(config, global_env=None, version="version", environment=None):
     _env_variables = {
-        'LOG_STDOUT': 'true',
-        'FIAAS_INFRASTRUCTURE': config.infrastructure,
-        'LOG_FORMAT': 'json',
-        'CONSTRETTO_TAGS': _create_constretto_tag(environment),
+        "LOG_STDOUT": "true",
+        "FIAAS_INFRASTRUCTURE": config.infrastructure,
+        "LOG_FORMAT": "json",
+        "CONSTRETTO_TAGS": _create_constretto_tag(environment),
     }
 
     _managed_env_variables = {
-        'FIAAS_ARTIFACT_NAME': 'testapp',
-        'FIAAS_VERSION': version,
-        'FIAAS_IMAGE': 'finntech/testimage:' + version,
+        "FIAAS_ARTIFACT_NAME": "testapp",
+        "FIAAS_VERSION": version,
+        "FIAAS_IMAGE": "finntech/testimage:" + version,
     }
     if not config.disable_deprecated_managed_env_vars:
-        _managed_env_variables.update({
-            'ARTIFACT_NAME': 'testapp',
-            'VERSION': version,
-            'IMAGE': 'finntech/testimage:' + version,
-        })
+        _managed_env_variables.update(
+            {
+                "ARTIFACT_NAME": "testapp",
+                "VERSION": version,
+                "IMAGE": "finntech/testimage:" + version,
+            }
+        )
     _env_variables.update(_managed_env_variables)
 
     if environment:
-        _env_variables.update({
-            'FIAAS_ENVIRONMENT': environment,
-            'FINN_ENV': environment,
-        })
+        _env_variables.update(
+            {
+                "FIAAS_ENVIRONMENT": environment,
+                "FINN_ENV": environment,
+            }
+        )
 
     if global_env:
         _env_variables.update(global_env)
         _env_variables.update({"FIAAS_{}".format(k): v for k, v in list(global_env.items())})
 
-    env = [{'name': k, 'value': v} for k, v in list(_env_variables.items())]
+    env = [{"name": k, "value": v} for k, v in list(_env_variables.items())]
 
-    env.append({'name': 'FIAAS_REQUESTS_CPU', 'valueFrom': {'resourceFieldRef': {
-        'containerName': 'testapp', 'resource': 'requests.cpu', 'divisor': 1}}})
-    env.append({'name': 'FIAAS_REQUESTS_MEMORY', 'valueFrom': {'resourceFieldRef': {
-        'containerName': 'testapp', 'resource': 'requests.memory', 'divisor': 1}}})
-    env.append({'name': 'FIAAS_LIMITS_CPU', 'valueFrom': {'resourceFieldRef': {
-        'containerName': 'testapp', 'resource': 'limits.cpu', 'divisor': 1}}})
-    env.append({'name': 'FIAAS_LIMITS_MEMORY', 'valueFrom': {'resourceFieldRef': {
-        'containerName': 'testapp', 'resource': 'limits.memory', 'divisor': 1}}})
-    env.append({'name': 'FIAAS_NAMESPACE', 'valueFrom': {'fieldRef': {'fieldPath': 'metadata.namespace'}}})
-    env.append({'name': 'FIAAS_POD_NAME', 'valueFrom': {'fieldRef': {'fieldPath': 'metadata.name'}}})
+    env.append(
+        {
+            "name": "FIAAS_REQUESTS_CPU",
+            "valueFrom": {"resourceFieldRef": {"containerName": "testapp", "resource": "requests.cpu", "divisor": 1}},
+        }
+    )
+    env.append(
+        {
+            "name": "FIAAS_REQUESTS_MEMORY",
+            "valueFrom": {
+                "resourceFieldRef": {"containerName": "testapp", "resource": "requests.memory", "divisor": 1}
+            },
+        }
+    )
+    env.append(
+        {
+            "name": "FIAAS_LIMITS_CPU",
+            "valueFrom": {"resourceFieldRef": {"containerName": "testapp", "resource": "limits.cpu", "divisor": 1}},
+        }
+    )
+    env.append(
+        {
+            "name": "FIAAS_LIMITS_MEMORY",
+            "valueFrom": {"resourceFieldRef": {"containerName": "testapp", "resource": "limits.memory", "divisor": 1}},
+        }
+    )
+    env.append({"name": "FIAAS_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}})
+    env.append({"name": "FIAAS_POD_NAME", "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}})
 
     env.sort(key=lambda x: x["name"])
     return env
@@ -536,8 +659,8 @@ def create_environment_variables(config, global_env=None, version="version", env
 
 def _create_constretto_tag(environment):
     if environment:
-        return 'kubernetes-{},kubernetes,{}'.format(environment, environment)
-    return 'kubernetes'
+        return "kubernetes-{},kubernetes,{}".format(environment, environment)
+    return "kubernetes"
 
 
 def _get_expected_template_labels(custom_labels):
@@ -546,31 +669,22 @@ def _get_expected_template_labels(custom_labels):
 
 def _get_expected_volumes(app_spec, use_in_memory_emptydirs=False):
     config_map_volume = {
-        'name': "{}-config".format(app_spec.name),
-        'configMap': {
-            'name': app_spec.name,
-            'optional': True
-        }
+        "name": "{}-config".format(app_spec.name),
+        "configMap": {"name": app_spec.name, "optional": True},
     }
-    tmp_volume = {
-        'name': "tmp"
-    }
+    tmp_volume = {"name": "tmp"}
     if use_in_memory_emptydirs:
-        tmp_volume["emptyDir"] = {'medium': "Memory"}
+        tmp_volume["emptyDir"] = {"medium": "Memory"}
     return [config_map_volume, tmp_volume]
 
 
 def _get_expected_volume_mounts(app_spec):
     config_map_volume_mount = {
-        'name': "{}-config".format(app_spec.name),
-        'readOnly': True,
-        'mountPath': '/var/run/config/fiaas/'
+        "name": "{}-config".format(app_spec.name),
+        "readOnly": True,
+        "mountPath": "/var/run/config/fiaas/",
     }
-    tmp_volume_mount = {
-        'name': "tmp",
-        'readOnly': False,
-        'mountPath': "/tmp"
-    }
+    tmp_volume_mount = {"name": "tmp", "readOnly": False, "mountPath": "/tmp"}
     return [config_map_volume_mount, tmp_volume_mount]
 
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -25,17 +25,31 @@ from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
 from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTLSDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.ingress_v1beta1 import V1Beta1IngressAdapter
-from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
-    ResourcesSpec, PrometheusSpec, DatadogSpec, \
-    PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec
+from fiaas_deploy_daemon.specs.models import (
+    AppSpec,
+    ResourceRequirementSpec,
+    ResourcesSpec,
+    PrometheusSpec,
+    DatadogSpec,
+    PortSpec,
+    CheckSpec,
+    HttpCheckSpec,
+    TcpCheckSpec,
+    HealthCheckSpec,
+    AutoscalerSpec,
+    LabelAndAnnotationSpec,
+    IngressItemSpec,
+    IngressPathMappingSpec,
+    StrongboxSpec,
+    IngressTLSSpec,
+)
 
 from utils import TypeMatcher
 
 LABELS = {"ingress_deployer": "pass through", "app": "testapp", "fiaas/deployment_id": "12345"}
 ANNOTATIONS = {"some/annotation": "val"}
 LABEL_SELECTOR_PARAMS = {"labelSelector": "app=testapp,fiaas/deployment_id,fiaas/deployment_id!=12345"}
-INGRESSES_URI = '/apis/extensions/v1beta1/namespaces/default/ingresses/'
+INGRESSES_URI = "/apis/extensions/v1beta1/namespaces/default/ingresses/"
 DEFAULT_TLS_ISSUER = "certmanager.k8s.io/cluster-issuer"
 DEFAULT_TLS_ANNOTATIONS = {"certmanager.k8s.io/cluster-issuer": "letsencrypt"}
 
@@ -47,27 +61,47 @@ def app_spec(**kwargs):
         namespace="default",
         image="finntech/testimage:version",
         autoscaler=AutoscalerSpec(enabled=False, min_replicas=2, max_replicas=3, cpu_threshold_percentage=50),
-        resources=ResourcesSpec(requests=ResourceRequirementSpec(cpu=None, memory=None),
-                                limits=ResourceRequirementSpec(cpu=None, memory=None)),
+        resources=ResourcesSpec(
+            requests=ResourceRequirementSpec(cpu=None, memory=None),
+            limits=ResourceRequirementSpec(cpu=None, memory=None),
+        ),
         admin_access=False,
         secrets_in_environment=False,
-        prometheus=PrometheusSpec(enabled=True, port='http', path='/internal-backstage/prometheus'),
+        prometheus=PrometheusSpec(enabled=True, port="http", path="/internal-backstage/prometheus"),
         datadog=DatadogSpec(enabled=False, tags={}),
         ports=[
             PortSpec(protocol="http", name="http", port=80, target_port=8080),
         ],
         health_checks=HealthCheckSpec(
-            liveness=CheckSpec(tcp=TcpCheckSpec(port=8080), http=None, execute=None, initial_delay_seconds=10,
-                               period_seconds=10, success_threshold=1, failure_threshold=3, timeout_seconds=1),
-            readiness=CheckSpec(http=HttpCheckSpec(path="/", port=8080, http_headers={}), tcp=None, execute=None,
-                                initial_delay_seconds=10, period_seconds=10, success_threshold=1,
-                                failure_threshold=3, timeout_seconds=1)),
-        teams=['foo'],
-        tags=['bar'],
+            liveness=CheckSpec(
+                tcp=TcpCheckSpec(port=8080),
+                http=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+            readiness=CheckSpec(
+                http=HttpCheckSpec(path="/", port=8080, http_headers={}),
+                tcp=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+        ),
+        teams=["foo"],
+        tags=["bar"],
         deployment_id="test_app_deployment_id",
         labels=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}, {}),
         annotations=LabelAndAnnotationSpec({}, {}, ANNOTATIONS.copy(), {}, {}, {}, {}),
-        ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
+        ingresses=[
+            IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})
+        ],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
         ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
@@ -79,37 +113,43 @@ def app_spec(**kwargs):
 
 
 def ingress(rules=None, metadata=None, expose=False, tls=None):
-    default_rules = [{
-        'host': "testapp.svc.test.example.com",
-        'http': {
-            'paths': [{
-                'path': '/',
-                'backend': {
-                    'serviceName': 'testapp',
-                    'servicePort': 80,
-                }
-            }]
-        }
-    }, {
-        'host': "testapp.127.0.0.1.xip.io",
-        'http': {
-            'paths': [{
-                'path': '/',
-                'backend': {
-                    'serviceName': 'testapp',
-                    'servicePort': 80,
-                }
-            }]
-        }
-    }]
-    default_metadata = pytest.helpers.create_metadata('testapp', labels=LABELS, annotations=ANNOTATIONS, external=expose)
+    default_rules = [
+        {
+            "host": "testapp.svc.test.example.com",
+            "http": {
+                "paths": [
+                    {
+                        "path": "/",
+                        "backend": {
+                            "serviceName": "testapp",
+                            "servicePort": 80,
+                        },
+                    }
+                ]
+            },
+        },
+        {
+            "host": "testapp.127.0.0.1.xip.io",
+            "http": {
+                "paths": [
+                    {
+                        "path": "/",
+                        "backend": {
+                            "serviceName": "testapp",
+                            "servicePort": 80,
+                        },
+                    }
+                ]
+            },
+        },
+    ]
+    default_metadata = pytest.helpers.create_metadata(
+        "testapp", labels=LABELS, annotations=ANNOTATIONS, external=expose
+    )
 
     expected_ingress = {
-        'spec': {
-            'rules': rules if rules else default_rules,
-            'tls': tls if tls else []
-        },
-        'metadata': metadata if metadata else default_metadata,
+        "spec": {"rules": rules if rules else default_rules, "tls": tls if tls else []},
+        "metadata": metadata if metadata else default_metadata,
     }
     return expected_ingress
 
@@ -117,372 +157,570 @@ def ingress(rules=None, metadata=None, expose=False, tls=None):
 TEST_DATA = (
     # (test_case_name, provided_app_spec, expected_ingress)
     ("only_default_hosts", app_spec(), ingress()),
-    ("single_explicit_host",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[{
-         'host': "foo.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }])),
-    ("single_explicit_host_multiple_paths",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[
-             IngressPathMappingSpec(path="/", port=80),
-             IngressPathMappingSpec(path="/other", port=5000)], annotations={})],
-         ports=[
-             PortSpec(protocol="http", name="http", port=80, target_port=8080),
-             PortSpec(protocol="http", name="other", port=5000, target_port=8081)]),
-     ingress(expose=True, rules=[{
-         'host': "foo.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/other',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/other',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/other',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }])),
-    ("multiple_explicit_hosts",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
-         IngressItemSpec(host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[{
-         'host': "foo.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "bar.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }])),
-    ("multiple_explicit_hosts_multiple_paths",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[
-             IngressPathMappingSpec(path="/one", port=80),
-             IngressPathMappingSpec(path="/two", port=5000)
-         ], annotations={}),
-         IngressItemSpec(host="bar.example.com", pathmappings=[
-             IngressPathMappingSpec(path="/three", port=80),
-             IngressPathMappingSpec(path="/four", port=5000)
-         ], annotations={})],
-         ports=[
-             PortSpec(protocol="http", name="http", port=80, target_port=8080),
-             PortSpec(protocol="http", name="other", port=5000, target_port=8081),
-         ]),
-     ingress(expose=True, rules=[{
-         'host': "foo.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/one',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/two',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }, {
-         'host': "bar.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/three',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/four',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/one',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/two',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }, {
-                 'path': '/three',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/four',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': '/one',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/two',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }, {
-                 'path': '/three',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }, {
-                 'path': '/four',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 5000,
-                 }
-             }]
-         }
-     }])),
-    ("rewrite_host_simple",
-     app_spec(ingresses=[
-         IngressItemSpec(host="rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[{
-         'host': "test.rewrite.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }])),
-    ("rewrite_host_regex_substitution",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[{
-         'host': "test.foo.rewrite.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': '/',
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }])),
-    ("custom_labels_and_annotations",
-     app_spec(labels=LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={},
-                                            ingress={"ingress_deployer": "pass through", "custom": "label"},
-                                            service={}, service_account={}, pod={}, status={}),
-              annotations=LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={},
-                                                 ingress={"custom": "annotation"}, service={}, service_account={}, pod={}, status={})),
-     ingress(metadata=pytest.helpers.create_metadata('testapp', external=False,
-                                                     labels={"ingress_deployer": "pass through", "custom": "label",
-                                                             "app": "testapp", "fiaas/deployment_id": "12345"},
-                                                     annotations={"fiaas/expose": "false", "custom": "annotation"}))),
-    ("regex_path",
-     app_spec(ingresses=[
-         IngressItemSpec(host=None, pathmappings=[
-             IngressPathMappingSpec(
-                 path=r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
-                 port=80)], annotations={})]),
-     ingress(expose=False, rules=[{
-         'host': "testapp.svc.test.example.com",
-         'http': {
-             'paths': [{
-                 'path': r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }, {
-         'host': "testapp.127.0.0.1.xip.io",
-         'http': {
-             'paths': [{
-                 'path': r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
-                 'backend': {
-                     'serviceName': 'testapp',
-                     'servicePort': 80,
-                 }
-             }]
-         }
-     }])),
+    (
+        "single_explicit_host",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                )
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                {
+                    "host": "foo.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
+    (
+        "single_explicit_host_multiple_paths",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com",
+                    pathmappings=[
+                        IngressPathMappingSpec(path="/", port=80),
+                        IngressPathMappingSpec(path="/other", port=5000),
+                    ],
+                    annotations={},
+                )
+            ],
+            ports=[
+                PortSpec(protocol="http", name="http", port=80, target_port=8080),
+                PortSpec(protocol="http", name="other", port=5000, target_port=8081),
+            ],
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                {
+                    "host": "foo.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/other",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/other",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/other",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
+    (
+        "multiple_explicit_hosts",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+                IngressItemSpec(
+                    host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                {
+                    "host": "foo.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "bar.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
+    (
+        "multiple_explicit_hosts_multiple_paths",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com",
+                    pathmappings=[
+                        IngressPathMappingSpec(path="/one", port=80),
+                        IngressPathMappingSpec(path="/two", port=5000),
+                    ],
+                    annotations={},
+                ),
+                IngressItemSpec(
+                    host="bar.example.com",
+                    pathmappings=[
+                        IngressPathMappingSpec(path="/three", port=80),
+                        IngressPathMappingSpec(path="/four", port=5000),
+                    ],
+                    annotations={},
+                ),
+            ],
+            ports=[
+                PortSpec(protocol="http", name="http", port=80, target_port=8080),
+                PortSpec(protocol="http", name="other", port=5000, target_port=8081),
+            ],
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                {
+                    "host": "foo.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/one",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/two",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+                {
+                    "host": "bar.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/three",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/four",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/one",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/two",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                            {
+                                "path": "/three",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/four",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/one",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/two",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                            {
+                                "path": "/three",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            },
+                            {
+                                "path": "/four",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 5000,
+                                },
+                            },
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
+    (
+        "rewrite_host_simple",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                )
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                {
+                    "host": "test.rewrite.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
+    (
+        "rewrite_host_regex_substitution",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.rewrite.example.com",
+                    pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                    annotations={},
+                )
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                {
+                    "host": "test.foo.rewrite.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": "/",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
+    (
+        "custom_labels_and_annotations",
+        app_spec(
+            labels=LabelAndAnnotationSpec(
+                deployment={},
+                horizontal_pod_autoscaler={},
+                ingress={"ingress_deployer": "pass through", "custom": "label"},
+                service={},
+                service_account={},
+                pod={},
+                status={},
+            ),
+            annotations=LabelAndAnnotationSpec(
+                deployment={},
+                horizontal_pod_autoscaler={},
+                ingress={"custom": "annotation"},
+                service={},
+                service_account={},
+                pod={},
+                status={},
+            ),
+        ),
+        ingress(
+            metadata=pytest.helpers.create_metadata(
+                "testapp",
+                external=False,
+                labels={
+                    "ingress_deployer": "pass through",
+                    "custom": "label",
+                    "app": "testapp",
+                    "fiaas/deployment_id": "12345",
+                },
+                annotations={"fiaas/expose": "false", "custom": "annotation"},
+            )
+        ),
+    ),
+    (
+        "regex_path",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host=None,
+                    pathmappings=[
+                        IngressPathMappingSpec(
+                            path=r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                            port=80,
+                        )
+                    ],
+                    annotations={},
+                )
+            ]
+        ),
+        ingress(
+            expose=False,
+            rules=[
+                {
+                    "host": "testapp.svc.test.example.com",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+                {
+                    "host": "testapp.127.0.0.1.xip.io",
+                    "http": {
+                        "paths": [
+                            {
+                                "path": r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                                "backend": {
+                                    "serviceName": "testapp",
+                                    "servicePort": 80,
+                                },
+                            }
+                        ]
+                    },
+                },
+            ],
+        ),
+    ),
 )
 
 
@@ -529,8 +767,11 @@ class TestIngressDeployer(object):
 
     def pytest_generate_tests(self, metafunc):
         fixtures = ("app_spec", "expected_ingress")
-        if metafunc.cls == self.__class__ and metafunc.function.__name__ == "test_ingress_deploy" and \
-                all(fixname in metafunc.fixturenames for fixname in fixtures):
+        if (
+            metafunc.cls == self.__class__
+            and metafunc.function.__name__ == "test_ingress_deploy"
+            and all(fixname in metafunc.fixturenames for fixname in fixtures)
+        ):
             for test_id, app_spec, expected_ingress in TEST_DATA:
                 params = {"app_spec": app_spec, "expected_ingress": expected_ingress}
                 metafunc.addcall(params, test_id)
@@ -550,7 +791,7 @@ class TestIngressDeployer(object):
 
     @pytest.fixture
     def dtparse(self):
-        with mock.patch('pyrfc3339.parse') as m:
+        with mock.patch("pyrfc3339.parse") as m:
             yield m
 
     @pytest.mark.usefixtures("dtparse", "get")
@@ -558,57 +799,59 @@ class TestIngressDeployer(object):
         app_spec.annotations.ingress.update(ANNOTATIONS.copy())
 
         del app_spec.ingresses[:]  # make sure the default ingress will be re-created
-        app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
-                                                  pathmappings=[IngressPathMappingSpec(path="/", port=8000)],
-                                                  annotations={"some/annotation": "some-value"}))
-        app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
-                                                  pathmappings=[IngressPathMappingSpec(path="/_/ipblocked", port=8000)],
-                                                  annotations={"some/allowlist": "10.0.0.1/12"}))
+        app_spec.ingresses.append(
+            IngressItemSpec(
+                host="extra.example.com",
+                pathmappings=[IngressPathMappingSpec(path="/", port=8000)],
+                annotations={"some/annotation": "some-value"},
+            )
+        )
+        app_spec.ingresses.append(
+            IngressItemSpec(
+                host="extra.example.com",
+                pathmappings=[IngressPathMappingSpec(path="/_/ipblocked", port=8000)],
+                annotations={"some/allowlist": "10.0.0.1/12"},
+            )
+        )
 
         expected_ingress = ingress()
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_ingress
 
-        expected_metadata2 = pytest.helpers.create_metadata('testapp-1', labels=LABELS,
-                                                            annotations={"some/annotation": "some-value"}, external=True)
-        expected_ingress2 = ingress(rules=[
-            {
-                "host": "extra.example.com",
-                "http": {
-                    "paths": [
-                        {
-                            "path": "/",
-                            "backend": {
-                                "serviceName": app_spec.name,
-                                "servicePort": 8000
-                            }
-                        }
-                    ]
+        expected_metadata2 = pytest.helpers.create_metadata(
+            "testapp-1", labels=LABELS, annotations={"some/annotation": "some-value"}, external=True
+        )
+        expected_ingress2 = ingress(
+            rules=[
+                {
+                    "host": "extra.example.com",
+                    "http": {"paths": [{"path": "/", "backend": {"serviceName": app_spec.name, "servicePort": 8000}}]},
                 }
-            }
-        ], metadata=expected_metadata2)
+            ],
+            metadata=expected_metadata2,
+        )
         mock_response2 = create_autospec(Response)
         mock_response.json.return_value = expected_ingress2
 
-        expected_metadata3 = pytest.helpers.create_metadata('testapp-2', labels=LABELS,
-                                                            annotations={"some/annotation": "val",
-                                                                         "some/allowlist": "10.0.0.1/12"}, external=True)
-        expected_ingress3 = ingress(rules=[
-            {
-                "host": "extra.example.com",
-                "http": {
-                    "paths": [
-                        {
-                            "path": "/_/ipblocked",
-                            "backend": {
-                                "serviceName": app_spec.name,
-                                "servicePort": 8000
-                            }
-                        }
-                    ]
+        expected_metadata3 = pytest.helpers.create_metadata(
+            "testapp-2",
+            labels=LABELS,
+            annotations={"some/annotation": "val", "some/allowlist": "10.0.0.1/12"},
+            external=True,
+        )
+        expected_ingress3 = ingress(
+            rules=[
+                {
+                    "host": "extra.example.com",
+                    "http": {
+                        "paths": [
+                            {"path": "/_/ipblocked", "backend": {"serviceName": app_spec.name, "servicePort": 8000}}
+                        ]
+                    },
                 }
-            }
-        ], metadata=expected_metadata3)
+            ],
+            metadata=expected_metadata3,
+        )
         mock_response3 = create_autospec(Response)
         mock_response3.json.return_value = expected_ingress3
 
@@ -616,14 +859,22 @@ class TestIngressDeployer(object):
 
         deployer.deploy(app_spec, LABELS)
 
-        post.assert_has_calls([mock.call(INGRESSES_URI, expected_ingress), mock.call(INGRESSES_URI, expected_ingress2),
-                               mock.call(INGRESSES_URI, expected_ingress3)])
+        post.assert_has_calls(
+            [
+                mock.call(INGRESSES_URI, expected_ingress),
+                mock.call(INGRESSES_URI, expected_ingress2),
+                mock.call(INGRESSES_URI, expected_ingress3),
+            ]
+        )
         delete.assert_called_once_with(INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
 
-    @pytest.mark.parametrize("spec_name", (
+    @pytest.mark.parametrize(
+        "spec_name",
+        (
             "app_spec_thrift",
             "app_spec_no_ports",
-    ))
+        ),
+    )
     def test_remove_existing_ingress_if_not_needed(self, request, delete, post, deployer, spec_name):
         app_spec = request.getfuncargvalue(spec_name)
 
@@ -639,62 +890,94 @@ class TestIngressDeployer(object):
         pytest.helpers.assert_no_calls(post, INGRESSES_URI)
         pytest.helpers.assert_any_call(delete, INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
 
-    @pytest.mark.parametrize("app_spec, hosts", (
-            (app_spec(), ['testapp.svc.test.example.com', 'testapp.127.0.0.1.xip.io']),
-            (app_spec(ingresses=[
-                IngressItemSpec(host="foo.rewrite.example.com",
-                                pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-             ['test.foo.rewrite.example.com', 'testapp.svc.test.example.com', 'testapp.127.0.0.1.xip.io']),
-    ))
+    @pytest.mark.parametrize(
+        "app_spec, hosts",
+        (
+            (app_spec(), ["testapp.svc.test.example.com", "testapp.127.0.0.1.xip.io"]),
+            (
+                app_spec(
+                    ingresses=[
+                        IngressItemSpec(
+                            host="foo.rewrite.example.com",
+                            pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                            annotations={},
+                        )
+                    ]
+                ),
+                ["test.foo.rewrite.example.com", "testapp.svc.test.example.com", "testapp.127.0.0.1.xip.io"],
+            ),
+        ),
+    )
     @pytest.mark.usefixtures("delete")
     def test_applies_ingress_tls_deployer(self, deployer, ingress_tls_deployer, app_spec, hosts):
         with mock.patch("k8s.models.ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             deployer.deploy(app_spec, LABELS)
-            ingress_tls_deployer.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
+            ingress_tls_deployer.apply.assert_called_once_with(
+                TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True
+            )
 
     @pytest.fixture
     def deployer_issuer_overrides(self, config, default_app_spec, ingress_adapter):
         config.tls_certificate_issuer_type_overrides = {
             "foo.example.com": "certmanager.k8s.io/issuer",
             "bar.example.com": "certmanager.k8s.io/cluster-issuer",
-            "foo.bar.example.com": "certmanager.k8s.io/issuer"
+            "foo.bar.example.com": "certmanager.k8s.io/issuer",
         }
         return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.mark.usefixtures("delete")
-    def test_applies_ingress_tls_deployer_issuer_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):
+    def test_applies_ingress_tls_deployer_issuer_overrides(
+        self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec
+    ):
         with mock.patch("k8s.models.ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             app_spec.ingresses[:] = [
                 # has issuer-override
-                IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # no issuer-override
-                IngressItemSpec(host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
-                IngressItemSpec(host="foo.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
-                IngressItemSpec(host="other.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+                IngressItemSpec(
+                    host="foo.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+                IngressItemSpec(
+                    host="other.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # suffix has issuer-override
-                IngressItemSpec(host="sub.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="sub.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # more specific suffix has issuer-override
-                IngressItemSpec(host="sub.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="sub.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # has annotations
-                IngressItemSpec(host="ann.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)],
-                                annotations={"some": "annotation"})
+                IngressItemSpec(
+                    host="ann.foo.example.com",
+                    pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                    annotations={"some": "annotation"},
+                ),
             ]
 
             deployer_issuer_overrides.deploy(app_spec, LABELS)
             host_groups = [sorted(call.args[2]) for call in ingress_tls_deployer.apply.call_args_list]
-            ingress_names = [call.kwargs['metadata'].name for call in get_or_create.call_args_list]
+            ingress_names = [call.kwargs["metadata"].name for call in get_or_create.call_args_list]
             expected_host_groups = [
                 ["ann.foo.example.com"],
-                ["bar.example.com", "other.example.com", "sub.bar.example.com", "testapp.127.0.0.1.xip.io", "testapp.svc.test.example.com"],
-                ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"]
+                [
+                    "bar.example.com",
+                    "other.example.com",
+                    "sub.bar.example.com",
+                    "testapp.127.0.0.1.xip.io",
+                    "testapp.svc.test.example.com",
+                ],
+                ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"],
             ]
-            expected_ingress_names = [
-                "testapp",
-                "testapp-1",
-                "testapp-2"
-            ]
+            expected_ingress_names = ["testapp", "testapp-1", "testapp-2"]
             assert ingress_tls_deployer.apply.call_count == 3
             assert expected_host_groups == sorted(host_groups)
             assert expected_ingress_names == sorted(ingress_names)
@@ -726,56 +1009,136 @@ class TestIngressTLSDeployer(object):
         config.enable_deprecated_tls_entry_per_host = request.param["enable_deprecated_tls_entry_per_host"]
         return IngressTLSDeployer(config, IngressTLS)
 
-    @pytest.mark.parametrize("tls, app_spec, spec_tls, issuer_type, tls_annotations", [
-        ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
-         INGRESS_SPEC_TLS, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
-        ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
-         INGRESS_SPEC_TLS, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
-        ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
-         INGRESS_SPEC_TLS,
-         "overwrite-issuer",
-         {"overwrite-issuer": "letsencrypt"}),
-        ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
-         INGRESS_SPEC_TLS,
-         DEFAULT_TLS_ISSUER,
-         DEFAULT_TLS_ANNOTATIONS),
-        ({"use_ingress_tls": "default_off", "cert_issuer": "letsencrypt", "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer="myoverwrite")),
-         INGRESS_SPEC_TLS,
-         DEFAULT_TLS_ISSUER,
-         {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
-        ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer="myoverwrite")),
-         INGRESS_SPEC_TLS,
-         DEFAULT_TLS_ISSUER,
-         {"certmanager.k8s.io/cluster-issuer": "myoverwrite"}),
-        ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
-         INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
-        ({"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
-         INGRESS_SPEC_TLS_COLLAPSED_ONLY, DEFAULT_TLS_ISSUER, {"kubernetes.io/tls-acme": "true"}),
-        ({"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-        ({"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
-         app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)), [], DEFAULT_TLS_ISSUER, None),
-    ], indirect=['tls'])
+    @pytest.mark.parametrize(
+        "tls, app_spec, spec_tls, issuer_type, tls_annotations",
+        [
+            (
+                {"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                INGRESS_SPEC_TLS,
+                DEFAULT_TLS_ISSUER,
+                {"kubernetes.io/tls-acme": "true"},
+            ),
+            (
+                {"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                INGRESS_SPEC_TLS,
+                DEFAULT_TLS_ISSUER,
+                {"kubernetes.io/tls-acme": "true"},
+            ),
+            (
+                {"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {
+                    "use_ingress_tls": "default_off",
+                    "cert_issuer": "letsencrypt",
+                    "enable_deprecated_tls_entry_per_host": True,
+                },
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                INGRESS_SPEC_TLS,
+                "overwrite-issuer",
+                {"overwrite-issuer": "letsencrypt"},
+            ),
+            (
+                {
+                    "use_ingress_tls": "default_off",
+                    "cert_issuer": "letsencrypt",
+                    "enable_deprecated_tls_entry_per_host": True,
+                },
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                INGRESS_SPEC_TLS,
+                DEFAULT_TLS_ISSUER,
+                DEFAULT_TLS_ANNOTATIONS,
+            ),
+            (
+                {
+                    "use_ingress_tls": "default_off",
+                    "cert_issuer": "letsencrypt",
+                    "enable_deprecated_tls_entry_per_host": True,
+                },
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer="myoverwrite")),
+                INGRESS_SPEC_TLS,
+                DEFAULT_TLS_ISSUER,
+                {"certmanager.k8s.io/cluster-issuer": "myoverwrite"},
+            ),
+            (
+                {"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": True},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer="myoverwrite")),
+                INGRESS_SPEC_TLS,
+                DEFAULT_TLS_ISSUER,
+                {"certmanager.k8s.io/cluster-issuer": "myoverwrite"},
+            ),
+            (
+                {"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                INGRESS_SPEC_TLS_COLLAPSED_ONLY,
+                DEFAULT_TLS_ISSUER,
+                {"kubernetes.io/tls-acme": "true"},
+            ),
+            (
+                {"use_ingress_tls": "default_off", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                INGRESS_SPEC_TLS_COLLAPSED_ONLY,
+                DEFAULT_TLS_ISSUER,
+                {"kubernetes.io/tls-acme": "true"},
+            ),
+            (
+                {"use_ingress_tls": "default_on", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+            (
+                {"use_ingress_tls": "disabled", "cert_issuer": None, "enable_deprecated_tls_entry_per_host": False},
+                app_spec(ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None)),
+                [],
+                DEFAULT_TLS_ISSUER,
+                None,
+            ),
+        ],
+        indirect=["tls"],
+    )
     def test_apply_tls(self, tls, app_spec, spec_tls, issuer_type, tls_annotations):
         ingress = Ingress()
         ingress.metadata = ObjectMeta(name=app_spec.name)
@@ -783,12 +1146,20 @@ class TestIngressTLSDeployer(object):
         assert ingress.metadata.annotations == tls_annotations
         assert ingress.spec.tls == spec_tls
 
-    @pytest.mark.parametrize("suffix, expected", [
-        ("short.suffix", "zgwvxk7m22jnzqmofnboadb6kpuri4st.short.suffix"),
-        ("this.is.really.a.quite.extensive.suffix", "zgwvxk7m22jnzqmofnboadb.this.is.really.a.quite.extensive.suffix"),
-        ("extremely.long.suffix.which.pushes.the.boundary.to.the.utmost",
-         "z.extremely.long.suffix.which.pushes.the.boundary.to.the.utmost"),
-    ])
+    @pytest.mark.parametrize(
+        "suffix, expected",
+        [
+            ("short.suffix", "zgwvxk7m22jnzqmofnboadb6kpuri4st.short.suffix"),
+            (
+                "this.is.really.a.quite.extensive.suffix",
+                "zgwvxk7m22jnzqmofnboadb.this.is.really.a.quite.extensive.suffix",
+            ),
+            (
+                "extremely.long.suffix.which.pushes.the.boundary.to.the.utmost",
+                "z.extremely.long.suffix.which.pushes.the.boundary.to.the.utmost",
+            ),
+        ],
+    )
     def test_shorten_name(self, config, suffix, expected):
         config.use_ingress_tls = "default_on"
         config.ingress_suffixes = [suffix]

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
@@ -24,17 +24,31 @@ from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration, HostRewriteRule
 from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer, IngressTLSDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.ingress_networkingv1 import NetworkingV1IngressAdapter
-from fiaas_deploy_daemon.specs.models import AppSpec, ResourceRequirementSpec, \
-    ResourcesSpec, PrometheusSpec, DatadogSpec, \
-    PortSpec, CheckSpec, HttpCheckSpec, TcpCheckSpec, HealthCheckSpec, AutoscalerSpec, \
-    LabelAndAnnotationSpec, IngressItemSpec, IngressPathMappingSpec, StrongboxSpec, IngressTLSSpec
+from fiaas_deploy_daemon.specs.models import (
+    AppSpec,
+    ResourceRequirementSpec,
+    ResourcesSpec,
+    PrometheusSpec,
+    DatadogSpec,
+    PortSpec,
+    CheckSpec,
+    HttpCheckSpec,
+    TcpCheckSpec,
+    HealthCheckSpec,
+    AutoscalerSpec,
+    LabelAndAnnotationSpec,
+    IngressItemSpec,
+    IngressPathMappingSpec,
+    StrongboxSpec,
+    IngressTLSSpec,
+)
 
 from utils import TypeMatcher
 
 LABELS = {"ingress_deployer": "pass through", "app": "testapp", "fiaas/deployment_id": "12345"}
 ANNOTATIONS = {"some/annotation": "val"}
 LABEL_SELECTOR_PARAMS = {"labelSelector": "app=testapp,fiaas/deployment_id,fiaas/deployment_id!=12345"}
-INGRESSES_URI = '/apis/networking.k8s.io/v1/namespaces/default/ingresses/'
+INGRESSES_URI = "/apis/networking.k8s.io/v1/namespaces/default/ingresses/"
 DEFAULT_TLS_ISSUER = "certmanager.k8s.io/cluster-issuer"
 DEFAULT_TLS_ANNOTATIONS = {"certmanager.k8s.io/cluster-issuer": "letsencrypt"}
 
@@ -46,27 +60,47 @@ def app_spec(**kwargs):
         namespace="default",
         image="finntech/testimage:version",
         autoscaler=AutoscalerSpec(enabled=False, min_replicas=2, max_replicas=3, cpu_threshold_percentage=50),
-        resources=ResourcesSpec(requests=ResourceRequirementSpec(cpu=None, memory=None),
-                                limits=ResourceRequirementSpec(cpu=None, memory=None)),
+        resources=ResourcesSpec(
+            requests=ResourceRequirementSpec(cpu=None, memory=None),
+            limits=ResourceRequirementSpec(cpu=None, memory=None),
+        ),
         admin_access=False,
         secrets_in_environment=False,
-        prometheus=PrometheusSpec(enabled=True, port='http', path='/internal-backstage/prometheus'),
+        prometheus=PrometheusSpec(enabled=True, port="http", path="/internal-backstage/prometheus"),
         datadog=DatadogSpec(enabled=False, tags={}),
         ports=[
             PortSpec(protocol="http", name="http", port=80, target_port=8080),
         ],
         health_checks=HealthCheckSpec(
-            liveness=CheckSpec(tcp=TcpCheckSpec(port=8080), http=None, execute=None, initial_delay_seconds=10,
-                               period_seconds=10, success_threshold=1, failure_threshold=3, timeout_seconds=1),
-            readiness=CheckSpec(http=HttpCheckSpec(path="/", port=8080, http_headers={}), tcp=None, execute=None,
-                                initial_delay_seconds=10, period_seconds=10, success_threshold=1,
-                                failure_threshold=3, timeout_seconds=1)),
-        teams=['foo'],
-        tags=['bar'],
+            liveness=CheckSpec(
+                tcp=TcpCheckSpec(port=8080),
+                http=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+            readiness=CheckSpec(
+                http=HttpCheckSpec(path="/", port=8080, http_headers={}),
+                tcp=None,
+                execute=None,
+                initial_delay_seconds=10,
+                period_seconds=10,
+                success_threshold=1,
+                failure_threshold=3,
+                timeout_seconds=1,
+            ),
+        ),
+        teams=["foo"],
+        tags=["bar"],
         deployment_id="test_app_deployment_id",
         labels=LabelAndAnnotationSpec({}, {}, {}, {}, {}, {}, {}),
         annotations=LabelAndAnnotationSpec({}, {}, ANNOTATIONS.copy(), {}, {}, {}, {}),
-        ingresses=[IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})],
+        ingresses=[
+            IngressItemSpec(host=None, pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})
+        ],
         strongbox=StrongboxSpec(enabled=False, iam_role=None, aws_region="eu-west-1", groups=None),
         singleton=False,
         ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
@@ -79,36 +113,38 @@ def app_spec(**kwargs):
 
 def _create_rule(host, paths=None):
     rule = {
-        'host': host,
-        'http': {
-            'paths': [{
-                'path': '/',
-                'pathType': 'ImplementationSpecific',
-                'backend': {
-                    'service': {
-                        'name': "testapp",
-                        'port': {
-                            'number': 80,
+        "host": host,
+        "http": {
+            "paths": [
+                {
+                    "path": "/",
+                    "pathType": "ImplementationSpecific",
+                    "backend": {
+                        "service": {
+                            "name": "testapp",
+                            "port": {
+                                "number": 80,
+                            },
                         },
                     },
                 }
-            }]
-        }
+            ]
+        },
     }
     if paths:
-        rule['http']['paths'] = paths
+        rule["http"]["paths"] = paths
     return rule
 
 
 def _create_path(path, svc, port):
     return {
-        'path': path,
-        'pathType': 'ImplementationSpecific',
-        'backend': {
-            'service': {
-                'name': svc,
-                'port': {
-                    'number': port,
+        "path": path,
+        "pathType": "ImplementationSpecific",
+        "backend": {
+            "service": {
+                "name": svc,
+                "port": {
+                    "number": port,
                 },
             },
         },
@@ -120,14 +156,13 @@ def ingress(rules=None, metadata=None, expose=False, tls=None):
         _create_rule("testapp.svc.test.example.com"),
         _create_rule("testapp.127.0.0.1.xip.io"),
     ]
-    default_metadata = pytest.helpers.create_metadata('testapp', labels=LABELS, annotations=ANNOTATIONS, external=expose)
+    default_metadata = pytest.helpers.create_metadata(
+        "testapp", labels=LABELS, annotations=ANNOTATIONS, external=expose
+    )
 
     expected_ingress = {
-        'spec': {
-            'rules': rules if rules else default_rules,
-            'tls': tls if tls else []
-        },
-        'metadata': metadata if metadata else default_metadata,
+        "spec": {"rules": rules if rules else default_rules, "tls": tls if tls else []},
+        "metadata": metadata if metadata else default_metadata,
     }
     return expected_ingress
 
@@ -135,122 +170,261 @@ def ingress(rules=None, metadata=None, expose=False, tls=None):
 TEST_DATA = (
     # (test_case_name, provided_app_spec, expected_ingress)
     ("only_default_hosts", app_spec(), ingress()),
-    ("single_explicit_host",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[
-         _create_rule("foo.example.com"),
-         _create_rule("testapp.svc.test.example.com"),
-         _create_rule("testapp.127.0.0.1.xip.io"),
-     ])),
-    ("single_explicit_host_multiple_paths",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[
-             IngressPathMappingSpec(path="/", port=80),
-             IngressPathMappingSpec(path="/other", port=5000)], annotations={})],
-         ports=[
-             PortSpec(protocol="http", name="http", port=80, target_port=8080),
-             PortSpec(protocol="http", name="other", port=5000, target_port=8081)]),
-     ingress(expose=True, rules=[
-         _create_rule("foo.example.com", paths=[
-             _create_path("/", "testapp", 80),
-             _create_path("/other", "testapp", 5000)
-         ]),
-         _create_rule("testapp.svc.test.example.com", paths=[
-             _create_path("/", "testapp", 80),
-             _create_path("/other", "testapp", 5000)
-         ]),
-         _create_rule("testapp.127.0.0.1.xip.io", paths=[
-             _create_path("/", "testapp", 80),
-             _create_path("/other", "testapp", 5000)
-         ]),
-     ])),
-    ("multiple_explicit_hosts",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
-         IngressItemSpec(host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[
-        _create_rule("foo.example.com"),
-        _create_rule("bar.example.com"),
-        _create_rule("testapp.svc.test.example.com"),
-        _create_rule("testapp.127.0.0.1.xip.io"),
-     ])),
-    ("multiple_explicit_hosts_multiple_paths",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.example.com", pathmappings=[
-             IngressPathMappingSpec(path="/one", port=80),
-             IngressPathMappingSpec(path="/two", port=5000)
-         ], annotations={}),
-         IngressItemSpec(host="bar.example.com", pathmappings=[
-             IngressPathMappingSpec(path="/three", port=80),
-             IngressPathMappingSpec(path="/four", port=5000)
-         ], annotations={})],
-         ports=[
-             PortSpec(protocol="http", name="http", port=80, target_port=8080),
-             PortSpec(protocol="http", name="other", port=5000, target_port=8081),
-         ]),
-     ingress(expose=True, rules=[
-        _create_rule("foo.example.com", paths=[
-            _create_path("/one", "testapp", 80),
-            _create_path("/two", "testapp", 5000),
-        ]),
-        _create_rule("bar.example.com", paths=[
-            _create_path("/three", "testapp", 80),
-            _create_path("/four", "testapp", 5000),
-        ]),
-        _create_rule("testapp.svc.test.example.com", paths=[
-            _create_path("/one", "testapp", 80),
-            _create_path("/two", "testapp", 5000),
-            _create_path("/three", "testapp", 80),
-            _create_path("/four", "testapp", 5000),
-        ]),
-        _create_rule("testapp.127.0.0.1.xip.io", paths=[
-            _create_path("/one", "testapp", 80),
-            _create_path("/two", "testapp", 5000),
-            _create_path("/three", "testapp", 80),
-            _create_path("/four", "testapp", 5000),
-        ]),
-     ])),
-    ("rewrite_host_simple",
-     app_spec(ingresses=[
-         IngressItemSpec(host="rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[
-         _create_rule("test.rewrite.example.com"),
-         _create_rule("testapp.svc.test.example.com"),
-         _create_rule("testapp.127.0.0.1.xip.io"),
-     ])),
-    ("rewrite_host_regex_substitution",
-     app_spec(ingresses=[
-         IngressItemSpec(host="foo.rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-     ingress(expose=True, rules=[
-         _create_rule("test.foo.rewrite.example.com"),
-         _create_rule("testapp.svc.test.example.com"),
-         _create_rule("testapp.127.0.0.1.xip.io"),
-     ])),
-    ("custom_labels_and_annotations",
-     app_spec(labels=LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={},
-                                            ingress={"ingress_deployer": "pass through", "custom": "label"},
-                                            service={}, service_account={}, pod={}, status={}),
-              annotations=LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={},
-                                                 ingress={"custom": "annotation"}, service={}, service_account={}, pod={}, status={})),
-     ingress(metadata=pytest.helpers.create_metadata('testapp', external=False,
-                                                     labels={"ingress_deployer": "pass through", "custom": "label",
-                                                             "app": "testapp", "fiaas/deployment_id": "12345"},
-                                                     annotations={"fiaas/expose": "false", "custom": "annotation"}))),
-    ("regex_path",
-     app_spec(ingresses=[
-         IngressItemSpec(host=None, pathmappings=[
-             IngressPathMappingSpec(
-                 path=r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
-                 port=80)], annotations={})]),
-     ingress(expose=False, rules=[
-         _create_rule("testapp.svc.test.example.com", paths=[
-             _create_path(r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)", 'testapp', 80),
-         ]),
-         _create_rule("testapp.127.0.0.1.xip.io", paths=[
-             _create_path(r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)", 'testapp', 80),
-         ]),
-     ])),
+    (
+        "single_explicit_host",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                )
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                _create_rule("foo.example.com"),
+                _create_rule("testapp.svc.test.example.com"),
+                _create_rule("testapp.127.0.0.1.xip.io"),
+            ],
+        ),
+    ),
+    (
+        "single_explicit_host_multiple_paths",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com",
+                    pathmappings=[
+                        IngressPathMappingSpec(path="/", port=80),
+                        IngressPathMappingSpec(path="/other", port=5000),
+                    ],
+                    annotations={},
+                )
+            ],
+            ports=[
+                PortSpec(protocol="http", name="http", port=80, target_port=8080),
+                PortSpec(protocol="http", name="other", port=5000, target_port=8081),
+            ],
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                _create_rule(
+                    "foo.example.com", paths=[_create_path("/", "testapp", 80), _create_path("/other", "testapp", 5000)]
+                ),
+                _create_rule(
+                    "testapp.svc.test.example.com",
+                    paths=[_create_path("/", "testapp", 80), _create_path("/other", "testapp", 5000)],
+                ),
+                _create_rule(
+                    "testapp.127.0.0.1.xip.io",
+                    paths=[_create_path("/", "testapp", 80), _create_path("/other", "testapp", 5000)],
+                ),
+            ],
+        ),
+    ),
+    (
+        "multiple_explicit_hosts",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+                IngressItemSpec(
+                    host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                _create_rule("foo.example.com"),
+                _create_rule("bar.example.com"),
+                _create_rule("testapp.svc.test.example.com"),
+                _create_rule("testapp.127.0.0.1.xip.io"),
+            ],
+        ),
+    ),
+    (
+        "multiple_explicit_hosts_multiple_paths",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.example.com",
+                    pathmappings=[
+                        IngressPathMappingSpec(path="/one", port=80),
+                        IngressPathMappingSpec(path="/two", port=5000),
+                    ],
+                    annotations={},
+                ),
+                IngressItemSpec(
+                    host="bar.example.com",
+                    pathmappings=[
+                        IngressPathMappingSpec(path="/three", port=80),
+                        IngressPathMappingSpec(path="/four", port=5000),
+                    ],
+                    annotations={},
+                ),
+            ],
+            ports=[
+                PortSpec(protocol="http", name="http", port=80, target_port=8080),
+                PortSpec(protocol="http", name="other", port=5000, target_port=8081),
+            ],
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                _create_rule(
+                    "foo.example.com",
+                    paths=[
+                        _create_path("/one", "testapp", 80),
+                        _create_path("/two", "testapp", 5000),
+                    ],
+                ),
+                _create_rule(
+                    "bar.example.com",
+                    paths=[
+                        _create_path("/three", "testapp", 80),
+                        _create_path("/four", "testapp", 5000),
+                    ],
+                ),
+                _create_rule(
+                    "testapp.svc.test.example.com",
+                    paths=[
+                        _create_path("/one", "testapp", 80),
+                        _create_path("/two", "testapp", 5000),
+                        _create_path("/three", "testapp", 80),
+                        _create_path("/four", "testapp", 5000),
+                    ],
+                ),
+                _create_rule(
+                    "testapp.127.0.0.1.xip.io",
+                    paths=[
+                        _create_path("/one", "testapp", 80),
+                        _create_path("/two", "testapp", 5000),
+                        _create_path("/three", "testapp", 80),
+                        _create_path("/four", "testapp", 5000),
+                    ],
+                ),
+            ],
+        ),
+    ),
+    (
+        "rewrite_host_simple",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="rewrite.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                )
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                _create_rule("test.rewrite.example.com"),
+                _create_rule("testapp.svc.test.example.com"),
+                _create_rule("testapp.127.0.0.1.xip.io"),
+            ],
+        ),
+    ),
+    (
+        "rewrite_host_regex_substitution",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host="foo.rewrite.example.com",
+                    pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                    annotations={},
+                )
+            ]
+        ),
+        ingress(
+            expose=True,
+            rules=[
+                _create_rule("test.foo.rewrite.example.com"),
+                _create_rule("testapp.svc.test.example.com"),
+                _create_rule("testapp.127.0.0.1.xip.io"),
+            ],
+        ),
+    ),
+    (
+        "custom_labels_and_annotations",
+        app_spec(
+            labels=LabelAndAnnotationSpec(
+                deployment={},
+                horizontal_pod_autoscaler={},
+                ingress={"ingress_deployer": "pass through", "custom": "label"},
+                service={},
+                service_account={},
+                pod={},
+                status={},
+            ),
+            annotations=LabelAndAnnotationSpec(
+                deployment={},
+                horizontal_pod_autoscaler={},
+                ingress={"custom": "annotation"},
+                service={},
+                service_account={},
+                pod={},
+                status={},
+            ),
+        ),
+        ingress(
+            metadata=pytest.helpers.create_metadata(
+                "testapp",
+                external=False,
+                labels={
+                    "ingress_deployer": "pass through",
+                    "custom": "label",
+                    "app": "testapp",
+                    "fiaas/deployment_id": "12345",
+                },
+                annotations={"fiaas/expose": "false", "custom": "annotation"},
+            )
+        ),
+    ),
+    (
+        "regex_path",
+        app_spec(
+            ingresses=[
+                IngressItemSpec(
+                    host=None,
+                    pathmappings=[
+                        IngressPathMappingSpec(
+                            path=r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                            port=80,
+                        )
+                    ],
+                    annotations={},
+                )
+            ]
+        ),
+        ingress(
+            expose=False,
+            rules=[
+                _create_rule(
+                    "testapp.svc.test.example.com",
+                    paths=[
+                        _create_path(
+                            r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                            "testapp",
+                            80,
+                        ),
+                    ],
+                ),
+                _create_rule(
+                    "testapp.127.0.0.1.xip.io",
+                    paths=[
+                        _create_path(
+                            r"/(foo|bar/|other/(baz|quux)/stuff|foo.html|[1-5][0-9][0-9]$|[1-5][0-9][0-9]\..*$)",
+                            "testapp",
+                            80,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ),
 )
 
 
@@ -297,8 +471,11 @@ class TestIngressDeployer(object):
 
     def pytest_generate_tests(self, metafunc):
         fixtures = ("app_spec", "expected_ingress")
-        if metafunc.cls == self.__class__ and metafunc.function.__name__ == "test_ingress_deploy" and \
-                all(fixname in metafunc.fixturenames for fixname in fixtures):
+        if (
+            metafunc.cls == self.__class__
+            and metafunc.function.__name__ == "test_ingress_deploy"
+            and all(fixname in metafunc.fixturenames for fixname in fixtures)
+        ):
             for test_id, app_spec, expected_ingress in TEST_DATA:
                 params = {"app_spec": app_spec, "expected_ingress": expected_ingress}
                 metafunc.addcall(params, test_id)
@@ -318,7 +495,7 @@ class TestIngressDeployer(object):
 
     @pytest.fixture
     def dtparse(self):
-        with mock.patch('pyrfc3339.parse') as m:
+        with mock.patch("pyrfc3339.parse") as m:
             yield m
 
     @pytest.mark.usefixtures("dtparse", "get")
@@ -326,31 +503,45 @@ class TestIngressDeployer(object):
         app_spec.annotations.ingress.update(ANNOTATIONS.copy())
 
         del app_spec.ingresses[:]  # make sure the default ingress will be re-created
-        app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
-                                                  pathmappings=[IngressPathMappingSpec(path="/", port=8000)],
-                                                  annotations={"some/annotation": "some-value"}))
-        app_spec.ingresses.append(IngressItemSpec(host="extra.example.com",
-                                                  pathmappings=[IngressPathMappingSpec(path="/_/ipblocked", port=8000)],
-                                                  annotations={"some/allowlist": "10.0.0.1/12"}))
+        app_spec.ingresses.append(
+            IngressItemSpec(
+                host="extra.example.com",
+                pathmappings=[IngressPathMappingSpec(path="/", port=8000)],
+                annotations={"some/annotation": "some-value"},
+            )
+        )
+        app_spec.ingresses.append(
+            IngressItemSpec(
+                host="extra.example.com",
+                pathmappings=[IngressPathMappingSpec(path="/_/ipblocked", port=8000)],
+                annotations={"some/allowlist": "10.0.0.1/12"},
+            )
+        )
 
         expected_ingress = ingress()
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_ingress
 
-        expected_metadata2 = pytest.helpers.create_metadata('testapp-1', labels=LABELS,
-                                                            annotations={"some/annotation": "some-value"}, external=True)
-        expected_ingress2 = ingress(rules=[
-            _create_rule('extra.example.com', paths=[_create_path('/', app_spec.name, 8000)])
-        ], metadata=expected_metadata2)
+        expected_metadata2 = pytest.helpers.create_metadata(
+            "testapp-1", labels=LABELS, annotations={"some/annotation": "some-value"}, external=True
+        )
+        expected_ingress2 = ingress(
+            rules=[_create_rule("extra.example.com", paths=[_create_path("/", app_spec.name, 8000)])],
+            metadata=expected_metadata2,
+        )
         mock_response2 = create_autospec(Response)
         mock_response.json.return_value = expected_ingress2
 
-        expected_metadata3 = pytest.helpers.create_metadata('testapp-2', labels=LABELS,
-                                                            annotations={"some/annotation": "val",
-                                                                         "some/allowlist": "10.0.0.1/12"}, external=True)
-        expected_ingress3 = ingress(rules=[
-            _create_rule('extra.example.com', paths=[_create_path('/_/ipblocked', app_spec.name, 8000)])
-        ], metadata=expected_metadata3)
+        expected_metadata3 = pytest.helpers.create_metadata(
+            "testapp-2",
+            labels=LABELS,
+            annotations={"some/annotation": "val", "some/allowlist": "10.0.0.1/12"},
+            external=True,
+        )
+        expected_ingress3 = ingress(
+            rules=[_create_rule("extra.example.com", paths=[_create_path("/_/ipblocked", app_spec.name, 8000)])],
+            metadata=expected_metadata3,
+        )
         mock_response3 = create_autospec(Response)
         mock_response3.json.return_value = expected_ingress3
 
@@ -358,14 +549,22 @@ class TestIngressDeployer(object):
 
         deployer.deploy(app_spec, LABELS)
 
-        post.assert_has_calls([mock.call(INGRESSES_URI, expected_ingress), mock.call(INGRESSES_URI, expected_ingress2),
-                               mock.call(INGRESSES_URI, expected_ingress3)])
+        post.assert_has_calls(
+            [
+                mock.call(INGRESSES_URI, expected_ingress),
+                mock.call(INGRESSES_URI, expected_ingress2),
+                mock.call(INGRESSES_URI, expected_ingress3),
+            ]
+        )
         delete.assert_called_once_with(INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
 
-    @pytest.mark.parametrize("spec_name", (
+    @pytest.mark.parametrize(
+        "spec_name",
+        (
             "app_spec_thrift",
             "app_spec_no_ports",
-    ))
+        ),
+    )
     def test_remove_existing_ingress_if_not_needed(self, request, delete, post, deployer, spec_name):
         app_spec = request.getfuncargvalue(spec_name)
 
@@ -381,62 +580,94 @@ class TestIngressDeployer(object):
         pytest.helpers.assert_no_calls(post, INGRESSES_URI)
         pytest.helpers.assert_any_call(delete, INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
 
-    @pytest.mark.parametrize("app_spec, hosts", (
-            (app_spec(), ['testapp.svc.test.example.com', 'testapp.127.0.0.1.xip.io']),
-            (app_spec(ingresses=[
-                IngressItemSpec(host="foo.rewrite.example.com",
-                                pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={})]),
-             ['test.foo.rewrite.example.com', 'testapp.svc.test.example.com', 'testapp.127.0.0.1.xip.io']),
-    ))
+    @pytest.mark.parametrize(
+        "app_spec, hosts",
+        (
+            (app_spec(), ["testapp.svc.test.example.com", "testapp.127.0.0.1.xip.io"]),
+            (
+                app_spec(
+                    ingresses=[
+                        IngressItemSpec(
+                            host="foo.rewrite.example.com",
+                            pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                            annotations={},
+                        )
+                    ]
+                ),
+                ["test.foo.rewrite.example.com", "testapp.svc.test.example.com", "testapp.127.0.0.1.xip.io"],
+            ),
+        ),
+    )
     @pytest.mark.usefixtures("delete")
     def test_applies_ingress_tls_deployer(self, deployer, ingress_tls_deployer, app_spec, hosts):
         with mock.patch("k8s.models.networking_v1_ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             deployer.deploy(app_spec, LABELS)
-            ingress_tls_deployer.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True)
+            ingress_tls_deployer.apply.assert_called_once_with(
+                TypeMatcher(Ingress), app_spec, hosts, DEFAULT_TLS_ISSUER, use_suffixes=True
+            )
 
     @pytest.fixture
     def deployer_issuer_overrides(self, config, default_app_spec, ingress_adapter):
         config.tls_certificate_issuer_type_overrides = {
             "foo.example.com": "certmanager.k8s.io/issuer",
             "bar.example.com": "certmanager.k8s.io/cluster-issuer",
-            "foo.bar.example.com": "certmanager.k8s.io/issuer"
+            "foo.bar.example.com": "certmanager.k8s.io/issuer",
         }
         return IngressDeployer(config, default_app_spec, ingress_adapter)
 
     @pytest.mark.usefixtures("delete")
-    def test_applies_ingress_tls_deployer_issuer_overrides(self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec):
+    def test_applies_ingress_tls_deployer_issuer_overrides(
+        self, post, deployer_issuer_overrides, ingress_tls_deployer, app_spec
+    ):
         with mock.patch("k8s.models.networking_v1_ingress.Ingress.get_or_create") as get_or_create:
             get_or_create.return_value = mock.create_autospec(Ingress, spec_set=True)
             app_spec.ingresses[:] = [
                 # has issuer-override
-                IngressItemSpec(host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # no issuer-override
-                IngressItemSpec(host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
-                IngressItemSpec(host="foo.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
-                IngressItemSpec(host="other.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+                IngressItemSpec(
+                    host="foo.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
+                IngressItemSpec(
+                    host="other.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # suffix has issuer-override
-                IngressItemSpec(host="sub.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="sub.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # more specific suffix has issuer-override
-                IngressItemSpec(host="sub.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}),
+                IngressItemSpec(
+                    host="sub.bar.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)], annotations={}
+                ),
                 # has annotations
-                IngressItemSpec(host="ann.foo.example.com", pathmappings=[IngressPathMappingSpec(path="/", port=80)],
-                                annotations={"some": "annotation"})
+                IngressItemSpec(
+                    host="ann.foo.example.com",
+                    pathmappings=[IngressPathMappingSpec(path="/", port=80)],
+                    annotations={"some": "annotation"},
+                ),
             ]
 
             deployer_issuer_overrides.deploy(app_spec, LABELS)
             host_groups = [sorted(call.args[2]) for call in ingress_tls_deployer.apply.call_args_list]
-            ingress_names = [call.kwargs['metadata'].name for call in get_or_create.call_args_list]
+            ingress_names = [call.kwargs["metadata"].name for call in get_or_create.call_args_list]
             expected_host_groups = [
                 ["ann.foo.example.com"],
-                ["bar.example.com", "other.example.com", "sub.bar.example.com", "testapp.127.0.0.1.xip.io", "testapp.svc.test.example.com"],
-                ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"]
+                [
+                    "bar.example.com",
+                    "other.example.com",
+                    "sub.bar.example.com",
+                    "testapp.127.0.0.1.xip.io",
+                    "testapp.svc.test.example.com",
+                ],
+                ["foo.bar.example.com", "foo.example.com", "sub.foo.example.com"],
             ]
-            expected_ingress_names = [
-                "testapp",
-                "testapp-1",
-                "testapp-2"
-            ]
+            expected_ingress_names = ["testapp", "testapp-1", "testapp-2"]
             assert ingress_tls_deployer.apply.call_count == 3
             assert expected_host_groups == sorted(host_groups)
             assert expected_ingress_names == sorted(ingress_names)

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_owner_references.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_owner_references.py
@@ -7,19 +7,20 @@ from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerRefere
 
 
 class TestOwnerReferences(object):
-
     @pytest.fixture
     def owner_references(self):
         return OwnerReferences()
 
     @pytest.fixture
     def expected(self, app_spec):
-        expected = OwnerReference(apiVersion="fiaas.schibsted.io/v1",
-                                  kind="Application",
-                                  controller=True,
-                                  blockOwnerDeletion=True,
-                                  name=app_spec.name,
-                                  uid=app_spec.uid)
+        expected = OwnerReference(
+            apiVersion="fiaas.schibsted.io/v1",
+            kind="Application",
+            controller=True,
+            blockOwnerDeletion=True,
+            name=app_spec.name,
+            uid=app_spec.uid,
+        )
         return expected
 
     def test_apply(self, app_spec, owner_references, expected):

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ready_check.py
@@ -44,8 +44,15 @@ class TestReadyCheck(object):
 
     @pytest.fixture
     def lifecycle_subject(self, app_spec):
-        return Subject(app_spec.uid, app_spec.name, app_spec.namespace, app_spec.deployment_id, None,
-                       app_spec.labels.status, app_spec.annotations.status)
+        return Subject(
+            app_spec.uid,
+            app_spec.name,
+            app_spec.namespace,
+            app_spec.deployment_id,
+            None,
+            app_spec.labels.status,
+            app_spec.annotations.status,
+        )
 
     @pytest.fixture
     def config(self):
@@ -60,12 +67,19 @@ class TestReadyCheck(object):
         with mock.patch("k8s.models.certificate.Certificate.get") as get_cert:
             yield get_cert
 
-    @pytest.mark.parametrize("generation,observed_generation", (
-            (0, 0),
-            (0, 1)
-    ))
-    def test_deployment_complete(self, get, app_spec, bookkeeper, generation, observed_generation, lifecycle,
-                                 lifecycle_subject, ingress_adapter, config):
+    @pytest.mark.parametrize("generation,observed_generation", ((0, 0), (0, 1)))
+    def test_deployment_complete(
+        self,
+        get,
+        app_spec,
+        bookkeeper,
+        generation,
+        observed_generation,
+        lifecycle,
+        lifecycle_subject,
+        ingress_adapter,
+        config,
+    ):
         self._create_response(get, generation=generation, observed_generation=observed_generation)
         ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
@@ -75,17 +89,33 @@ class TestReadyCheck(object):
         lifecycle.success.assert_called_with(lifecycle_subject)
         lifecycle.failed.assert_not_called()
 
-    @pytest.mark.parametrize("requested,replicas,available,updated,generation,observed_generation", (
+    @pytest.mark.parametrize(
+        "requested,replicas,available,updated,generation,observed_generation",
+        (
             (8, 9, 7, 2, 0, 0),
             (2, 2, 1, 2, 0, 0),
             (2, 2, 2, 1, 0, 0),
             (2, 1, 1, 1, 0, 0),
             (1, 2, 1, 1, 0, 0),
             (2, 2, 2, 2, 1, 0),
-    ))
-    def test_deployment_incomplete(self, get, app_spec, bookkeeper, requested, replicas, available, updated,
-                                   generation, observed_generation, lifecycle, lifecycle_subject, ingress_adapter,
-                                   config):
+        ),
+    )
+    def test_deployment_incomplete(
+        self,
+        get,
+        app_spec,
+        bookkeeper,
+        requested,
+        replicas,
+        available,
+        updated,
+        generation,
+        observed_generation,
+        lifecycle,
+        lifecycle_subject,
+        ingress_adapter,
+        config,
+    ):
         self._create_response(get, requested, replicas, available, updated, generation, observed_generation)
         ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
 
@@ -95,15 +125,32 @@ class TestReadyCheck(object):
         lifecycle.success.assert_not_called()
         lifecycle.failed.assert_not_called()
 
-    @pytest.mark.parametrize("requested,replicas,available,updated,annotations,repository", (
+    @pytest.mark.parametrize(
+        "requested,replicas,available,updated,annotations,repository",
+        (
             (8, 9, 7, 2, None, None),
             (2, 2, 1, 2, None, None),
             (2, 2, 2, 1, None, None),
             (2, 1, 1, 1, None, None),
             (2, 1, 1, 1, {"fiaas/source-repository": "xyz"}, "xyz"),
-    ))
-    def test_deployment_failed(self, get, app_spec, bookkeeper, requested, replicas, available, updated,
-                               lifecycle, lifecycle_subject, annotations, repository, ingress_adapter, config):
+        ),
+    )
+    def test_deployment_failed(
+        self,
+        get,
+        app_spec,
+        bookkeeper,
+        requested,
+        replicas,
+        available,
+        updated,
+        lifecycle,
+        lifecycle_subject,
+        annotations,
+        repository,
+        ingress_adapter,
+        config,
+    ):
         if annotations:
             app_spec = app_spec._replace(annotations=LabelAndAnnotationSpec(*[annotations] * 7))
 
@@ -118,8 +165,9 @@ class TestReadyCheck(object):
         lifecycle.success.assert_not_called()
         lifecycle.failed.assert_called_with(lifecycle_subject)
 
-    def test_deployment_complete_deactivated(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
-                                             ingress_adapter, config):
+    def test_deployment_complete_deactivated(
+        self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config
+    ):
 
         self._create_response_zero_replicas(get)
         ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
@@ -130,7 +178,9 @@ class TestReadyCheck(object):
         lifecycle.success.assert_called_with(lifecycle_subject)
         lifecycle.failed.assert_not_called()
 
-    @pytest.mark.parametrize("ingress_class,ingress_tls,cert_valid,expiration_date,result,success", (
+    @pytest.mark.parametrize(
+        "ingress_class,ingress_tls,cert_valid,expiration_date,result,success",
+        (
             (Ingress, IngressTLS, True, (datetime.now() + timedelta(days=5)), False, True),
             (V1Ingress, V1IngressTLS, True, (datetime.now() + timedelta(days=5)), False, True),
             (Ingress, IngressTLS, True, None, False, True),
@@ -140,10 +190,26 @@ class TestReadyCheck(object):
             (Ingress, IngressTLS, False, None, False, False),
             (V1Ingress, V1IngressTLS, False, None, False, False),
             (Ingress, IngressTLS, False, None, True, True),
-            (V1Ingress, V1IngressTLS, False, None, True, True)
-    ))
-    def test_tls_ingress(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, get_cert, ingress_adapter,
-                         ingress_class, ingress_tls, cert_valid, expiration_date, result, success, config):
+            (V1Ingress, V1IngressTLS, False, None, True, True),
+        ),
+    )
+    def test_tls_ingress(
+        self,
+        get,
+        app_spec,
+        bookkeeper,
+        lifecycle,
+        lifecycle_subject,
+        get_cert,
+        ingress_adapter,
+        ingress_class,
+        ingress_tls,
+        cert_valid,
+        expiration_date,
+        result,
+        success,
+        config,
+    ):
         config.tls_certificate_ready = True
         app_spec = app_spec._replace(ingress_tls=IngressTLSSpec(enabled=True, certificate_issuer=None))
         replicas = 2
@@ -176,8 +242,9 @@ class TestReadyCheck(object):
             bookkeeper.failed.assert_called_with(app_spec)
             lifecycle.failed.assert_called_with(lifecycle_subject)
 
-    def test_deployment_tls_config_no_tls_extension(self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject,
-                                                    ingress_adapter, config):
+    def test_deployment_tls_config_no_tls_extension(
+        self, get, app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config
+    ):
         config.tls_certificate_ready = True
         self._create_response(get)
         ready = ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
@@ -204,33 +271,42 @@ class TestReadyCheck(object):
         return cert
 
     @staticmethod
-    def _create_response(get, requested=REPLICAS, replicas=REPLICAS, available=REPLICAS, updated=REPLICAS,
-                         generation=0, observed_generation=0):
+    def _create_response(
+        get,
+        requested=REPLICAS,
+        replicas=REPLICAS,
+        available=REPLICAS,
+        updated=REPLICAS,
+        generation=0,
+        observed_generation=0,
+    ):
         get.side_effect = None
         resp = mock.MagicMock()
         get.return_value = resp
         resp.json.return_value = {
-            'metadata': pytest.helpers.create_metadata('testapp', generation=generation),
-            'spec': {
-                'selector': {'matchLabels': {'app': 'testapp'}},
-                'template': {
-                    'spec': {
-                        'containers': [{
-                            'name': 'testapp',
-                            'image': 'finntech/testimage:version',
-                        }]
+            "metadata": pytest.helpers.create_metadata("testapp", generation=generation),
+            "spec": {
+                "selector": {"matchLabels": {"app": "testapp"}},
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "testapp",
+                                "image": "finntech/testimage:version",
+                            }
+                        ]
                     },
-                    'metadata': pytest.helpers.create_metadata('testapp')
+                    "metadata": pytest.helpers.create_metadata("testapp"),
                 },
-                'replicas': requested
+                "replicas": requested,
             },
-            'status': {
-                'replicas': replicas,
-                'availableReplicas': available,
-                'unavailableReplicas': replicas - available,
-                'updatedReplicas': updated,
-                'observedGeneration': observed_generation,
-            }
+            "status": {
+                "replicas": replicas,
+                "availableReplicas": available,
+                "unavailableReplicas": replicas - available,
+                "updatedReplicas": updated,
+                "observedGeneration": observed_generation,
+            },
         }
 
     @staticmethod
@@ -239,21 +315,23 @@ class TestReadyCheck(object):
         resp = mock.MagicMock()
         get.return_value = resp
         resp.json.return_value = {
-            'metadata': pytest.helpers.create_metadata('testapp', generation=0),
-            'spec': {
-                'selector': {'matchLabels': {'app': 'testapp'}},
-                'template': {
-                    'spec': {
-                        'containers': [{
-                            'name': 'testapp',
-                            'image': 'finntech/testimage:version',
-                        }]
+            "metadata": pytest.helpers.create_metadata("testapp", generation=0),
+            "spec": {
+                "selector": {"matchLabels": {"app": "testapp"}},
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "testapp",
+                                "image": "finntech/testimage:version",
+                            }
+                        ]
                     },
-                    'metadata': pytest.helpers.create_metadata('testapp')
+                    "metadata": pytest.helpers.create_metadata("testapp"),
                 },
-                'replicas': 0
+                "replicas": 0,
             },
-            'status': {
-                'observedGeneration': 0,
-            }
+            "status": {
+                "observedGeneration": 0,
+            },
         }

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_service_account_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_service_account_deploy.py
@@ -29,12 +29,11 @@ from utils import TypeMatcher
 
 from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
 
-SERVICE_ACCOUNT_URI = '/api/v1/namespaces/default/serviceaccounts/'
+SERVICE_ACCOUNT_URI = "/api/v1/namespaces/default/serviceaccounts/"
 LABELS = {"service": "pass through"}
 
 
 class TestServiceAccountDeployer(object):
-
     @pytest.fixture
     def deployer(self, owner_references):
         config = create_autospec(Configuration([]), spec_set=True)
@@ -43,9 +42,9 @@ class TestServiceAccountDeployer(object):
     @pytest.mark.usefixtures("get")
     def test_deploy_new_service_account(self, deployer, post, app_spec, owner_references):
         expected_service_account = {
-                'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS),
-                'secrets': [],
-                'imagePullSecrets': []
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
+            "secrets": [],
+            "imagePullSecrets": [],
         }
 
         mock_response = create_autospec(Response)
@@ -57,31 +56,36 @@ class TestServiceAccountDeployer(object):
         pytest.helpers.assert_any_call(post, SERVICE_ACCOUNT_URI, expected_service_account)
         owner_references.apply.assert_called_once_with(TypeMatcher(ServiceAccount), app_spec)
 
-    @pytest.mark.parametrize('owner_references', (
-        [],
-        [{
-                "apiVersion": "example.com/v1",
-                "kind": "random",
-                "name": "testapp",
-        }],
-        [
-            {
-                "apiVersion": "example.com/v1",
-                "kind": "random",
-                "name": "testapp",
-            },
-            {
-                "apiVersion": "example.com/v1",
-                "kind": "random2",
-                "name": "testapp",
-            },
-        ],
-    ))
+    @pytest.mark.parametrize(
+        "owner_references",
+        (
+            [],
+            [
+                {
+                    "apiVersion": "example.com/v1",
+                    "kind": "random",
+                    "name": "testapp",
+                }
+            ],
+            [
+                {
+                    "apiVersion": "example.com/v1",
+                    "kind": "random",
+                    "name": "testapp",
+                },
+                {
+                    "apiVersion": "example.com/v1",
+                    "kind": "random2",
+                    "name": "testapp",
+                },
+            ],
+        ),
+    )
     def test_deploy_existing_service_account(self, get, deployer, post, put, app_spec, owner_references):
         existing_service_account = {
-                'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS, owner_references=owner_references),
-                'secrets': [],
-                'imagePullSecrets': []
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS, owner_references=owner_references),
+            "secrets": [],
+            "imagePullSecrets": [],
         }
 
         mock_response = create_autospec(Response)
@@ -95,20 +99,22 @@ class TestServiceAccountDeployer(object):
 
     def test_deploy_existing_fiaas_owned_service_account(self, get, post, put, app_spec):
         existing_service_account = {
-            'metadata': pytest.helpers.create_metadata(
+            "metadata": pytest.helpers.create_metadata(
                 app_spec.name,
                 labels=LABELS,
-                owner_references=[{
-                    "apiVersion": "fiaas.schibsted.io/v1",
-                    "blockOwnerDeletion": True,
-                    "controller": True,
-                    "kind": "Application",
-                    "name": app_spec.name,
-                    "uid": app_spec.uid,
-                }],
+                owner_references=[
+                    {
+                        "apiVersion": "fiaas.schibsted.io/v1",
+                        "blockOwnerDeletion": True,
+                        "controller": True,
+                        "kind": "Application",
+                        "name": app_spec.name,
+                        "uid": app_spec.uid,
+                    }
+                ],
             ),
-            'secrets': [{'name': app_spec.name + "-token-6f7fp"}],
-            'imagePullSecrets': []
+            "secrets": [{"name": app_spec.name + "-token-6f7fp"}],
+            "imagePullSecrets": [],
         }
 
         def get_existing_or_not(uri):
@@ -134,19 +140,22 @@ class TestServiceAccountDeployer(object):
 
     @pytest.fixture
     def service_account_get(self):
-        with mock.patch('k8s.models.service_account.ServiceAccount.get') as get:
+        with mock.patch("k8s.models.service_account.ServiceAccount.get") as get:
             yield get
 
-    @pytest.mark.parametrize('default_sa_exists,image_pull_secrets', (
-        (False, []),
-        (True, []),
-        (True, ['one']),
-        (True, ['one', 'two', 'three']),
-    ))
-    def test_service_account_should_propagate_image_pull_secrets_from_default(self, service_account_get, post,
-                                                                              app_spec, owner_references, deployer,
-                                                                              default_sa_exists, image_pull_secrets):
-        default_sa_name = 'default'
+    @pytest.mark.parametrize(
+        "default_sa_exists,image_pull_secrets",
+        (
+            (False, []),
+            (True, []),
+            (True, ["one"]),
+            (True, ["one", "two", "three"]),
+        ),
+    )
+    def test_service_account_should_propagate_image_pull_secrets_from_default(
+        self, service_account_get, post, app_spec, owner_references, deployer, default_sa_exists, image_pull_secrets
+    ):
+        default_sa_name = "default"
         default_service_account = ServiceAccount(
             metadata=ObjectMeta(name=default_sa_name),
             imagePullSecrets=image_pull_secrets,
@@ -161,9 +170,9 @@ class TestServiceAccountDeployer(object):
         service_account_get.side_effect = get_default_or_notfound
 
         expected_service_account = {
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS),
-            'secrets': [],
-            'imagePullSecrets': image_pull_secrets,
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
+            "secrets": [],
+            "imagePullSecrets": image_pull_secrets,
         }
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_service_account

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_service_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_service_deploy.py
@@ -27,9 +27,9 @@ from fiaas_deploy_daemon.specs.models import LabelAndAnnotationSpec
 
 from utils import TypeMatcher
 
-SELECTOR = {'app': 'testapp'}
+SELECTOR = {"app": "testapp"}
 LABELS = {"service": "pass through"}
-SERVICES_URI = '/api/v1/namespaces/default/services/'
+SERVICES_URI = "/api/v1/namespaces/default/services/"
 
 
 class TestServiceDeployer(object):
@@ -50,20 +50,14 @@ class TestServiceDeployer(object):
     @pytest.mark.usefixtures("get")
     def test_deploy_new_service(self, deployer, service_type, post, app_spec, owner_references, extension_hook):
         expected_service = {
-            'spec': {
-                'selector': SELECTOR,
-                'type': service_type,
-                "loadBalancerSourceRanges": [
-                ],
-                'ports': [{
-                    'protocol': 'TCP',
-                    'targetPort': 8080,
-                    'name': 'http',
-                    'port': 80
-                }],
-                'sessionAffinity': 'None'
+            "spec": {
+                "selector": SELECTOR,
+                "type": service_type,
+                "loadBalancerSourceRanges": [],
+                "ports": [{"protocol": "TCP", "targetPort": 8080, "name": "http", "port": 80}],
+                "sessionAffinity": "None",
             },
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS)
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
         }
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_service
@@ -81,30 +75,39 @@ class TestServiceDeployer(object):
         expected_annotations = {"custom": "annotation"}
 
         expected_service = {
-            'spec': {
-                'selector': SELECTOR,
-                'type': service_type,
-                "loadBalancerSourceRanges": [
-                ],
-                'ports': [{
-                    'protocol': 'TCP',
-                    'targetPort': 8080,
-                    'name': 'http',
-                    'port': 80
-                }],
-                'sessionAffinity': 'None'
+            "spec": {
+                "selector": SELECTOR,
+                "type": service_type,
+                "loadBalancerSourceRanges": [],
+                "ports": [{"protocol": "TCP", "targetPort": 8080, "name": "http", "port": 80}],
+                "sessionAffinity": "None",
             },
-            'metadata': pytest.helpers.create_metadata('testapp', labels=expected_labels,
-                                                       annotations=expected_annotations)
+            "metadata": pytest.helpers.create_metadata(
+                "testapp", labels=expected_labels, annotations=expected_annotations
+            ),
         }
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_service
         post.return_value = mock_response
 
-        labels = LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={}, ingress={},
-                                        service=expected_labels, service_account={}, pod={}, status={})
-        annotations = LabelAndAnnotationSpec(deployment={}, horizontal_pod_autoscaler={}, ingress={},
-                                             service=expected_annotations, service_account={}, pod={}, status={})
+        labels = LabelAndAnnotationSpec(
+            deployment={},
+            horizontal_pod_autoscaler={},
+            ingress={},
+            service=expected_labels,
+            service_account={},
+            pod={},
+            status={},
+        )
+        annotations = LabelAndAnnotationSpec(
+            deployment={},
+            horizontal_pod_autoscaler={},
+            ingress={},
+            service=expected_annotations,
+            service_account={},
+            pod={},
+            status={},
+        )
         app_spec_custom_labels_and_annotations = app_spec._replace(labels=labels, annotations=annotations)
 
         deployer.deploy(app_spec_custom_labels_and_annotations, SELECTOR, {})
@@ -114,28 +117,19 @@ class TestServiceDeployer(object):
     @pytest.mark.usefixtures("get")
     def test_deploy_new_service_with_multiple_ports(self, deployer, service_type, post, app_spec_thrift_and_http):
         expected_service = {
-            'spec': {
-                'selector': SELECTOR,
-                'type': service_type,
+            "spec": {
+                "selector": SELECTOR,
+                "type": service_type,
                 "loadBalancerSourceRanges": [],
-                'ports': [
-                    {
-                        'protocol': 'TCP',
-                        'targetPort': 8080,
-                        'name': 'http',
-                        'port': 80
-                    },
-                    {
-                        'protocol': 'TCP',
-                        'targetPort': 7999,
-                        'name': 'thrift',
-                        'port': 7999
-                    },
+                "ports": [
+                    {"protocol": "TCP", "targetPort": 8080, "name": "http", "port": 80},
+                    {"protocol": "TCP", "targetPort": 7999, "name": "thrift", "port": 7999},
                 ],
-                'sessionAffinity': 'None'
+                "sessionAffinity": "None",
             },
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS,
-                                                       annotations={"fiaas/tcp_port_names": "thrift"})
+            "metadata": pytest.helpers.create_metadata(
+                "testapp", labels=LABELS, annotations={"fiaas/tcp_port_names": "thrift"}
+            ),
         }
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_service
@@ -146,31 +140,23 @@ class TestServiceDeployer(object):
         pytest.helpers.assert_any_call(post, SERVICES_URI, expected_service)
 
     @pytest.mark.usefixtures("get")
-    def test_deploy_new_service_with_multiple_tcp_ports(self, deployer, service_type, post,
-                                                        app_spec_multiple_thrift_ports):
+    def test_deploy_new_service_with_multiple_tcp_ports(
+        self, deployer, service_type, post, app_spec_multiple_thrift_ports
+    ):
         expected_service = {
-            'spec': {
-                'selector': SELECTOR,
-                'type': service_type,
+            "spec": {
+                "selector": SELECTOR,
+                "type": service_type,
                 "loadBalancerSourceRanges": [],
-                'ports': [
-                    {
-                        'protocol': 'TCP',
-                        'targetPort': 7999,
-                        'name': 'thrift1',
-                        'port': 7999
-                    },
-                    {
-                        'protocol': 'TCP',
-                        'targetPort': 8000,
-                        'name': 'thrift2',
-                        'port': 8000
-                    },
+                "ports": [
+                    {"protocol": "TCP", "targetPort": 7999, "name": "thrift1", "port": 7999},
+                    {"protocol": "TCP", "targetPort": 8000, "name": "thrift2", "port": 8000},
                 ],
-                'sessionAffinity': 'None'
+                "sessionAffinity": "None",
             },
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS,
-                                                       annotations={"fiaas/tcp_port_names": "thrift1,thrift2"})
+            "metadata": pytest.helpers.create_metadata(
+                "testapp", labels=LABELS, annotations={"fiaas/tcp_port_names": "thrift1,thrift2"}
+            ),
         }
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_service
@@ -183,41 +169,27 @@ class TestServiceDeployer(object):
     def test_update_service(self, deployer, service_type, get, post, put, app_spec):
         mock_response = create_autospec(Response)
         mock_response.json.return_value = {
-            'spec': {
-                'selector': SELECTOR,
-                'type': service_type,
-                "loadBalancerSourceRanges": [
-                ],
-                'ports': [{
-                    'protocol': 'TCP',
-                    'targetPort': 8081,
-                    'name': 'http',
-                    'port': 81,
-                    'nodePort': 34567
-                }],
-                'sessionAffinity': 'None'
+            "spec": {
+                "selector": SELECTOR,
+                "type": service_type,
+                "loadBalancerSourceRanges": [],
+                "ports": [{"protocol": "TCP", "targetPort": 8081, "name": "http", "port": 81, "nodePort": 34567}],
+                "sessionAffinity": "None",
             },
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS)
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
         }
         get.side_effect = None
         get.return_value = mock_response
 
         expected_service = {
-            'spec': {
-                'selector': SELECTOR,
-                'type': service_type,
-                "loadBalancerSourceRanges": [
-                ],
-                'ports': [{
-                    'protocol': 'TCP',
-                    'targetPort': 8080,
-                    'name': 'http',
-                    'port': 80,
-                    'nodePort': 34567
-                }],
-                'sessionAffinity': 'None'
+            "spec": {
+                "selector": SELECTOR,
+                "type": service_type,
+                "loadBalancerSourceRanges": [],
+                "ports": [{"protocol": "TCP", "targetPort": 8080, "name": "http", "port": 80, "nodePort": 34567}],
+                "sessionAffinity": "None",
             },
-            'metadata': pytest.helpers.create_metadata('testapp', labels=LABELS)
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
         }
         mock_response = create_autospec(Response)
         mock_response.json.return_value = expected_service

--- a/tests/fiaas_deploy_daemon/deployer/test_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/test_deploy.py
@@ -52,8 +52,15 @@ class TestDeploy(object):
 
     @pytest.fixture
     def lifecycle_subject(self, app_spec):
-        return Subject(app_spec.uid, app_spec.name, app_spec.namespace, app_spec.deployment_id, None,
-                       app_spec.labels.status, app_spec.annotations.status)
+        return Subject(
+            app_spec.uid,
+            app_spec.name,
+            app_spec.namespace,
+            app_spec.deployment_id,
+            None,
+            app_spec.labels.status,
+            app_spec.annotations.status,
+        )
 
     @pytest.fixture
     def ingress_adapter(self):
@@ -74,10 +81,13 @@ class TestDeploy(object):
 
         adapter.deploy.assert_called_with(app_spec)
 
-    @pytest.mark.parametrize("annotations,repository", [
-        (None, None),
-        ({"fiaas/source-repository": "xyz"}, "xyz"),
-    ])
+    @pytest.mark.parametrize(
+        "annotations,repository",
+        [
+            (None, None),
+            ({"fiaas/source-repository": "xyz"}, "xyz"),
+        ],
+    )
     def test_signals_start_of_deploy(self, app_spec, lifecycle, lifecycle_subject, deployer, annotations, repository):
         if annotations:
             app_spec = app_spec._replace(annotations=LabelAndAnnotationSpec(*[annotations] * 7))
@@ -86,11 +96,16 @@ class TestDeploy(object):
 
         lifecycle.state_change_signal.send.assert_called_with(status=STATUS_STARTED, subject=lifecycle_subject)
 
-    @pytest.mark.parametrize("annotations,repository", [
-        (None, None),
-        ({"fiaas/source-repository": "xyz"}, "xyz"),
-    ])
-    def test_signals_failure_on_exception(self, app_spec, lifecycle, lifecycle_subject, deployer, adapter, annotations, repository):
+    @pytest.mark.parametrize(
+        "annotations,repository",
+        [
+            (None, None),
+            ({"fiaas/source-repository": "xyz"}, "xyz"),
+        ],
+    )
+    def test_signals_failure_on_exception(
+        self, app_spec, lifecycle, lifecycle_subject, deployer, adapter, annotations, repository
+    ):
         if annotations:
             app_spec = app_spec._replace(annotations=LabelAndAnnotationSpec(*[annotations] * 7))
         deployer._queue = [DeployerEvent("UPDATE", app_spec, lifecycle_subject)]
@@ -100,10 +115,12 @@ class TestDeploy(object):
 
         lifecycle.state_change_signal.send.assert_called_with(status=STATUS_FAILED, subject=lifecycle_subject)
 
-    def test_schedules_ready_check(self, app_spec, scheduler, bookkeeper, deployer, lifecycle, lifecycle_subject,
-                                   ingress_adapter, config):
+    def test_schedules_ready_check(
+        self, app_spec, scheduler, bookkeeper, deployer, lifecycle, lifecycle_subject, ingress_adapter, config
+    ):
         deployer()
 
         lifecycle.state_change_signal.send.assert_called_once_with(status=STATUS_STARTED, subject=lifecycle_subject)
-        scheduler.add.assert_called_with(ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter,
-                                                    config))
+        scheduler.add.assert_called_with(
+            ReadyCheck(app_spec, bookkeeper, lifecycle, lifecycle_subject, ingress_adapter, config)
+        )

--- a/tests/fiaas_deploy_daemon/specs/conftest.py
+++ b/tests/fiaas_deploy_daemon/specs/conftest.py
@@ -21,18 +21,20 @@ import yaml
 @pytest.fixture
 def load_app_config_testdata(request):
     def _load(filename):
-        path = _find_file(filename+".yml", request.fspath.dirpath(), "examples")
-        with open(path, 'r') as fobj:
+        path = _find_file(filename + ".yml", request.fspath.dirpath(), "examples")
+        with open(path, "r") as fobj:
             return yaml.safe_load(fobj)
+
     return _load
 
 
 @pytest.fixture
 def load_app_config_transformations(request):
     def _load(filename):
-        path = _find_file(filename+".yml", request.fspath.dirpath(), "transformations")
-        with open(path, 'r') as fobj:
+        path = _find_file(filename + ".yml", request.fspath.dirpath(), "transformations")
+        with open(path, "r") as fobj:
             return yaml.safe_load(fobj)
+
     return _load
 
 

--- a/tests/fiaas_deploy_daemon/specs/test_lookup.py
+++ b/tests/fiaas_deploy_daemon/specs/test_lookup.py
@@ -21,27 +21,9 @@ import pytest
 from fiaas_deploy_daemon.specs.factory import InvalidConfiguration
 from fiaas_deploy_daemon.specs.lookup import LookupMapping
 
-CONFIG = {
-    "object": {
-        "complex": {
-            "first": 1,
-            "second": 2
-        }
-    },
-    "list": [
-        "one",
-        "two",
-        "three"
-    ]
-}
+CONFIG = {"object": {"complex": {"first": 1, "second": 2}}, "list": ["one", "two", "three"]}
 
-DEFAULTS = {
-    "object": {
-        "simple": 1,
-        "complex": {}
-    },
-    "list": []
-}
+DEFAULTS = {"object": {"simple": 1, "complex": {}}, "list": []}
 
 
 class TestLookup(object):
@@ -51,9 +33,7 @@ class TestLookup(object):
 
     def test_dict(self, lookup):
         assert lookup["object"]["simple"] == 1
-        assert lookup["object"]["complex"] == {
-            "first": 1, "second": 2
-        }
+        assert lookup["object"]["complex"] == {"first": 1, "second": 2}
         assert lookup["object"]["complex"]["first"] == 1
 
     def test_list(self, lookup):
@@ -61,37 +41,39 @@ class TestLookup(object):
         assert lookup["list"][0] == "one"
         assert lookup["list"][-1] == "three"
 
-    @pytest.mark.parametrize("type,expected", (
+    @pytest.mark.parametrize(
+        "type,expected",
+        (
             ("object", 2),
             ("list", 3),
-    ))
+        ),
+    )
     def test_len(self, lookup, type, expected):
         assert len(lookup[type]) == expected
 
     def test_items(self, lookup):
         assert list(lookup["object"].items()) == [("simple", 1), ("complex", {"first": 1, "second": 2})]
 
-    @pytest.mark.parametrize("config,defaults", (
-        (CONFIG, 1),
-        (CONFIG, True),
-        (CONFIG, "string"),
-        (1, DEFAULTS),
-        (True, DEFAULTS),
-        ("string", DEFAULTS)
-    ))
+    @pytest.mark.parametrize(
+        "config,defaults",
+        ((CONFIG, 1), (CONFIG, True), (CONFIG, "string"), (1, DEFAULTS), (True, DEFAULTS), ("string", DEFAULTS)),
+    )
     def test_incompatible_types(self, config, defaults):
         with pytest.raises(InvalidConfiguration):
             LookupMapping(config, defaults)
 
-    @pytest.mark.parametrize("config,defaults", (
-        (None, 1),
-        (None, True),
-        (None, "string"),
-        (None, DEFAULTS),
-        (1, None),
-        (True, None),
-        ("string", None),
-        (CONFIG, None)
-    ))
+    @pytest.mark.parametrize(
+        "config,defaults",
+        (
+            (None, 1),
+            (None, True),
+            (None, "string"),
+            (None, DEFAULTS),
+            (1, None),
+            (True, None),
+            ("string", None),
+            (CONFIG, None),
+        ),
+    )
     def test_ignore_empty(self, config, defaults):
         LookupMapping(config, defaults)

--- a/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
+++ b/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
@@ -56,11 +56,14 @@ class TestSpecFactory(object):
     def factory(self, v3, transformers, config):
         return SpecFactory(v3, transformers, config)
 
-    @pytest.mark.parametrize("version,mock_to_call", [
-        (None, "v1"),
-        (1, "v1"),
-        (2, "v2"),
-    ])
+    @pytest.mark.parametrize(
+        "version,mock_to_call",
+        [
+            (None, "v1"),
+            (1, "v1"),
+            (2, "v2"),
+        ],
+    )
     def test_dispatch_to_correct_transformer(self, request, factory, version, mock_to_call):
         minimal_config = {}
         if version:
@@ -92,14 +95,7 @@ class TestSpecFactory(object):
         actual = factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
         assert actual == expected
 
-    @pytest.mark.parametrize("exception", (
-        AttributeError,
-        KeyError,
-        IndexError,
-        ValueError,
-        TypeError,
-        NameError
-    ))
+    @pytest.mark.parametrize("exception", (AttributeError, KeyError, IndexError, ValueError, TypeError, NameError))
     def test_parse_errors_raises_invalid_config(self, factory, v3, exception):
         v3.side_effect = exception
         with pytest.raises(InvalidConfiguration):

--- a/tests/fiaas_deploy_daemon/specs/v2/test_v2transformer.py
+++ b/tests/fiaas_deploy_daemon/specs/v2/test_v2transformer.py
@@ -17,37 +17,37 @@
 import pytest
 
 from fiaas_deploy_daemon.specs.lookup import LookupMapping
-from fiaas_deploy_daemon.specs.v2.transformer import Transformer, _get, _set, RESOURCE_UNDEFINED_UGLYHACK, \
-    _flatten, _remove_intersect
+from fiaas_deploy_daemon.specs.v2.transformer import (
+    Transformer,
+    _get,
+    _set,
+    RESOURCE_UNDEFINED_UGLYHACK,
+    _flatten,
+    _remove_intersect,
+)
 
 
 class TestTransformer(object):
     @pytest.fixture
     def data(self):
-        return {
-            "first": {
-                "second": {
-                    "third": {
-                        "one": 1,
-                        "string": "some string"
-                    }
-                }
-            }
-        }
+        return {"first": {"second": {"third": {"one": 1, "string": "some string"}}}}
 
     @pytest.fixture
     def transformer(self):
         return Transformer()
 
-    @pytest.mark.parametrize("filename", (
-        "v2minimal",
-        "full_config",
-        "host",
-        "multiple_ports",
-        "tcp_config",
-        "partial_override",
-        "only_liveness",
-    ))
+    @pytest.mark.parametrize(
+        "filename",
+        (
+            "v2minimal",
+            "full_config",
+            "host",
+            "multiple_ports",
+            "tcp_config",
+            "partial_override",
+            "only_liveness",
+        ),
+    )
     def test_transformation(self, filename, transformer, load_app_config_testdata, load_app_config_transformations):
         config = load_app_config_testdata(filename)
         expected = load_app_config_transformations(filename)
@@ -72,48 +72,59 @@ class TestTransformer(object):
         assert data["first"]["alternative"]["crazy"] == "crazy"
 
     def test_flatten_creates_dicts(self):
-        x = {'prometheus': LookupMapping(
-                config={'path': '/xxx'},
-                defaults={'path': '/internal-backstage/prometheus', 'enabled': True, 'port': 'http'})}
-        assert _flatten(x) == {'prometheus': {'path': '/xxx', 'enabled': True, 'port': 'http'}}
+        x = {
+            "prometheus": LookupMapping(
+                config={"path": "/xxx"},
+                defaults={"path": "/internal-backstage/prometheus", "enabled": True, "port": "http"},
+            )
+        }
+        assert _flatten(x) == {"prometheus": {"path": "/xxx", "enabled": True, "port": "http"}}
 
-    @pytest.mark.parametrize("filename", (
-        "v2minimal",
-        "full_config",
-        "host",
-        "multiple_ports",
-        "tcp_config",
-        "partial_override",
-        "only_liveness",
-    ))
-    def test_transformation_strips_defaults(self, filename, transformer,
-                                            load_app_config_testdata, load_app_config_transformations):
+    @pytest.mark.parametrize(
+        "filename",
+        (
+            "v2minimal",
+            "full_config",
+            "host",
+            "multiple_ports",
+            "tcp_config",
+            "partial_override",
+            "only_liveness",
+        ),
+    )
+    def test_transformation_strips_defaults(
+        self, filename, transformer, load_app_config_testdata, load_app_config_transformations
+    ):
         config = load_app_config_testdata(filename)
         expected = load_app_config_transformations("strip_defaults/" + filename)
         actual = transformer(config, strip_defaults=True)
         assert expected == actual
 
-    @pytest.mark.parametrize("test_input, expected", (
-        pytest.param(({'first': 1},
-                      {'first': 1}),
-                     {},
-                     id='removes identical values'),
-        pytest.param(({'first': [{'yy': 123, 'zz': 456, 'xx': 777}]},
-                      {'first': [{'yy': 123, 'zz': 456, 'xx': 777}]}),
-                     {},
-                     id='removes identical values from single item dict list'),
-        pytest.param(({'first': [{'yy': 1}]},
-                      {'first': [{'yy': 1, 'zz': 2, 'xx': 3}]}),
-                     {},
-                     id='removes items from single item dict list that are subset'),
-        pytest.param(({'first': [{'yy': 1, 'xx': 2, 'zz': 3}]},
-                      {'first': [{'yy': 1, 'xx': 3}]}),
-                     {'first': [{'xx': 2, 'zz': 3}]},
-                     id='leaves items from single item dict list that are different'),
-        pytest.param(({'first': {'yy': 1}},
-                      {'first': {'yy': 1, 'zz': 2, 'xx': 3}}),
-                     {},
-                     id='removes dict values that are the same')
-    ))
+    @pytest.mark.parametrize(
+        "test_input, expected",
+        (
+            pytest.param(({"first": 1}, {"first": 1}), {}, id="removes identical values"),
+            pytest.param(
+                ({"first": [{"yy": 123, "zz": 456, "xx": 777}]}, {"first": [{"yy": 123, "zz": 456, "xx": 777}]}),
+                {},
+                id="removes identical values from single item dict list",
+            ),
+            pytest.param(
+                ({"first": [{"yy": 1}]}, {"first": [{"yy": 1, "zz": 2, "xx": 3}]}),
+                {},
+                id="removes items from single item dict list that are subset",
+            ),
+            pytest.param(
+                ({"first": [{"yy": 1, "xx": 2, "zz": 3}]}, {"first": [{"yy": 1, "xx": 3}]}),
+                {"first": [{"xx": 2, "zz": 3}]},
+                id="leaves items from single item dict list that are different",
+            ),
+            pytest.param(
+                ({"first": {"yy": 1}}, {"first": {"yy": 1, "zz": 2, "xx": 3}}),
+                {},
+                id="removes dict values that are the same",
+            ),
+        ),
+    )
     def test_remove_intersect(self, test_input, expected):
         assert _remove_intersect(test_input[0], test_input[1]) == expected

--- a/tests/fiaas_deploy_daemon/test_config.py
+++ b/tests/fiaas_deploy_daemon/test_config.py
@@ -22,7 +22,6 @@ from fiaas_deploy_daemon.config import Configuration, HostRewriteRule, KeyValue,
 
 
 class TestConfig(object):
-
     @pytest.fixture
     def getenv(self):
         with mock.patch("os.getenv") as getenv:
@@ -48,7 +47,7 @@ class TestConfig(object):
         config = Configuration([])
 
         assert not config.debug
-        assert config.api_server == 'https://kubernetes.default.svc.cluster.local'
+        assert config.api_server == "https://kubernetes.default.svc.cluster.local"
         assert config.api_token is None
         assert config.environment == ""
         assert config.infrastructure == "diy"
@@ -59,14 +58,17 @@ class TestConfig(object):
         assert config.disable_deprecated_managed_env_vars is False
         assert config.tls_certificate_ready is False
 
-    @pytest.mark.parametrize("arg,key", [
-        ("--api-server", "api_server"),
-        ("--api-token", "api_token"),
-        ("--api-cert", "api_cert"),
-        ("--environment", "environment"),
-        ("--proxy", "proxy"),
-        ("--strongbox-init-container-image", "strongbox_init_container_image"),
-    ])
+    @pytest.mark.parametrize(
+        "arg,key",
+        [
+            ("--api-server", "api_server"),
+            ("--api-token", "api_token"),
+            ("--api-cert", "api_cert"),
+            ("--environment", "environment"),
+            ("--proxy", "proxy"),
+            ("--strongbox-init-container-image", "strongbox_init_container_image"),
+        ],
+    )
     def test_parameters(self, arg, key):
         config = Configuration([arg, "value"])
 
@@ -77,14 +79,17 @@ class TestConfig(object):
 
         assert config.infrastructure == "gke"
 
-    @pytest.mark.parametrize("key", (
-        "debug",
-        "enable_crd_support",
-        "enable_deprecated_multi_namespace_support",
-        "enable_deprecated_tls_entry_per_host",
-        "disable_crd_creation",
-        "datadog_activate_sleep"
-    ))
+    @pytest.mark.parametrize(
+        "key",
+        (
+            "debug",
+            "enable_crd_support",
+            "enable_deprecated_multi_namespace_support",
+            "enable_deprecated_tls_entry_per_host",
+            "disable_crd_creation",
+            "datadog_activate_sleep",
+        ),
+    )
     def test_flags(self, key):
         flag = "--{}".format(key.replace("_", "-"))
         config = Configuration([])
@@ -92,13 +97,16 @@ class TestConfig(object):
         config = Configuration([flag])
         assert getattr(config, key) is True
 
-    @pytest.mark.parametrize("key,attr,value", [
-        ("environment", "environment", "gke"),
-        ("proxy", "proxy", "http://proxy.example.com"),
-        ("ingress-suffix", "ingress_suffixes", [r"1\.example.com", "2.example.com"]),
-        ("strongbox-init-container-image", "strongbox_init_container_image", "fiaas/strongbox-image-test:123"),
-        ("extension-hook-url", "extension_hook_url", "hook-service-url"),
-    ])
+    @pytest.mark.parametrize(
+        "key,attr,value",
+        [
+            ("environment", "environment", "gke"),
+            ("proxy", "proxy", "http://proxy.example.com"),
+            ("ingress-suffix", "ingress_suffixes", [r"1\.example.com", "2.example.com"]),
+            ("strongbox-init-container-image", "strongbox_init_container_image", "fiaas/strongbox-image-test:123"),
+            ("extension-hook-url", "extension_hook_url", "hook-service-url"),
+        ],
+    )
     def test_config_from_file(self, key, attr, value, tmpdir):
         config_file = tmpdir.join("config.yaml")
         with config_file.open("w") as fobj:
@@ -166,10 +174,7 @@ class TestConfig(object):
         issuer_types = ["foo.bar.com=issuer", "woo.foo.bar.com=other"]
         args = ["--tls-certificate-issuer-type-overrides=%s" % issuer_type for issuer_type in issuer_types]
         config = Configuration(args)
-        assert config.tls_certificate_issuer_type_overrides == {
-            "foo.bar.com": "issuer",
-            "woo.foo.bar.com": "other"
-        }
+        assert config.tls_certificate_issuer_type_overrides == {"foo.bar.com": "issuer", "woo.foo.bar.com": "other"}
 
 
 class TestHostRewriteRule(object):
@@ -177,12 +182,18 @@ class TestHostRewriteRule(object):
         arg = "pattern=value"
         assert HostRewriteRule(arg) == HostRewriteRule(arg)
 
-    @pytest.mark.parametrize("rule,host,result", [
-        (r"pattern=value", "pattern", "value"),
-        (r"www.([a-z]+).com=www.\1.net", "www.example.com", "www.example.net"),
-        (r"(?P<name>[a-z_-]+).example.com=\g<name>-stage.route.\g<name>.example.net", "query-manager.example.com",
-         "query-manager-stage.route.query-manager.example.net"),
-    ])
+    @pytest.mark.parametrize(
+        "rule,host,result",
+        [
+            (r"pattern=value", "pattern", "value"),
+            (r"www.([a-z]+).com=www.\1.net", "www.example.com", "www.example.net"),
+            (
+                r"(?P<name>[a-z_-]+).example.com=\g<name>-stage.route.\g<name>.example.net",
+                "query-manager.example.com",
+                "query-manager-stage.route.query-manager.example.net",
+            ),
+        ],
+    )
     def test_apply(self, rule, host, result):
         hrr = HostRewriteRule(rule)
         assert hrr.matches(host)

--- a/tests/fiaas_deploy_daemon/test_extension_hook_caller.py
+++ b/tests/fiaas_deploy_daemon/test_extension_hook_caller.py
@@ -33,7 +33,6 @@ class Object(object):
 
 
 class TestExtensionHookCaller(object):
-
     @pytest.fixture
     def session_respond_500(self):
         mock_session = mock.create_autospec(Session)
@@ -90,7 +89,7 @@ class TestExtensionHookCaller(object):
 
     @pytest.mark.usefixtures("session_respond_404")
     def test_return_same_object_when_404_occurs(self, session_respond_404, app_spec, deployment):
-        conf = Configuration(['--extension-hook-url', URL_PARAM])
+        conf = Configuration(["--extension-hook-url", URL_PARAM])
         extension_hook_caller = ExtensionHookCaller(conf, session_respond_404)
         obj = copy.deepcopy(deployment)
         extension_hook_caller.apply(obj, app_spec)
@@ -98,7 +97,7 @@ class TestExtensionHookCaller(object):
 
     @pytest.mark.usefixtures("session_respond_200")
     def test_return_respone_when_200_occurs(self, session_respond_200, app_spec, deployment):
-        conf = Configuration(['--extension-hook-url', URL_PARAM])
+        conf = Configuration(["--extension-hook-url", URL_PARAM])
         extension_hook_caller = ExtensionHookCaller(conf, session_respond_200)
         obj = copy.deepcopy(deployment)
         expected = self.deployment_v2()
@@ -109,7 +108,7 @@ class TestExtensionHookCaller(object):
 
     @pytest.mark.usefixtures("session_respond_500")
     def test_raise_exception_when_500_occurs(self, session_respond_500, app_spec, deployment):
-        conf = Configuration(['--extension-hook-url', URL_PARAM])
+        conf = Configuration(["--extension-hook-url", URL_PARAM])
         extension_hook_caller = ExtensionHookCaller(conf, session_respond_500)
         obj = copy.deepcopy(deployment)
         with pytest.raises(HTTPError):

--- a/tests/fiaas_deploy_daemon/test_healthcheck.py
+++ b/tests/fiaas_deploy_daemon/test_healthcheck.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fiaas_deploy_daemon/test_log_extras.py
+++ b/tests/fiaas_deploy_daemon/test_log_extras.py
@@ -29,7 +29,9 @@ class TestLogExtras(object):
         logger = logging.getLogger("test.log.extras")
         logger.addHandler(StatusHandler())
         logger.warning(TEST_MESSAGE)
-        logs = get_final_logs(app_name=app_spec.name, namespace=app_spec.namespace, deployment_id=app_spec.deployment_id)
+        logs = get_final_logs(
+            app_name=app_spec.name, namespace=app_spec.namespace, deployment_id=app_spec.deployment_id
+        )
         assert len(logs) == 1
         log_message = logs[0]
         assert TEST_MESSAGE in log_message
@@ -42,7 +44,9 @@ class TestLogExtras(object):
             kw = {request.param: None}
             return app_spec._replace(**kw)
 
-    @pytest.mark.parametrize("spec,name,namespace,deployment_id", (
+    @pytest.mark.parametrize(
+        "spec,name,namespace,deployment_id",
+        (
             (False, None, "namespace", "deployment_id"),
             (False, "name", None, "deployment_id"),
             (False, "name", "namespace", None),
@@ -50,7 +54,9 @@ class TestLogExtras(object):
             ("name", None, None, None),
             ("namespace", None, None, None),
             ("deployment_id", None, None, None),
-    ), indirect=["spec"])
+        ),
+        indirect=["spec"],
+    )
     def test_require_all_three_fields(self, spec, name, namespace, deployment_id):
         with pytest.raises(TypeError):
             set_extras(app_spec=spec, app_name=name, namespace=namespace, deployment_id=deployment_id)

--- a/tests/fiaas_deploy_daemon/test_logsetup.py
+++ b/tests/fiaas_deploy_daemon/test_logsetup.py
@@ -46,9 +46,9 @@ class TestLogSetup(object):
 
     @staticmethod
     def _describe_stream_handler(formatter):
-        return InstanceOf(logging.StreamHandler) & Attrs(stream=sys.stdout,
-                                                         filters=List(of=InstanceOf(ExtraFilter)),
-                                                         formatter=InstanceOf(formatter, exact=True))
+        return InstanceOf(logging.StreamHandler) & Attrs(
+            stream=sys.stdout, filters=List(of=InstanceOf(ExtraFilter)), formatter=InstanceOf(formatter, exact=True)
+        )
 
     @staticmethod
     def _describe_status_handler():
@@ -57,16 +57,18 @@ class TestLogSetup(object):
     def test_default_behaviour(self, root_logger):
         init_logging(_FakeConfig())
 
-        root_logger.addHandler.assert_has_calls((mock.call(self._describe_stream_handler(logging.Formatter)),
-                                                 mock.call(self._describe_status_handler())),
-                                                any_order=True)
+        root_logger.addHandler.assert_has_calls(
+            (mock.call(self._describe_stream_handler(logging.Formatter)), mock.call(self._describe_status_handler())),
+            any_order=True,
+        )
         root_logger.setLevel.assert_called_with(logging.INFO)
 
     def test_output_json(self, root_logger):
         init_logging(_FakeConfig("json"))
-        root_logger.addHandler.assert_has_calls((mock.call(self._describe_stream_handler(FiaasFormatter)),
-                                                 mock.call(self._describe_status_handler())),
-                                                any_order=True)
+        root_logger.addHandler.assert_has_calls(
+            (mock.call(self._describe_stream_handler(FiaasFormatter)), mock.call(self._describe_status_handler())),
+            any_order=True,
+        )
 
     def test_debug_logging(self, root_logger):
         init_logging(_FakeConfig(debug=True))

--- a/tests/fiaas_deploy_daemon/test_retry.py
+++ b/tests/fiaas_deploy_daemon/test_retry.py
@@ -1,4 +1,3 @@
-
 # Copyright 2017-2019 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,22 +35,25 @@ def test_upsertconflict_str():
     assert str(e) == expected
 
 
-@pytest.mark.parametrize("status", (
-    400,  # Bad Request
-    402,  # Payment Required
-    403,  # Forbidden
-    404,  # Not Found
-    405,  # Method Not Allowed
-    406,  # Not Acceptable
-    408,  # Request Timeout
-    410,  # Gone
-    411,  # Length Required
-    413,  # Payload Too Large
-    414,  # URI Too long
-    415,  # Unsupported Media Type
-    417,  # Expectation Failed
-    426,  # Upgrade Required
-))
+@pytest.mark.parametrize(
+    "status",
+    (
+        400,  # Bad Request
+        402,  # Payment Required
+        403,  # Forbidden
+        404,  # Not Found
+        405,  # Method Not Allowed
+        406,  # Not Acceptable
+        408,  # Request Timeout
+        410,  # Gone
+        411,  # Length Required
+        413,  # Payload Too Large
+        414,  # URI Too long
+        415,  # Unsupported Media Type
+        417,  # Expectation Failed
+        426,  # Upgrade Required
+    ),
+)
 def test_retry_on_conflict_should_raise_clienterror_for_non_conflict_clienterror(status):
     response = mock.MagicMock(spec=Response)
     response.status_code = status
@@ -124,11 +126,14 @@ def name_test_function():
     pass
 
 
-@pytest.mark.parametrize("func, expected", (
-    (id, "builtins.id"),
-    (name_test_function, "{}.name_test_function".format(__name__)),
-    (NameTester.clsmethod, "{}.NameTester.clsmethod".format(__name__)),
-    (NameTester.method, "{}.NameTester.method".format(__name__)),
-))
+@pytest.mark.parametrize(
+    "func, expected",
+    (
+        (id, "builtins.id"),
+        (name_test_function, "{}.name_test_function".format(__name__)),
+        (NameTester.clsmethod, "{}.NameTester.clsmethod".format(__name__)),
+        (NameTester.method, "{}.NameTester.method".format(__name__)),
+    ),
+)
 def test_canonical_name(func, expected):
     assert canonical_name(func) == expected

--- a/tests/fiaas_deploy_daemon/test_warn_env_variable_config.py
+++ b/tests/fiaas_deploy_daemon/test_warn_env_variable_config.py
@@ -7,7 +7,7 @@ from unittest import mock
 import pytest
 
 
-class ConfigFlag():
+class ConfigFlag:
     def __init__(self, env_key, env_value, config_key=None, config_value=None):
         self.env_key = env_key
         self.env_value = env_value
@@ -18,53 +18,72 @@ class ConfigFlag():
 @pytest.fixture()
 def config_flags():
     yield [
-        ConfigFlag('SECRETS_DIRECTORY', '/path/to/test'),
-        ConfigFlag('LOG_FORMAT', 'json'),
-        ConfigFlag('http_proxy', 'http://localhost:1234', config_key='proxy'),
-        ConfigFlag('DEBUG', 'true', config_value=True),
-        ConfigFlag('FIAAS_ENVIRONMENT', 'dev', config_key='environment'),
-        ConfigFlag('FIAAS_SERVICE_TYPE', 'NodePort', config_key='service_type'),
-        ConfigFlag('FIAAS_INFRASTRUCTURE', 'gke', config_key='infrastructure'),
-        ConfigFlag('PORT', '9999', config_value=9999),
-        ConfigFlag('ENABLE_CRD_SUPPORT', 'true', config_value=True),
-        ConfigFlag('SECRETS_INIT_CONTAINER_IMAGE', 'fiaas/fictional_secrets_init_container_image:latest'),
-        ConfigFlag('SECRETS_SERVICE_ACCOUNT_NAME', 'secrets_service_account_name'),
-        ConfigFlag('DATADOG_CONTAINER_IMAGE', 'fiaas/fictional_datadog_container_image:latest'),
-        ConfigFlag('DATADOG_CONTAINER_MEMORY', '100M'),
-        ConfigFlag('FIAAS_DATADOG_GLOBAL_TAGS', '[pattern=value,FIAAS_DD_tag=test]', config_key='datadog_global_tags',
-                   config_value={'pattern': 'value', 'FIAAS_DD_tag': 'test'}),
-        ConfigFlag('PRE_STOP_DELAY', '2', config_value=2),
-        ConfigFlag('STRONGBOX_INIT_CONTAINER_IMAGE', 'fiaas/fictional_strongbox_init_container_image'),
-        ConfigFlag('ENABLE_DEPRECATED_MULTI_NAMESPACE_SUPPORT', 'true', config_value=True),
-        ConfigFlag('USE_INGRESS_TLS', 'default_off'),
-        ConfigFlag('TLS_CERTIFICATE_ISSUER', 'a_certificate_issuer'),
-        ConfigFlag('USE_IN_MEMORY_EMPTYDIRS', 'true', config_value=True),
-        ConfigFlag('DEPLOYMENT_MAX_SURGE', '50%'),
-        ConfigFlag('DEPLOYMENT_MAX_UNAVAILABLE', '50%'),
-        ConfigFlag('READY_CHECK_TIMEOUT_MULTIPLIER', '7', config_value=7),
-        ConfigFlag('DISABLE_DEPRECATED_MANAGED_ENV_VARS', 'true', config_value=True),
-        ConfigFlag('USAGE_REPORTING_CLUSTER_NAME', 'cluster_name'),
-        ConfigFlag('USAGE_REPORTING_OPERATOR', 'usage_operator'),
-        ConfigFlag('USAGE_REPORTING_ENDPOINT', 'http://localhost'),
-        ConfigFlag('USAGE_REPORTING_TENANT', 'usage_tenant'),
-        ConfigFlag('USAGE_REPORTING_TEAM', 'usage_team'),
-        ConfigFlag('API_SERVER', 'http://localhost'),
-        ConfigFlag('API_TOKEN', 'api_token'),
-        ConfigFlag('API_CERT', 'api_cert'),
-        ConfigFlag('CLIENT_CERT', 'client_cert'),
-        ConfigFlag('CLIENT_KEY', 'client_key'),
-        ConfigFlag('INGRESS_SUFFIXES', r'[1\.example.com,2.example.com]', config_value=[r'1\.example.com', '2.example.com']),
-        ConfigFlag('HOST_REWRITE_RULES', r'[pattern=value,(\d+)\.example\.com=$1.example.net,www.([a-z]+.com)={env}.$1]',
-                   config_value=[HostRewriteRule('pattern=value'),
-                                 HostRewriteRule(r'(\d+)\.example\.com=$1.example.net'),
-                                 HostRewriteRule('www.([a-z]+.com)={env}.$1')]),
-        ConfigFlag('FIAAS_GLOBAL_ENV', '[pattern=value,FIAAS_ENV=test]', config_key='global_env',
-                   config_value={'pattern': 'value', 'FIAAS_ENV': 'test'}),
-        ConfigFlag('FIAAS_SECRET_INIT_CONTAINERS',
-                   '[default=fiaas/fictional_secrets_init_container_image:latest,other=fiaas/other_secrets_init_container_image:latest]',
-                   config_key='secret_init_containers',
-                   config_value={'default': 'fiaas/fictional_secrets_init_container_image:latest',
-                                 'other': 'fiaas/other_secrets_init_container_image:latest'}),
+        ConfigFlag("SECRETS_DIRECTORY", "/path/to/test"),
+        ConfigFlag("LOG_FORMAT", "json"),
+        ConfigFlag("http_proxy", "http://localhost:1234", config_key="proxy"),
+        ConfigFlag("DEBUG", "true", config_value=True),
+        ConfigFlag("FIAAS_ENVIRONMENT", "dev", config_key="environment"),
+        ConfigFlag("FIAAS_SERVICE_TYPE", "NodePort", config_key="service_type"),
+        ConfigFlag("FIAAS_INFRASTRUCTURE", "gke", config_key="infrastructure"),
+        ConfigFlag("PORT", "9999", config_value=9999),
+        ConfigFlag("ENABLE_CRD_SUPPORT", "true", config_value=True),
+        ConfigFlag("SECRETS_INIT_CONTAINER_IMAGE", "fiaas/fictional_secrets_init_container_image:latest"),
+        ConfigFlag("SECRETS_SERVICE_ACCOUNT_NAME", "secrets_service_account_name"),
+        ConfigFlag("DATADOG_CONTAINER_IMAGE", "fiaas/fictional_datadog_container_image:latest"),
+        ConfigFlag("DATADOG_CONTAINER_MEMORY", "100M"),
+        ConfigFlag(
+            "FIAAS_DATADOG_GLOBAL_TAGS",
+            "[pattern=value,FIAAS_DD_tag=test]",
+            config_key="datadog_global_tags",
+            config_value={"pattern": "value", "FIAAS_DD_tag": "test"},
+        ),
+        ConfigFlag("PRE_STOP_DELAY", "2", config_value=2),
+        ConfigFlag("STRONGBOX_INIT_CONTAINER_IMAGE", "fiaas/fictional_strongbox_init_container_image"),
+        ConfigFlag("ENABLE_DEPRECATED_MULTI_NAMESPACE_SUPPORT", "true", config_value=True),
+        ConfigFlag("USE_INGRESS_TLS", "default_off"),
+        ConfigFlag("TLS_CERTIFICATE_ISSUER", "a_certificate_issuer"),
+        ConfigFlag("USE_IN_MEMORY_EMPTYDIRS", "true", config_value=True),
+        ConfigFlag("DEPLOYMENT_MAX_SURGE", "50%"),
+        ConfigFlag("DEPLOYMENT_MAX_UNAVAILABLE", "50%"),
+        ConfigFlag("READY_CHECK_TIMEOUT_MULTIPLIER", "7", config_value=7),
+        ConfigFlag("DISABLE_DEPRECATED_MANAGED_ENV_VARS", "true", config_value=True),
+        ConfigFlag("USAGE_REPORTING_CLUSTER_NAME", "cluster_name"),
+        ConfigFlag("USAGE_REPORTING_OPERATOR", "usage_operator"),
+        ConfigFlag("USAGE_REPORTING_ENDPOINT", "http://localhost"),
+        ConfigFlag("USAGE_REPORTING_TENANT", "usage_tenant"),
+        ConfigFlag("USAGE_REPORTING_TEAM", "usage_team"),
+        ConfigFlag("API_SERVER", "http://localhost"),
+        ConfigFlag("API_TOKEN", "api_token"),
+        ConfigFlag("API_CERT", "api_cert"),
+        ConfigFlag("CLIENT_CERT", "client_cert"),
+        ConfigFlag("CLIENT_KEY", "client_key"),
+        ConfigFlag(
+            "INGRESS_SUFFIXES", r"[1\.example.com,2.example.com]", config_value=[r"1\.example.com", "2.example.com"]
+        ),
+        ConfigFlag(
+            "HOST_REWRITE_RULES",
+            r"[pattern=value,(\d+)\.example\.com=$1.example.net,www.([a-z]+.com)={env}.$1]",
+            config_value=[
+                HostRewriteRule("pattern=value"),
+                HostRewriteRule(r"(\d+)\.example\.com=$1.example.net"),
+                HostRewriteRule("www.([a-z]+.com)={env}.$1"),
+            ],
+        ),
+        ConfigFlag(
+            "FIAAS_GLOBAL_ENV",
+            "[pattern=value,FIAAS_ENV=test]",
+            config_key="global_env",
+            config_value={"pattern": "value", "FIAAS_ENV": "test"},
+        ),
+        ConfigFlag(
+            "FIAAS_SECRET_INIT_CONTAINERS",
+            "[default=fiaas/fictional_secrets_init_container_image:latest,other=fiaas/other_secrets_init_container_image:latest]",
+            config_key="secret_init_containers",
+            config_value={
+                "default": "fiaas/fictional_secrets_init_container_image:latest",
+                "other": "fiaas/other_secrets_init_container_image:latest",
+            },
+        ),
     ]
 
 
@@ -77,7 +96,7 @@ def test_warn_if_env_variable_config(monkeypatch, config_flags):
     log = mock.MagicMock(spec=logging.Logger)
     warn_if_env_variable_config(config, log)
 
-    expected_env_keys = ', '.join(sorted(cf.env_key for cf in config_flags))
+    expected_env_keys = ", ".join(sorted(cf.env_key for cf in config_flags))
     expected_log_message = (
         "found configuration environment variables %s. The ability to configure fiaas-deploy-daemon via environment variables has been "
         "removed. If you are trying to use these environment variables to configure fiaas-deploy-daemon, that configuration will not take "

--- a/tests/fiaas_deploy_daemon/usage_reporting/test_dev_hose_auth.py
+++ b/tests/fiaas_deploy_daemon/usage_reporting/test_dev_hose_auth.py
@@ -48,16 +48,19 @@ class TestDevHoseAuth(object):
         auth = DevHoseAuth(self._KEY, "߷\u23FB@/")
         timestamp = (datetime(2017, 9, 26, 11, 16, 25, 439000) - datetime(1970, 1, 1)).total_seconds()
         string_to_sign = auth._create_string_to_sign(mock_request, timestamp, "߷\u23FB@/")
-        assert string_to_sign == "/%DF%B7%E2%8F%BB@/a-zA-Z0-9.-~_@:!$&'()*+,;=/?\n" \
-                                 "%DF%B7%E2%8F%BB%40%2F\n" \
-                                 "1506424585000\n" \
-                                 "eyJ0eXBlIjogIlx1MDdmN1x1MjNmYkAvIn0%3D\n" \
-                                 "%DF%B7%E2%8F%BB%40%2F\n"
+        assert (
+            string_to_sign == "/%DF%B7%E2%8F%BB@/a-zA-Z0-9.-~_@:!$&'()*+,;=/?\n"
+            "%DF%B7%E2%8F%BB%40%2F\n"
+            "1506424585000\n"
+            "eyJ0eXBlIjogIlx1MDdmN1x1MjNmYkAvIn0%3D\n"
+            "%DF%B7%E2%8F%BB%40%2F\n"
+        )
 
     @pytest.mark.parametrize("key", (_KEY, b"\n" + _KEY, _KEY + b"\n"))
     def test_signing(self, mock_request, key):
-        with mock.patch("fiaas_deploy_daemon.usage_reporting.dev_hose_auth.uuid.uuid4") as m_uuid, \
-                mock.patch("fiaas_deploy_daemon.usage_reporting.dev_hose_auth.time.time") as m_time:
+        with mock.patch("fiaas_deploy_daemon.usage_reporting.dev_hose_auth.uuid.uuid4") as m_uuid, mock.patch(
+            "fiaas_deploy_daemon.usage_reporting.dev_hose_auth.time.time"
+        ) as m_time:
             m_uuid.return_value = "mocked_nonce"
             m_time.return_value = 1514764861.000001
             auth = DevHoseAuth(key, "tenant")

--- a/tests/fiaas_deploy_daemon/usage_reporting/test_devhose_transformer.py
+++ b/tests/fiaas_deploy_daemon/usage_reporting/test_devhose_transformer.py
@@ -27,8 +27,8 @@ class TestDevhoseDeploymentEventTransformer(object):
     def config(self, request):
         config = mock.create_autospec(Configuration([]), spec_set=True)
         config.environment = request.param.get("env")
-        config.usage_reporting_cluster_name = 'cluster_name'
-        config.usage_reporting_operator = 'operator_sdrn'
+        config.usage_reporting_cluster_name = "cluster_name"
+        config.usage_reporting_operator = "operator_sdrn"
         config.usage_reporting_team = request.param.get("team")
         yield config
 
@@ -37,196 +37,255 @@ class TestDevhoseDeploymentEventTransformer(object):
         transformer = DevhoseDeploymentEventTransformer(config)
         return transformer
 
-    @pytest.mark.parametrize("statuses, timestamps, config, expected, annotations", [
-        (["STARTED"], ["2018-09-10T13:49:05Z"], {"env": "dev"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "dev",
-            "repository": "source/repo/name",
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "in_progress",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "dev"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-          }, {'fiaas/source-repository': 'source/repo/name'}),
-        (["STARTED"], ["2018-09-10T13:49:05Z"], {"env": "pre"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "pre",
-            "repository": "source/repo/name",
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "in_progress",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "pre"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-          }, {'fiaas/source-repository': 'source/repo/name'}),
-        (["STARTED"], ["2018-09-10T13:49:05Z"], {"env": "pro"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "pro",
-            "repository": "source/repo/name",
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "in_progress",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "pro"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-          }, {'fiaas/source-repository': 'source/repo/name'}),
-        (["STARTED"], ["2018-09-10T13:49:05Z"], {"env": "something_else"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "other",
-            "repository": "source/repo/name",
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "in_progress",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "something_else"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-          }, {'fiaas/source-repository': 'source/repo/name'}),
-        (["STARTED", "SUCCESS"], ["2018-09-10T13:49:05Z", "2018-09-10T13:50:05Z"], {"env": "dev"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "dev",
-            "repository": "source/repo/name",
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:50:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "succeeded",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "dev"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-          }, {'fiaas/source-repository': 'source/repo/name'}),
-        (["STARTED", "FAILED"], ["2018-09-10T13:49:05Z", "2018-09-10T13:50:05Z"], {"env": "dev"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "dev",
-            "repository": "source/repo/name",
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:50:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "failed",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "dev"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-          }, {'fiaas/source-repository': 'source/repo/name'}),
-        (["STARTED"], ["2018-09-10T13:49:05Z"], {"env": "dev"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "dev",
-            "repository": None,
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "in_progress",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "dev"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": None
-        }, None),
-        (["STARTED"], ["2018-09-10T13:49:05Z"], {"env": "dev", "team": "team_sdrn"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "dev",
-            "repository": None,
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "in_progress",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "dev"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": "team_sdrn"
-        }, None),
-        (["FAILED"], ["2018-09-10T13:49:05Z"], {"env": "dev", "team": "team_sdrn"}, {
-            "id": "test_app_deployment_id",
-            "application": "testapp",
-            "environment": "dev",
-            "repository": None,
-            "started_at": "2018-09-10T13:49:05Z",
-            "timestamp": "2018-09-10T13:49:05Z",
-            "target": {
-                "infrastructure": "cluster_name",
-                "provider": "cluster_name",
-                "instance": "default",
-                "team": "operator_sdrn"
-            },
-            "status": "failed",
-            "source_type": "fiaas",
-            "facility": "sdrn:schibsted:service:fiaas",
-            "details": {"environment": "dev"},
-            "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
-            "team": "team_sdrn"
-        }, None),
-    ], indirect=['config'])
+    @pytest.mark.parametrize(
+        "statuses, timestamps, config, expected, annotations",
+        [
+            (
+                ["STARTED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "dev"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "dev",
+                    "repository": "source/repo/name",
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "in_progress",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "dev"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                {"fiaas/source-repository": "source/repo/name"},
+            ),
+            (
+                ["STARTED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "pre"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "pre",
+                    "repository": "source/repo/name",
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "in_progress",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "pre"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                {"fiaas/source-repository": "source/repo/name"},
+            ),
+            (
+                ["STARTED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "pro"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "pro",
+                    "repository": "source/repo/name",
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "in_progress",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "pro"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                {"fiaas/source-repository": "source/repo/name"},
+            ),
+            (
+                ["STARTED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "something_else"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "other",
+                    "repository": "source/repo/name",
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "in_progress",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "something_else"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                {"fiaas/source-repository": "source/repo/name"},
+            ),
+            (
+                ["STARTED", "SUCCESS"],
+                ["2018-09-10T13:49:05Z", "2018-09-10T13:50:05Z"],
+                {"env": "dev"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "dev",
+                    "repository": "source/repo/name",
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:50:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "succeeded",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "dev"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                {"fiaas/source-repository": "source/repo/name"},
+            ),
+            (
+                ["STARTED", "FAILED"],
+                ["2018-09-10T13:49:05Z", "2018-09-10T13:50:05Z"],
+                {"env": "dev"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "dev",
+                    "repository": "source/repo/name",
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:50:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "failed",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "dev"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                {"fiaas/source-repository": "source/repo/name"},
+            ),
+            (
+                ["STARTED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "dev"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "dev",
+                    "repository": None,
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "in_progress",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "dev"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": None,
+                },
+                None,
+            ),
+            (
+                ["STARTED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "dev", "team": "team_sdrn"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "dev",
+                    "repository": None,
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "in_progress",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "dev"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": "team_sdrn",
+                },
+                None,
+            ),
+            (
+                ["FAILED"],
+                ["2018-09-10T13:49:05Z"],
+                {"env": "dev", "team": "team_sdrn"},
+                {
+                    "id": "test_app_deployment_id",
+                    "application": "testapp",
+                    "environment": "dev",
+                    "repository": None,
+                    "started_at": "2018-09-10T13:49:05Z",
+                    "timestamp": "2018-09-10T13:49:05Z",
+                    "target": {
+                        "infrastructure": "cluster_name",
+                        "provider": "cluster_name",
+                        "instance": "default",
+                        "team": "operator_sdrn",
+                    },
+                    "status": "failed",
+                    "source_type": "fiaas",
+                    "facility": "sdrn:schibsted:service:fiaas",
+                    "details": {"environment": "dev"},
+                    "trigger": DevhoseDeploymentEventTransformer.FIAAS_TRIGGER,
+                    "team": "team_sdrn",
+                },
+                None,
+            ),
+        ],
+        indirect=["config"],
+    )
     def test_transformation(self, transformer, app_spec, statuses, timestamps, expected, annotations):
         if annotations:
             app_spec = app_spec._replace(annotations=LabelAndAnnotationSpec(*[annotations] * 7))
         with mock.patch("fiaas_deploy_daemon.usage_reporting.transformer._timestamp") as timestamp:
             timestamp.side_effect = timestamps
             for status in statuses:
-                transformed = transformer(status, app_spec.name, app_spec.namespace, app_spec.deployment_id,
-                                          _repository(app_spec))
+                transformed = transformer(
+                    status, app_spec.name, app_spec.namespace, app_spec.deployment_id, _repository(app_spec)
+                )
             assert expected == transformed
 
 

--- a/tests/fiaas_deploy_daemon/usage_reporting/test_usage_reporter.py
+++ b/tests/fiaas_deploy_daemon/usage_reporting/test_usage_reporter.py
@@ -46,19 +46,29 @@ class TestUsageReporter(object):
     def mock_auth(self):
         return mock.create_autospec(AuthBase())
 
-    @pytest.mark.parametrize("result,repository", [
-        (STATUS_STARTED, None),
-        (STATUS_FAILED, None),
-        (STATUS_SUCCESS, None),
-        (STATUS_STARTED, "repo"),
-        (STATUS_FAILED, "repo"),
-        (STATUS_SUCCESS, "repo"),
-    ])
+    @pytest.mark.parametrize(
+        "result,repository",
+        [
+            (STATUS_STARTED, None),
+            (STATUS_FAILED, None),
+            (STATUS_SUCCESS, None),
+            (STATUS_STARTED, "repo"),
+            (STATUS_FAILED, "repo"),
+            (STATUS_SUCCESS, "repo"),
+        ],
+    )
     def test_signal_to_event(self, config, mock_transformer, mock_session, mock_auth, app_spec, result, repository):
         reporter = UsageReporter(config, mock_transformer, mock_session, mock_auth)
 
-        lifecycle_subject = Subject(uid=app_spec.uid, app_name=app_spec.name, namespace=app_spec.namespace,
-                                    deployment_id=app_spec.deployment_id, repository=repository, labels=None, annotations=None)
+        lifecycle_subject = Subject(
+            uid=app_spec.uid,
+            app_name=app_spec.name,
+            namespace=app_spec.namespace,
+            deployment_id=app_spec.deployment_id,
+            repository=repository,
+            labels=None,
+            annotations=None,
+        )
         signal(DEPLOY_STATUS_CHANGED).send(status=result, subject=lifecycle_subject)
 
         event = reporter._event_queue.get_nowait()
@@ -76,8 +86,9 @@ class TestUsageReporter(object):
 
         reporter()
 
-        mock_transformer.assert_called_once_with(event.status, event.app_name, event.namespace, event.deployment_id,
-                                                 event.repository)
+        mock_transformer.assert_called_once_with(
+            event.status, event.app_name, event.namespace, event.deployment_id, event.repository
+        )
 
     def test_post_to_webhook(self, config, mock_transformer, mock_session, mock_auth):
         event = UsageEvent("status", "name", "namespace", "deployment_id", "repository")


### PR DESCRIPTION
I think the auto formatted/formatable code with `black` added in https://github.com/fiaas/fiaas-deploy-daemon/pull/199 is quite nice. I tried to use `black` locally and noticed that `tests/**` and some of the top level files weren't formatted yet, so this PR formats those files as well.
I also added black config in `pyproject.toml` so that the same line length (120) is the default.