### PR TITLE
Update e2e test Kubernetes target versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -65,11 +65,11 @@ blocks:
           # E2E_K8S_VERSION_OPTION in tests/conftest.py; it should point to the most recent version used in CI.
           - env_var: K8S_VERSION
             values:
-              - v1.25.11
-              - v1.26.6
-              - v1.27.3
-              - v1.28.0
-              - v1.29.1
+              - v1.27.16
+              - v1.28.13
+              - v1.29.8
+              - v1.30.4
+              - v1.31.0
 promotions:
   - name: Push container image
     pipeline_file: push-container-image.yml

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To run fiaas-deploy-daemon locally and connect it to a local cluster, do the fol
 
 With kind:
 * (See https://kind.sigs.k8s.io/docs/user/quick-start/#installation for how to install and configure kind)
-* Start kind: `$ kind create cluster --image kindest/node:v1.29.1`
+* Start kind: `$ kind create cluster --image kindest/node:v1.31.0`
 * Run `$ bin/run_fdd_against_kind`
 
 With minikube:

--- a/bin/install_e2e_dependencies
+++ b/bin/install_e2e_dependencies
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 K8S_VERSION="$1"
-KIND_VERSION=v0.18.0
+KIND_VERSION=v0.24.0
 
 curl -Lo "$HOME/.local/bin/kind" "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
 chmod +x "$HOME/.local/bin/kind"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def pytest_addoption(parser):
     parser.addoption(
         E2E_K8S_VERSION_OPTION,
         action="store",
-        default="v1.29.1",
+        default="v1.31.0",
         help="Run e2e tests against a kind cluster using this Kubernetes version",
     )
 


### PR DESCRIPTION
- Remove Kubernetes 1.25, 1.26
- Add Kubernetes 1.30, 1.31
- Kubernetes 1.31 is the new default e2e test version