### PR TITLE
Upgrade pytest and related dependencies

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    integration_test: integration/e2e tests which spin up a kind Kubernetes cluster. Requires docker.  (deselect with '-m "not integration_test"')
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,3 @@ output=build/reports/coverage.xml
 max-line-length=140
 max-complexity=10
 exclude=build,.git,__pycache__,.eggs,dist,.tox
-
-[tool:pytest]
-# Disable pytest warnings for now, must be fixed before we go to pytest 4
-addopts = -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -65,12 +65,12 @@ FLAKE8_REQ = [
 ]
 
 TESTS_REQ = [
-    "pytest-xdist == 1.27.0",
-    "pytest-sugar == 0.9.2",
-    "pytest-html == 1.22.0",
-    "pytest-cov == 2.7.1",
-    "pytest-helpers-namespace == 2019.1.8",
-    "pytest == 3.10.1",
+    "pytest-xdist == 3.2.1",
+    "pytest-sugar == 0.9.7",
+    "pytest-html == 3.2.0",
+    "pytest-cov == 4.0.0",
+    "pytest-helpers-namespace == 2021.12.29",
+    "pytest == 7.3.1",
     "requests-file == 1.4.3",
     "callee == 0.3",
 ]

--- a/setup.py
+++ b/setup.py
@@ -65,12 +65,12 @@ FLAKE8_REQ = [
 ]
 
 TESTS_REQ = [
-    "pytest-xdist == 3.2.1",
+    "pytest-xdist == 3.3.1",
     "pytest-sugar == 0.9.7",
     "pytest-html == 3.2.0",
-    "pytest-cov == 4.0.0",
+    "pytest-cov == 4.1.0",
     "pytest-helpers-namespace == 2021.12.29",
-    "pytest == 7.3.1",
+    "pytest == 7.4.2",
     "requests-file == 1.4.3",
     "callee == 0.3",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,7 @@ class FixtureScheduling(LoadScopeScheduling):
         return "-".join(fixture_values[:2])
 
 
-@pytest.mark.tryfirst
+@pytest.hookimpl(tryfirst=True)
 def pytest_xdist_make_scheduler(config, log):
     return FixtureScheduling(config, log)
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import dataclass
+
 from unittest import mock
 import pytest
 from k8s.models.common import ObjectMeta
@@ -155,10 +157,16 @@ def ingress(rules=None, metadata=None, expose=False, tls=None):
     return expected_ingress
 
 
+@dataclass
+class IngressTestcase:
+    test_id: str
+    app_spec: AppSpec
+    expected_ingress: dict
+
+
 TEST_DATA = (
-    # (test_case_name, provided_app_spec, expected_ingress)
-    ("only_default_hosts", app_spec(), ingress()),
-    (
+    IngressTestcase("only_default_hosts", app_spec(), ingress()),
+    IngressTestcase(
         "single_explicit_host",
         app_spec(
             ingresses=[
@@ -215,7 +223,7 @@ TEST_DATA = (
             ],
         ),
     ),
-    (
+    IngressTestcase(
         "single_explicit_host_multiple_paths",
         app_spec(
             ingresses=[
@@ -302,7 +310,7 @@ TEST_DATA = (
             ],
         ),
     ),
-    (
+    IngressTestcase(
         "multiple_explicit_hosts",
         app_spec(
             ingresses=[
@@ -376,7 +384,7 @@ TEST_DATA = (
             ],
         ),
     ),
-    (
+    IngressTestcase(
         "multiple_explicit_hosts_multiple_paths",
         app_spec(
             ingresses=[
@@ -520,7 +528,7 @@ TEST_DATA = (
             ],
         ),
     ),
-    (
+    IngressTestcase(
         "rewrite_host_simple",
         app_spec(
             ingresses=[
@@ -577,7 +585,7 @@ TEST_DATA = (
             ],
         ),
     ),
-    (
+    IngressTestcase(
         "rewrite_host_regex_substitution",
         app_spec(
             ingresses=[
@@ -636,7 +644,7 @@ TEST_DATA = (
             ],
         ),
     ),
-    (
+    IngressTestcase(
         "custom_labels_and_annotations",
         app_spec(
             labels=LabelAndAnnotationSpec(
@@ -672,7 +680,7 @@ TEST_DATA = (
             )
         ),
     ),
-    (
+    IngressTestcase(
         "regex_path",
         app_spec(
             ingresses=[
@@ -768,28 +776,18 @@ class TestIngressDeployer(object):
         default_app_spec = Mock(return_value=app_spec())
         return default_app_spec
 
-    def pytest_generate_tests(self, metafunc):
-        fixtures = ("app_spec", "expected_ingress")
-        if (
-            metafunc.cls == self.__class__
-            and metafunc.function.__name__ == "test_ingress_deploy"
-            and all(fixname in metafunc.fixturenames for fixname in fixtures)
-        ):
-            for test_id, app_spec, expected_ingress in TEST_DATA:
-                params = {"app_spec": app_spec, "expected_ingress": expected_ingress}
-                metafunc.addcall(params, test_id)
-
+    @pytest.mark.parametrize("testcase", TEST_DATA, ids=lambda itc: itc.test_id)
     @pytest.mark.usefixtures("get")
-    def test_ingress_deploy(self, post, delete, deployer, app_spec, expected_ingress, owner_references, extension_hook):
+    def test_ingress_deploy(self, post, delete, deployer, owner_references, extension_hook, testcase):
         mock_response = create_autospec(Response)
-        mock_response.json.return_value = expected_ingress
+        mock_response.json.return_value = testcase.expected_ingress
         post.return_value = mock_response
 
-        deployer.deploy(app_spec, LABELS)
+        deployer.deploy(testcase.app_spec, LABELS)
 
-        pytest.helpers.assert_any_call(post, INGRESSES_URI, expected_ingress)
-        owner_references.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec)
-        extension_hook.apply.assert_called_once_with(TypeMatcher(Ingress), app_spec)
+        pytest.helpers.assert_any_call(post, INGRESSES_URI, testcase.expected_ingress)
+        owner_references.apply.assert_called_once_with(TypeMatcher(Ingress), testcase.app_spec)
+        extension_hook.apply.assert_called_once_with(TypeMatcher(Ingress), testcase.app_spec)
         delete.assert_called_once_with(INGRESSES_URI, body=None, params=LABEL_SELECTOR_PARAMS)
 
     @pytest.fixture
@@ -879,7 +877,7 @@ class TestIngressDeployer(object):
         ),
     )
     def test_remove_existing_ingress_if_not_needed(self, request, delete, post, deployer, spec_name):
-        app_spec = request.getfuncargvalue(spec_name)
+        app_spec = request.getfixturevalue(spec_name)
 
         deployer.deploy(app_spec, LABELS)
 

--- a/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
+++ b/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
@@ -69,7 +69,7 @@ class TestSpecFactory(object):
         if version:
             minimal_config["version"] = version
         factory(UID, NAME, IMAGE, minimal_config, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
-        mock_factory = request.getfuncargvalue(mock_to_call)
+        mock_factory = request.getfixturevalue(mock_to_call)
         mock_factory.assert_called_with(minimal_config, strip_defaults=False)
 
     @pytest.mark.parametrize("version", [1, 2, 3])

--- a/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
+++ b/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
@@ -346,19 +346,21 @@ TEST_DATA = {
 
 def pytest_generate_tests(metafunc):
     fixtures = ("filename", "attribute", "value")
+
+    def generate_test_id(test_case):
+
+        filename, attribute, value = test_case
+        return "{}/{}=={}".format(filename, attribute.replace(".", "_"), repr(value).replace(".", "_"))
+
     if (
         metafunc.cls == TestFactory
         and metafunc.function.__name__ == "test"
         and all(fixname in metafunc.fixturenames for fixname in fixtures)
     ):
-        for filename in TEST_DATA:
-            for attribute in TEST_DATA[filename]:
-                value = TEST_DATA[filename][attribute]
-                fixture_args = {"filename": filename, "attribute": attribute, "value": value}
-                metafunc.addcall(
-                    fixture_args,
-                    "{}/{}=={}".format(filename, attribute.replace(".", "_"), repr(value).replace(".", "_")),
-                )
+        test_cases = [(filename, attribute, TEST_DATA[filename][attribute])
+                      for filename in TEST_DATA
+                      for attribute in TEST_DATA[filename]]
+        metafunc.parametrize("filename,attribute,value", test_cases)
 
 
 class TestFactory(object):

--- a/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
+++ b/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 
 from unittest import mock
 import pytest
@@ -344,23 +345,15 @@ TEST_DATA = {
 }
 
 
-def pytest_generate_tests(metafunc):
-    fixtures = ("filename", "attribute", "value")
+@dataclass
+class SpecAttributeTestCase:
+    filename: str
+    attribute: str
+    value: any
 
-    def generate_test_id(test_case):
-
-        filename, attribute, value = test_case
-        return "{}/{}=={}".format(filename, attribute.replace(".", "_"), repr(value).replace(".", "_"))
-
-    if (
-        metafunc.cls == TestFactory
-        and metafunc.function.__name__ == "test"
-        and all(fixname in metafunc.fixturenames for fixname in fixtures)
-    ):
-        test_cases = [(filename, attribute, TEST_DATA[filename][attribute])
-                      for filename in TEST_DATA
-                      for attribute in TEST_DATA[filename]]
-        metafunc.parametrize("filename,attribute,value", test_cases)
+    @property
+    def test_id(self):
+        return "{}/{}=={}".format(self.filename, self.attribute.replace(".", "_"), repr(self.value).replace(".", "_"))
 
 
 class TestFactory(object):
@@ -474,12 +467,21 @@ class TestFactory(object):
         assert isinstance(actual, _Lookup) is False  # _Lookup objects should not leak to AppSpec
         assert actual == value
 
-    def test(self, load_app_config_testdata, factory, filename, attribute, value):
+    @pytest.mark.parametrize(
+        "testcase",
+        (
+            SpecAttributeTestCase(filename, attribute, TEST_DATA[filename][attribute])
+            for filename in TEST_DATA
+            for attribute in TEST_DATA[filename]
+        ),
+        ids=lambda testcase: testcase.test_id
+    )
+    def test(self, load_app_config_testdata, factory, testcase):
         app_spec = factory(
             UID,
             NAME,
             IMAGE,
-            load_app_config_testdata(filename),
+            load_app_config_testdata(testcase.filename),
             ["IO"],
             ["foo"],
             "deployment_id",
@@ -488,8 +490,8 @@ class TestFactory(object):
             None,
         )
         assert app_spec is not None
-        code = "app_spec.%s" % attribute
+        code = "app_spec.%s" % testcase.attribute
         assert app_spec.secrets is not None
         actual = eval(code)
         assert isinstance(actual, _Lookup) is False  # _Lookup objects should not leak to AppSpec
-        assert actual == value
+        assert actual == testcase.value

--- a/tests/fiaas_deploy_daemon/test_extension_hook_caller.py
+++ b/tests/fiaas_deploy_daemon/test_extension_hook_caller.py
@@ -116,7 +116,7 @@ class TestExtensionHookCaller(object):
 
     @pytest.mark.usefixtures("session_respond_404")
     def test_return_same_object_when_no_url_in_config(self, session, app_spec, deployment):
-        conf = Configuration()
+        conf = Configuration([])
         extension_hook_caller = ExtensionHookCaller(conf, session)
         obj = copy.deepcopy(deployment)
         extension_hook_caller.apply(obj, app_spec)

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ passenv =
     DOCKER_HOST
 commands=
     codestyle: flake8 '--format=%(path)-50s: [%(code)s] %(text)s [line:%(row)d, column:%(col)d]' {posargs}
-    test: py.test -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report html --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --html=build/reports/tests.html --disable-warnings {posargs}
-    integration_test: py.test -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --html=build/reports/integration_tests.html --disable-warnings {posargs}
+    test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report html --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --html=build/reports/tests.html --disable-warnings {posargs}
+    integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --html=build/reports/integration_tests.html --disable-warnings {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands=
     codestyle: flake8 '--format=%(path)-50s: [%(code)s] %(text)s [line:%(row)d, column:%(col)d]' {posargs}
     # --cov-report html and --html disabled temporarily until pytest-html can be upgraded to 4.x
     # test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report html --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --html=build/reports/tests.html --disable-warnings {posargs}
-    test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --disable-warnings {posargs}
+    test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml {posargs}
     # --html disabled temporarily until pytest-html can be upgraded to 4.x
     # integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --html=build/reports/integration_tests.html --disable-warnings {posargs}
-    integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --disable-warnings {posargs}
+    integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,9 @@ passenv =
     DOCKER_HOST
 commands=
     codestyle: flake8 '--format=%(path)-50s: [%(code)s] %(text)s [line:%(row)d, column:%(col)d]' {posargs}
-    test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report html --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --html=build/reports/tests.html --disable-warnings {posargs}
-    integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --html=build/reports/integration_tests.html --disable-warnings {posargs}
+    # --cov-report html and --html disabled temporarily until pytest-html can be upgraded to 4.x
+    # test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report html --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --html=build/reports/tests.html --disable-warnings {posargs}
+    test: python -m pytest -m "not integration_test" -n auto -ra --cov=fiaas_deploy_daemon --cov-report xml --cov-report term --junit-xml=build/reports/tests.xml --disable-warnings {posargs}
+    # --html disabled temporarily until pytest-html can be upgraded to 4.x
+    # integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --html=build/reports/integration_tests.html --disable-warnings {posargs}
+    integration_test: python -m pytest -m integration_test -n 2 -ra --junit-xml=build/reports/integration_tests.xml --disable-warnings {posargs}


### PR DESCRIPTION
pytest and various related plugins were pinned to versions which supported python 2. Upgrade these dependencies to the most recent versions, since python 2 support is no longer relevant.

- There were several breaking changes between pytest versions 3.x -> 7.x. The changes which affected the tests here were mainly:
  - metafunc.addcall -> metafunc.parametrize, or switch to using parametrize decorator where possible
  - request.funcargvalue -> request.getfixturevalue
  - running tests with `py.test` from the command line doesn't seem to work  (at least locally), because of what appears to be an import/sys.path issue. I've changed the tox commands to use `python -m pytest`, which seems to work fine.

- I've disabled generating html test report because of a bug or interaction issue where the number of tests are reported twice (see 9f42cd9cebaf2aeed8a54aafc3bb19bfda99b383 for details). I think it can be enabled again after upgrading pytest-html, flask and its related dependencies to the most recent versions, but I'd prefer to do that in a separate PR.

- Deprecation warnings when running tests were disabled/hidden a long time ago (I think because there were so many). I've enabled these again, and fixed a few of them. The remaining warnings seem mostly related to Python 3.10 compatibility.