### PR TITLE
Type hints

### DIFF
--- a/fiaas_deploy_daemon/deployer/bookkeeper.py
+++ b/fiaas_deploy_daemon/deployer/bookkeeper.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 from prometheus_client import Counter, Gauge, Histogram
 
+from fiaas_deploy_daemon.specs.models import AppSpec
+
 
 class Bookkeeper(object):
     """Measures time, fails and successes"""
@@ -25,12 +27,12 @@ class Bookkeeper(object):
     success_counter = Counter("deployer_success", "Deploy successful", ["app"])
     deploy_histogram = Histogram("deployer_time_to_deploy", "Time spent on each deploy")
 
-    def time(self, app_spec):
+    def time(self, app_spec: AppSpec):
         self.deploy_gauge.labels(app_spec.name).inc()
         return self.deploy_histogram.time()
 
-    def failed(self, app_spec):
+    def failed(self, app_spec: AppSpec):
         self.error_counter.labels(app_spec.name).inc()
 
-    def success(self, app_spec):
+    def success(self, app_spec: AppSpec):
         self.success_counter.labels(app_spec.name).inc()

--- a/fiaas_deploy_daemon/deployer/deploy.py
+++ b/fiaas_deploy_daemon/deployer/deploy.py
@@ -17,10 +17,21 @@
 
 
 import logging
+from queue import Queue
+from typing import Union
 
-from .kubernetes.ready_check import ReadyCheck
+from fiaas_deploy_daemon.config import Configuration
+from fiaas_deploy_daemon.deployer.kubernetes.adapter import K8s
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_networkingv1 import NetworkingV1IngressAdapter
+from fiaas_deploy_daemon.deployer.kubernetes.ingress_v1beta1 import V1Beta1IngressAdapter
+from fiaas_deploy_daemon.lifecycle import Lifecycle, Subject
+
 from ..base_thread import DaemonThread
 from ..log_extras import set_extras
+from ..specs.models import AppSpec
+from .bookkeeper import Bookkeeper
+from .kubernetes.ready_check import ReadyCheck
+from .scheduler import Scheduler
 
 LOG = logging.getLogger(__name__)
 
