### PR TITLE
Handle exceptions from lifecycle.failed

### DIFF
--- a/fiaas_deploy_daemon/deployer/scheduler.py
+++ b/fiaas_deploy_daemon/deployer/scheduler.py
@@ -14,12 +14,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import time
 from queue import PriorityQueue
 from time import monotonic as time_monotonic
 from typing import Callable
 
+from k8s.client import K8sClientException
+from requests.exceptions import RetryError
+
 from ..base_thread import DaemonThread
+
+LOG = logging.getLogger(__name__)
 
 
 class Scheduler(DaemonThread):
@@ -29,15 +35,25 @@ class Scheduler(DaemonThread):
         self._time_func: Callable[[], float] = time_func
         self._delay_func: Callable[[float], None] = delay_func
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, run_forever=True, **kwargs):
         while True:
             execute_at, task = self._tasks.get()
             if self._time_func() >= execute_at:
-                if task():
-                    self.add(task, 10)
+                try:
+                    if task():
+                        self.add(task, 10)
+                except (K8sClientException, RetryError):
+                    # K8sClientException: any unhandled server or client error (non-200 responses).
+                    # RetryError: request which received server error (e.g. 409 or 5xx response) was retried, and
+                    # exponential retries were exhausted.
+                    LOG.exception("Error while processing task")
             else:
                 self.add(task)
             self._delay_func(1)
+            # the run_forever parameter is only to enable testing
+            if not run_forever:
+                LOG.warning("breaking task processing loop because run_forever=%s", run_forever)
+                break
 
     def add(self, task: Callable[[], bool], delay=1):
         execute_at = self._time_func() + delay

--- a/tests/fiaas_deploy_daemon/deployer/test_scheduler.py
+++ b/tests/fiaas_deploy_daemon/deployer/test_scheduler.py
@@ -1,0 +1,58 @@
+from unittest import mock
+
+import pytest
+from k8s.client import ClientError, ServerError
+from requests.exceptions import RetryError
+
+from fiaas_deploy_daemon.deployer.scheduler import Scheduler
+
+
+class TestScheduler:
+    @pytest.fixture
+    def scheduler(self) -> Scheduler:
+        def no_delay(*args, **kwargs):
+            pass
+
+        def time_func_factory(*args, **kwargs):
+            t = 0
+            # scheduler re-adds tasks with a 10s delay if they fail. increasing "time" by 15s every tick should ensure
+            # a re-added task is always called on the next iteration
+            tick_interval = 15
+
+            def _tick():
+                nonlocal t
+                t += tick_interval
+                return t
+
+            return _tick
+
+        yield Scheduler(time_func=time_func_factory(), delay_func=no_delay)
+
+    def test_scheduler_runs_task(self, scheduler):
+        task = mock.MagicMock()
+        task.return_value = True
+
+        scheduler.add(task, delay=0)
+
+        scheduler(run_forever=False)
+
+        task.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "exception_class",
+        (
+            ClientError,
+            ServerError,
+            RetryError,
+        ),
+    )
+    def test_scheduler_handles_exception_raised_by_task(self, scheduler, exception_class):
+        raise_error = mock.MagicMock()
+        raise_error.side_effect = exception_class("updating ApplicationStatus resource failed")
+
+        scheduler.add(raise_error, delay=0)
+
+        # verify that the exception set up above does not flow out of the scheduler; the test will fail if it does
+        scheduler(run_forever=False)
+
+        raise_error.assert_called_once()


### PR DESCRIPTION
An edge case with a combination of a FIAAS config with a lot (thousands) of ingress paths and fiaas-deploy-daemon configured with several ingress-suffix hostnames can generate an ingress that is large enough to exceed the Kubernetes API maximum request payload limit of 3MB. This also causes the ApplicationStatus resource update (via `lifecycle`) to exceed the same limit, since it holds the log entries generated while deploying the application, and the AppSpec object is logged in full at least twice.
If this happens, the deployer and/or scheduler threads exit because exceptions caused by the failed API requests flow unhandled out of these. The liveness probe for fiaas-deploy-daemon then fails, causing the pod to be restarted.

In theory similar exceptions caused by other failure modes can also cause either of these threads to exit, so to increase robustness; log and drop exceptions from failed Kubernetes API requests while updating ApplicationStatus in the exception handler in the deployer thread, and where the scheduler thread calls ReadyChecks. Application deployments that trigger exceptions here will still fail in a half-deployed RUNNING state, but at least fiaas-deploy-daemon will not restart each time it attempts to deploy an application with a configuration like described above.