### PR TITLE
Remove 1.15 version from e2e tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,9 +65,6 @@ blocks:
           # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
-              - v1.21.14
-              - v1.22.17
-              - v1.23.17
               - v1.24.12
               - v1.25.8
               - v1.26.3

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,7 +65,6 @@ blocks:
           # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
-              - v1.15.12
               - v1.21.14
               - v1.22.17
               - v1.23.17

--- a/bin/install_e2e_dependencies
+++ b/bin/install_e2e_dependencies
@@ -2,12 +2,7 @@
 set -euo pipefail
 
 K8S_VERSION="$1"
-
-if [[ "$K8S_VERSION" =~ v1\.15\.[0-9]+ ]]; then
-    KIND_VERSION=v0.11.1
-else
-    KIND_VERSION=v0.18.0
-fi
+KIND_VERSION=v0.18.0
 
 curl -Lo "$HOME/.local/bin/kind" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
 chmod +x "$HOME/.local/bin/kind"


### PR DESCRIPTION
Hello. 

We have stopped using the 1.15 version of K8s, so I'm deleting this one. Is there any other version that can be deleted? We are already using 1.24+ K8s versions, so from our side, we can delete 1.21, 1.22, and 1.23 :)