### PR TITLE
Upgrade k8s to 0.24.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ GENERIC_REQ = [
     "decorator < 5.0.0",  # 5.0.0 and later drops py2 support (transitive dep from pinject)
     "six >= 1.12.0",
     "dnspython == 1.16.0",
-    "k8s == 0.23.4",
+    "k8s == 0.24.2",
     "appdirs == 1.4.3",
     "requests-toolbelt == 0.10.1",
     "backoff == 1.8.0",


### PR DESCRIPTION
The latest k8s release contains a bug fix for the Watcher class where it could previously hang for up to an hour before noticing a dropped connection. The fix also adds support for bookmark events, which avoids the need of a full quorum read on reconnections in the watcher.