### PR TITLE
Do not create PDBs for deployments with 0 replicas

### DIFF
--- a/fiaas_deploy_daemon/deployer/kubernetes/pod_disruption_budget.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/pod_disruption_budget.py
@@ -37,7 +37,7 @@ class PodDisruptionBudgetDeployer(object):
 
     @retry_on_upsert_conflict
     def deploy(self, app_spec: AppSpec, selector: dict[str, any], labels: dict[str, any]):
-        if app_spec.autoscaler.min_replicas == 1 or app_spec.autoscaler.max_replicas == 1:
+        if app_spec.autoscaler.min_replicas <= 1 or app_spec.autoscaler.max_replicas <= 1:
             # delete possible existing pdb
             self.delete(app_spec)
             return

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_pod_disruption_budget_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_pod_disruption_budget_deploy.py
@@ -74,6 +74,14 @@ class TestPodDisruptionBudgetDeployer(object):
         delete.assert_called_with(PDB_API + app_spec.name)
         pytest.helpers.assert_no_calls(post)
 
+    def test_zero_replicas_no_pdb_gives_no_post(self, deployer: PodDisruptionBudgetDeployer, delete, post, app_spec):
+        app_spec = app_spec._replace(
+            autoscaler=AutoscalerSpec(enabled=True, min_replicas=0, max_replicas=0, cpu_threshold_percentage=50)
+        )
+        deployer.deploy(app_spec, SELECTOR, LABELS)
+        delete.assert_called_with(PDB_API + app_spec.name)
+        pytest.helpers.assert_no_calls(post)
+
     def test_no_pdb_gives_no_put(self, deployer, delete, put, app_spec):
         app_spec = app_spec._replace(
             autoscaler=AutoscalerSpec(enabled=True, min_replicas=1, max_replicas=1, cpu_threshold_percentage=50)


### PR DESCRIPTION
We detected some PDBs created when the replicas are equal to zero. Changing equal to less or equal to do not create PDBs for 0 replicas. 