### PR TITLE
Update k8s library version to handle Application with empty config

### DIFF
--- a/bin/run_fdd_against_kind
+++ b/bin/run_fdd_against_kind
@@ -33,6 +33,8 @@ ARGS=(
 '--datadog-container-image' 'datadog/docker-dd-agent:12.2.5172-alpine'
 '--enable-crd-support'
 '--enable-service-account-per-app'
+'--use-networkingv1-ingress'
+'--use-apiextensionsv1-crd'
 )
 
 (set -ux; fiaas-deploy-daemon "${ARGS[@]}")

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ GENERIC_REQ = [
     "decorator < 5.0.0",  # 5.0.0 and later drops py2 support (transitive dep from pinject)
     "six >= 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.21.4",
+    "k8s == 0.22.0",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.9.1",
     "backoff == 1.8.0",


### PR DESCRIPTION
Update k8s to the most recent version, which includes the change added in https://github.com/fiaas/k8s/pull/112 to discard watch events
if a valid Model instance can't be created.

Closes #193 