### PR TITLE
Add permissions for applications/status

### DIFF
--- a/helm/fiaas-deploy-daemon/templates/role.yaml
+++ b/helm/fiaas-deploy-daemon/templates/role.yaml
@@ -32,6 +32,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - fiaas.schibsted.io
+  resources:
+  - applications/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - ""
   - apps
   - autoscaling


### PR DESCRIPTION
We detected a problem with the last image and the include-status-in-app flag. We are adding the permissions for the applications/status.