### PR TITLE
Update Kubernetes versions and documentation

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,9 +65,10 @@ blocks:
           # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
-              - v1.24.12
-              - v1.25.8
-              - v1.26.3
+              - v1.24.15
+              - v1.25.11
+              - v1.26.6
+              - v1.27.3
 promotions:
   - name: Push container image
     pipeline_file: push-container-image.yml

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run fiaas-deploy-daemon locally and connect it to a local cluster, do the fol
 
 With kind:
 * (See https://kind.sigs.k8s.io/docs/user/quick-start/#installation for how to install and configure kind)
-* Start kind: `$ kind create cluster --image kindest/node:v1.26.3`
+* Start kind: `$ kind create cluster --image kindest/node:v1.27.3`
 * Run `$ bin/run_fdd_against_kind`
 
 With minikube:
@@ -82,7 +82,7 @@ If you need to test some behavior manually you can deploy applications into mini
 
 #### Deploying an application via CustomResourceDefinition
 
-In Kubernetes 1.7 and later you can deploy applications by creating a Application CustomResource
+You can deploy applications by creating a Application CustomResource
 
 ```yaml
 apiVersion: fiaas.schibsted.io/v1

--- a/docs/platform_contract.md
+++ b/docs/platform_contract.md
@@ -23,7 +23,7 @@ The [Operators guide](operator_guide.md) documents what cluster operators need t
 
 ## Supported kubernetes versions
 
-We are currently testing Kubernetes version 1.9.0 and above. FIAAS may work on older versions, but is not tested.
+We are currently testing Kubernetes version 1.24.12 and above. FIAAS may work on older versions, but is not tested.
 
 ## Notable kubernetes features in use
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def pytest_addoption(parser):
     parser.addoption(
         E2E_K8S_VERSION_OPTION,
         action="store",
-        default="v1.26.3",
+        default="v1.27.3",
         help="Run e2e tests against a kind cluster using this Kubernetes version",
     )
 


### PR DESCRIPTION
This PR is for deprecating unsupported (by all of CNCF, GKE and EKS) Kubernetes versions.

Fixes #224.