@@ -31,15 +42,17 @@ class Deployer(DaemonThread):
     Mainly focused on bookkeeping, and leaving the hard work to the framework-adapter.
     """
 
-    def __init__(self, deploy_queue, bookkeeper, adapter, scheduler, lifecycle, ingress_adapter, config):
+    def __init__(
+        self, deploy_queue: Queue, bookkeeper, adapter, scheduler: Scheduler, lifecycle, ingress_adapter, config
+    ):
         super(Deployer, self).__init__()
         self._queue = _make_gen(deploy_queue.get)
-        self._bookkeeper = bookkeeper
-        self._adapter = adapter
-        self._scheduler = scheduler
-        self._lifecycle = lifecycle
-        self._ingress_adapter = ingress_adapter
-        self._config = config
+        self._bookkeeper: Bookkeeper = bookkeeper
+        self._adapter: K8s = adapter
+        self._scheduler: Scheduler = scheduler
+        self._lifecycle: Lifecycle = lifecycle
+        self._ingress_adapter: Union[NetworkingV1IngressAdapter, V1Beta1IngressAdapter] = ingress_adapter
+        self._config: Configuration = config
 
     def __call__(self):
         for event in self._queue:
@@ -52,7 +65,7 @@ class Deployer(DaemonThread):
             else:
                 raise ValueError("Unknown DeployerEvent action {}".format(event.action))
 
-    def _update(self, app_spec, lifecycle_subject):
+    def _update(self, app_spec: AppSpec, lifecycle_subject: Subject):
         try:
             self._lifecycle.start(lifecycle_subject)
             with self._bookkeeper.time(app_spec):
@@ -77,7 +90,7 @@ class Deployer(DaemonThread):
             self._lifecycle.failed(lifecycle_subject)
             self._bookkeeper.failed(app_spec)
 
-    def _delete(self, app_spec):
+    def _delete(self, app_spec: AppSpec):
         self._adapter.delete(app_spec)
         LOG.info("Completed removal of %r", app_spec)
 

--- a/fiaas_deploy_daemon/deployer/deploy.py
+++ b/fiaas_deploy_daemon/deployer/deploy.py
@@ -18,12 +18,10 @@
 
 import logging
 from queue import Queue
-from typing import Union
 
 from fiaas_deploy_daemon.config import Configuration
 from fiaas_deploy_daemon.deployer.kubernetes.adapter import K8s
-from fiaas_deploy_daemon.deployer.kubernetes.ingress_networkingv1 import NetworkingV1IngressAdapter
-from fiaas_deploy_daemon.deployer.kubernetes.ingress_v1beta1 import V1Beta1IngressAdapter
+from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressAdapterInterface
 from fiaas_deploy_daemon.lifecycle import Lifecycle, Subject
 
 from ..base_thread import DaemonThread
@@ -51,7 +49,7 @@ class Deployer(DaemonThread):
         self._adapter: K8s = adapter
         self._scheduler: Scheduler = scheduler
         self._lifecycle: Lifecycle = lifecycle
-        self._ingress_adapter: Union[NetworkingV1IngressAdapter, V1Beta1IngressAdapter] = ingress_adapter
+        self._ingress_adapter: IngressAdapterInterface = ingress_adapter
         self._config: Configuration = config
 
     def __call__(self):

--- a/fiaas_deploy_daemon/deployer/kubernetes/adapter.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/adapter.py
@@ -20,7 +20,13 @@ import logging
 
 from k8s.models.resourcequota import ResourceQuota, NotBestEffort
 
-from ...specs.models import ResourcesSpec, ResourceRequirementSpec
+from ...specs.models import AppSpec, ResourcesSpec, ResourceRequirementSpec
+
+from .autoscaler import AutoscalerDeployer
+from .deployment import DeploymentDeployer
+from .ingress import IngressDeployer
+from .service import ServiceDeployer
+from .service_account import ServiceAccountDeployer
 
 LOG = logging.getLogger(__name__)
 
@@ -33,13 +39,13 @@ class K8s(object):
     ):
         self._version = config.version
         self._enable_service_account_per_app = config.enable_service_account_per_app
-        self._service_deployer = service_deployer
-        self._deployment_deployer = deployment_deployer
-        self._ingress_deployer = ingress_deployer
-        self._autoscaler_deployer = autoscaler
-        self._service_account_deployer = service_account_deployer
+        self._service_deployer: ServiceDeployer = service_deployer
+        self._deployment_deployer: DeploymentDeployer = deployment_deployer
+        self._ingress_deployer: IngressDeployer = ingress_deployer
+        self._autoscaler_deployer: AutoscalerDeployer = autoscaler
+        self._service_account_deployer: ServiceAccountDeployer = service_account_deployer
 
-    def deploy(self, app_spec):
+    def deploy(self, app_spec: AppSpec):
         if _besteffort_qos_is_required(app_spec):
             app_spec = _remove_resource_requirements(app_spec)
         selector = _make_selector(app_spec)
@@ -51,13 +57,13 @@ class K8s(object):
         self._deployment_deployer.deploy(app_spec, selector, labels, _besteffort_qos_is_required(app_spec))
         self._autoscaler_deployer.deploy(app_spec, labels)
 
-    def delete(self, app_spec):
+    def delete(self, app_spec: AppSpec):
         self._ingress_deployer.delete(app_spec)
         self._autoscaler_deployer.delete(app_spec)
         self._service_deployer.delete(app_spec)
         self._deployment_deployer.delete(app_spec)
 
-    def _make_labels(self, app_spec):
+    def _make_labels(self, app_spec: AppSpec):
         labels = {
             "app": app_spec.name,
             "fiaas/version": app_spec.version,
@@ -81,15 +87,15 @@ def _to_valid_label_value(value):
     return value.lower().replace(" ", "-").replace("ø", "oe").replace("å", "aa").replace("æ", "ae").replace(":", "-")
 
 
-def _make_selector(app_spec):
+def _make_selector(app_spec: AppSpec):
     return {"app": app_spec.name}
 
 
-def _remove_resource_requirements(app_spec):
+def _remove_resource_requirements(app_spec: AppSpec):
     no_requirements = ResourceRequirementSpec(cpu=None, memory=None)
     return app_spec._replace(resources=ResourcesSpec(limits=no_requirements, requests=no_requirements))
 
 
-def _besteffort_qos_is_required(app_spec):
+def _besteffort_qos_is_required(app_spec: AppSpec):
     resourcequotas = ResourceQuota.list(namespace=app_spec.namespace)
     return any(rq.spec.hard.get("pods") == "0" and NotBestEffort in rq.spec.scopes for rq in resourcequotas)

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/datadog.py
@@ -24,6 +24,7 @@ from k8s.models.pod import (
     Lifecycle,
     SecretKeySelector,
 )
+from k8s.models.deployment import Deployment
 
 
 class DataDog(object):
@@ -35,7 +36,7 @@ class DataDog(object):
         self._datadog_global_tags = config.datadog_global_tags
         self._datadog_activate_sleep = config.datadog_activate_sleep
 
-    def apply(self, deployment, app_spec, besteffort_qos_is_required, pre_stop_delay):
+    def apply(self, deployment: Deployment, app_spec, besteffort_qos_is_required, pre_stop_delay):
         if app_spec.datadog.enabled:
             containers = deployment.spec.template.spec.containers
             main_container = containers[0]

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_networkingv1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_networkingv1.py
@@ -35,10 +35,10 @@ from fiaas_deploy_daemon.extension_hook_caller import ExtensionHookCaller
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
 
-from .ingress import IngressTLSDeployer, deduplicate_in_order
+from .ingress import IngressAdapterInterface, IngressTLSDeployer, deduplicate_in_order
 
 
-class NetworkingV1IngressAdapter(object):
+class NetworkingV1IngressAdapter(IngressAdapterInterface):
     def __init__(self, ingress_tls_deployer, owner_references, extension_hook):
         self._ingress_tls_deployer: IngressTLSDeployer = ingress_tls_deployer
         self._owner_references: OwnerReferences = owner_references

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_networkingv1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_networkingv1.py
@@ -16,31 +16,33 @@
 # limitations under the License.
 
 
+from k8s.base import Equality, Exists, Inequality
 from k8s.client import NotFound
 from k8s.models.common import ObjectMeta
 from k8s.models.networking_v1_ingress import (
-    Ingress,
-    IngressSpec,
-    IngressRule,
-    HTTPIngressRuleValue,
     HTTPIngressPath,
+    HTTPIngressRuleValue,
+    Ingress,
     IngressBackend,
+    IngressRule,
     IngressServiceBackend,
+    IngressSpec,
     ServiceBackendPort,
 )
-from k8s.base import Equality, Inequality, Exists
 
+from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
+from fiaas_deploy_daemon.extension_hook_caller import ExtensionHookCaller
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
 
-from .ingress import deduplicate_in_order
+from .ingress import IngressTLSDeployer, deduplicate_in_order
 
 
 class NetworkingV1IngressAdapter(object):
     def __init__(self, ingress_tls_deployer, owner_references, extension_hook):
-        self._ingress_tls_deployer = ingress_tls_deployer
-        self._owner_references = owner_references
-        self._extension_hook = extension_hook
+        self._ingress_tls_deployer: IngressTLSDeployer = ingress_tls_deployer
+        self._owner_references: OwnerReferences = owner_references
+        self._extension_hook: ExtensionHookCaller = extension_hook
 
     @retry_on_upsert_conflict
     def create_ingress(self, app_spec, annotated_ingress, labels):
@@ -69,7 +71,12 @@ class NetworkingV1IngressAdapter(object):
 
         hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
         self._ingress_tls_deployer.apply(
-            ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, annotated_ingress.issuer_name, use_suffixes=use_suffixes
+            ingress,
+            app_spec,
+            hosts_for_tls,
+            annotated_ingress.issuer_type,
+            annotated_ingress.issuer_name,
+            use_suffixes=use_suffixes,
         )
         self._owner_references.apply(ingress, app_spec)
         self._extension_hook.apply(ingress, app_spec)

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
@@ -24,10 +24,10 @@ from k8s.base import Equality, Inequality, Exists
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
 from fiaas_deploy_daemon.tools import merge_dicts
 
-from .ingress import deduplicate_in_order
+from .ingress import IngressAdapterInterface, deduplicate_in_order
 
 
-class V1Beta1IngressAdapter(object):
+class V1Beta1IngressAdapter(IngressAdapterInterface):
     def __init__(self, ingress_tls_deployer, owner_references, extension_hook):
         self._ingress_tls_deployer = ingress_tls_deployer
         self._owner_references = owner_references

--- a/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ingress_v1beta1.py
@@ -60,7 +60,12 @@ class V1Beta1IngressAdapter(object):
 
         hosts_for_tls = [rule.host for rule in per_host_ingress_rules]
         self._ingress_tls_deployer.apply(
-            ingress, app_spec, hosts_for_tls, annotated_ingress.issuer_type, annotated_ingress.issuer_name, use_suffixes=use_suffixes
+            ingress,
+            app_spec,
+            hosts_for_tls,
+            annotated_ingress.issuer_type,
+            annotated_ingress.issuer_name,
+            use_suffixes=use_suffixes,
         )
         self._owner_references.apply(ingress, app_spec)
         self._extension_hook.apply(ingress, app_spec)

--- a/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/ready_check.py
@@ -24,6 +24,8 @@ from k8s.models.certificate import Certificate
 from k8s.models.deployment import Deployment
 from time import monotonic as time_monotonic
 
+from .ingress import IngressAdapterInterface
+
 LOG = logging.getLogger(__name__)
 
 
@@ -40,7 +42,7 @@ class ReadyCheck(object):
         )
         self._fail_after = time_monotonic() + self._fail_after_seconds
         self._should_check_ingress = config.tls_certificate_ready
-        self._ingress_adapter = ingress_adapter
+        self._ingress_adapter: IngressAdapterInterface = ingress_adapter
 
     def __call__(self):
         if self._ready():

--- a/fiaas_deploy_daemon/deployer/kubernetes/service_account.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/service_account.py
@@ -19,25 +19,26 @@
 import logging
 
 from k8s.client import NotFound
+from k8s.models.common import ObjectMeta
 from k8s.models.service_account import ServiceAccount
 
-from k8s.models.common import ObjectMeta
+from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
 from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
+from fiaas_deploy_daemon.specs.models import AppSpec
 from fiaas_deploy_daemon.tools import merge_dicts
-
 
 LOG = logging.getLogger(__name__)
 
 
 class ServiceAccountDeployer(object):
     def __init__(self, config, owner_references):
-        self._owner_references = owner_references
+        self._owner_references: OwnerReferences = owner_references
 
-    def deploy(self, app_spec, labels):
+    def deploy(self, app_spec: AppSpec, labels):
         self._create(app_spec, labels)
 
     @retry_on_upsert_conflict
-    def _create(self, app_spec, labels):
+    def _create(self, app_spec: AppSpec, labels):
         LOG.info("Creating/updating serviceAccount for %s with labels: %s", app_spec.name, labels)
         service_account_name = app_spec.name
         namespace = app_spec.namespace

--- a/fiaas_deploy_daemon/deployer/scheduler.py
+++ b/fiaas_deploy_daemon/deployer/scheduler.py
@@ -16,8 +16,8 @@
 # limitations under the License.
 import time
 from queue import PriorityQueue
-
 from time import monotonic as time_monotonic
+from typing import Callable
 
 from ..base_thread import DaemonThread
 
@@ -26,8 +26,8 @@ class Scheduler(DaemonThread):
     def __init__(self, time_func=time_monotonic, delay_func=time.sleep):
         super(Scheduler, self).__init__()
         self._tasks = PriorityQueue()
-        self._time_func = time_func
-        self._delay_func = delay_func
+        self._time_func: Callable[[], float] = time_func
+        self._delay_func: Callable[[float], None] = delay_func
 
     def __call__(self, *args, **kwargs):
         while True:
@@ -39,6 +39,6 @@ class Scheduler(DaemonThread):
                 self.add(task)
             self._delay_func(1)
 
-    def add(self, task, delay=1):
+    def add(self, task: Callable[[], bool], delay=1):
         execute_at = self._time_func() + delay
         self._tasks.put((execute_at, task))

--- a/fiaas_deploy_daemon/lifecycle.py
+++ b/fiaas_deploy_daemon/lifecycle.py
@@ -37,16 +37,18 @@ class Lifecycle(object):
     def change(self, status, subject):
         self.state_change_signal.send(status=status, subject=subject)
 
-    def initiate(self, uid, app_name, namespace, deployment_id, repository=None, labels=None, annotations=None):
+    def initiate(
+        self, uid, app_name, namespace, deployment_id, repository=None, labels=None, annotations=None
+    ) -> Subject:
         subject = Subject(uid, app_name, namespace, deployment_id, repository, labels, annotations)
         self.state_change_signal.send(status=STATUS_INITIATED, subject=subject)
         return subject
 
-    def start(self, subject):
+    def start(self, subject: Subject):
         self.change(STATUS_STARTED, subject)
 
-    def success(self, subject):
+    def success(self, subject: Subject):
         self.change(STATUS_SUCCESS, subject)
 
-    def failed(self, subject):
+    def failed(self, subject: Subject):
         self.change(STATUS_FAILED, subject)

--- a/fiaas_deploy_daemon/logsetup.py
+++ b/fiaas_deploy_daemon/logsetup.py
@@ -23,6 +23,7 @@ import sys
 
 from fiaas_deploy_daemon.log_extras import StatusHandler
 from .log_extras import ExtraFilter, StatusErrorHandler
+from .config import Configuration
 
 
 class FiaasFormatter(logging.Formatter):
@@ -88,7 +89,7 @@ class FiaasFormatter(logging.Formatter):
         }
 
 
-def init_logging(config):
+def init_logging(config: Configuration):
     """Set up logging system, according to FINN best practice for cloud
 
     - Always logs to stdout
@@ -107,7 +108,7 @@ def init_logging(config):
     _set_special_levels()
 
 
-def _create_default_handler(config):
+def _create_default_handler(config: Configuration):
     handler = logging.StreamHandler(sys.stdout)
     handler.addFilter(ExtraFilter())
     if _json_format(config):
@@ -125,9 +126,9 @@ def _set_special_levels():
         kafka_logger.setLevel(logging.INFO)
 
 
-def _json_format(config):
+def _json_format(config: Configuration):
     return config.log_format == "json"
 
 
-def _plain_format(config):
+def _plain_format(config: Configuration):
     return config.log_format == "plain"


### PR DESCRIPTION
I've gone through and added type hints in most files. The goal of this is to make it more simple to navigate through the code in an IDE editor. The second commit uses an ABC instead of just type hints. As it says in the commit message, that's to avoid cyclic dependencies

This is obviously a big, sweeping change, but without semantics. Let me know if you want it to be in the `.git-blame-ignore-revs` file. While doing this, my editor (through running black I think, not sure though), resorted some of the imports. I hope that's ok.