### PR TITLE
Add missing key in liveness probe

### DIFF
--- a/docs/v3_spec.md
+++ b/docs/v3_spec.md
@@ -313,6 +313,7 @@ healthchecks:
     initial_delay_seconds: 10
     period_seconds: 10
     success_threshold: 1 # For liveness, 1 is the only valid value. For readiness, it can be higher
+    failure_threshold: 3
     timeout_seconds: 1
 ```
 


### PR DESCRIPTION
We detected that the failure_threshold was not documented in the docs, so we are adding it to the v3_spec docs.

https://github.com/fiaas/fiaas-deploy-daemon/blob/e414289c5639c162043a7d89ec50cb5a8a0c66eb/fiaas_deploy_daemon/specs/v3/defaults.yml#L43C5-L43C25