### PR TITLE
Smaller VM for CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,7 +16,7 @@ version: v1.0
 name: fiaas-deploy-daemon CI build
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-4
     os_image: ubuntu1804
 blocks:
   - name: "Run unit tests, build container image"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,7 +16,7 @@ version: v1.0
 name: fiaas-deploy-daemon CI build
 agent:
   machine:
-    type: e1-standard-8
+    type: e1-standard-2
     os_image: ubuntu1804
 blocks:
   - name: "Run unit tests, build container image"


### PR DESCRIPTION
These two test runs with "standard-4" seem to compare well to the "standard-8" setting.

https://fiaas-svc.semaphoreci.com/workflows/8413f527-5c5e-4203-9c49-e2bdfb6739cb?pipeline_id=d42d2bd8-65f8-412a-8563-f1c6a3de9081

https://fiaas-svc.semaphoreci.com/workflows/99425f88-5007-4046-ae7f-dd21bd081cf3?pipeline_id=649bd672-6d52-4562-907d-5d0ffd301f15

