### PR TITLE
Add retries in session

### DIFF
--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -60,7 +60,7 @@ class MainBindings(pinject.BindingSpec):
     def provide_session(self, config: Configuration):
         session = requests.Session()
         if config.extension_hook_url is not None:
-            retries = Retry(total=5, backoff_factor=0.1)
+            retries = Retry(total=5, backoff_factor=0.1, connect=5)
             session.mount(config.extension_hook_url, HTTPAdapter(max_retries=retries))
         if config.proxy:
             session.proxies = {scheme: config.proxy for scheme in ("http", "https")}

--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -28,7 +28,7 @@ import pinject
 import requests
 from k8s import config as k8s_config
 from prometheus_client import Info
-from requests.adapters import HTTPAdapter
+from requests.adapters import HTTPAdapter, Retry
 
 
 from .config import Configuration
@@ -59,7 +59,9 @@ class MainBindings(pinject.BindingSpec):
 
     def provide_session(self, config: Configuration):
         session = requests.Session()
-        session.mount(config.extension_hook_url, HTTPAdapter(max_retries=5))
+        if config.extension_hook_ulr is not None:
+            retries = Retry(total=5, backoff_factor=0.1)
+            session.mount(config.extension_hook_url, HTTPAdapter(max_retries=retries))
         if config.proxy:
             session.proxies = {scheme: config.proxy for scheme in ("http", "https")}
         if config.debug:

--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -59,7 +59,7 @@ class MainBindings(pinject.BindingSpec):
 
     def provide_session(self, config: Configuration):
         session = requests.Session()
-        if config.extension_hook_ulr is not None:
+        if config.extension_hook_url is not None:
             retries = Retry(total=5, backoff_factor=0.1)
             session.mount(config.extension_hook_url, HTTPAdapter(max_retries=retries))
         if config.proxy:

--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -30,7 +30,6 @@ from k8s import config as k8s_config
 from prometheus_client import Info
 from requests.adapters import HTTPAdapter, Retry
 
-
 from .config import Configuration
 from .crd import CustomResourceDefinitionBindings, DisabledCustomResourceDefinitionBindings
 from .deployer import DeployerBindings

--- a/fiaas_deploy_daemon/__init__.py
+++ b/fiaas_deploy_daemon/__init__.py
@@ -28,6 +28,8 @@ import pinject
 import requests
 from k8s import config as k8s_config
 from prometheus_client import Info
+from requests.adapters import HTTPAdapter
+
 
 from .config import Configuration
 from .crd import CustomResourceDefinitionBindings, DisabledCustomResourceDefinitionBindings
@@ -57,6 +59,7 @@ class MainBindings(pinject.BindingSpec):
 
     def provide_session(self, config: Configuration):
         session = requests.Session()
+        session.mount(config.extension_hook_url, HTTPAdapter(max_retries=5))
         if config.proxy:
             session.proxies = {scheme: config.proxy for scheme in ("http", "https")}
         if config.debug:


### PR DESCRIPTION
We are detecting some errors when calling the extension-hook:
```
  File "/usr/local/lib/python3.9/site-packages/fiaas_deploy_daemon/extension_hook_caller.py", line 36, in apply
    response = self._session.post(
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 501, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```
To reduce the number of failed deployments due to this, we are adding retries to the session object