### PR TITLE
Add certificates to Role with a flag

### DIFF
--- a/helm/fiaas-deploy-daemon/templates/_helpers.tpl
+++ b/helm/fiaas-deploy-daemon/templates/_helpers.tpl
@@ -27,3 +27,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ toYaml . }}
 {{- end -}}
 {{- end -}}
+
+{{- define "fiaas-deploy-daemon.RoleCertificateRules" -}}
+- apiGroups:
+  - cert-manager.io/v1
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/helm/fiaas-deploy-daemon/templates/role.yaml
+++ b/helm/fiaas-deploy-daemon/templates/role.yaml
@@ -54,4 +54,7 @@ rules:
   - list
   - update
   - watch
+{{- if .Values.rbac.role.enableCertificates }}
+{{- include "fiaas-deploy-daemon.RoleCertificateRules" }}
+{{- end }}
 {{- end }}

--- a/helm/fiaas-deploy-daemon/templates/role.yaml
+++ b/helm/fiaas-deploy-daemon/templates/role.yaml
@@ -55,6 +55,6 @@ rules:
   - update
   - watch
 {{- if .Values.rbac.role.enableCertificates }}
-{{- include "fiaas-deploy-daemon.RoleCertificateRules" . }}
+{{ include "fiaas-deploy-daemon.RoleCertificateRules" . }}
 {{- end }}
 {{- end }}

--- a/helm/fiaas-deploy-daemon/templates/role.yaml
+++ b/helm/fiaas-deploy-daemon/templates/role.yaml
@@ -55,6 +55,6 @@ rules:
   - update
   - watch
 {{- if .Values.rbac.role.enableCertificates }}
-{{- include "fiaas-deploy-daemon.RoleCertificateRules" }}
+{{- include "fiaas-deploy-daemon.RoleCertificateRules" . }}
 {{- end }}
 {{- end }}

--- a/helm/fiaas-deploy-daemon/values.yaml.tpl
+++ b/helm/fiaas-deploy-daemon/values.yaml.tpl
@@ -45,6 +45,7 @@ rbac:
     create: true
     labels: {}
     annotations: {}
+    enableCertificates: false
   roleBinding:
     create: true
     labels: {}


### PR DESCRIPTION
This change modifies the Role object in the Helm deployment to include cert-manager.io/v1/Certificate in the allowed Kubernetes objects. 

To keep compatibility, this feature is enabled through a flag (default: false)
