### PR TITLE
Add PDB rbac rule to helm chart

### DIFF
--- a/helm/fiaas-deploy-daemon/templates/role.yaml
+++ b/helm/fiaas-deploy-daemon/templates/role.yaml
@@ -48,12 +48,14 @@ rules:
   - autoscaling
   - extensions
   - networking.k8s.io
+  - policy
   resources:
   - configmaps
   - deployments
   - horizontalpodautoscalers
   - ingresses
   - pods
+  - poddisruptionbudgets
   - resourcequotas
   - services
   - serviceaccounts


### PR DESCRIPTION
I forgot to update the rbac rule in the helm chart when adding PodDisruptionBudget support. This PR fixes that.