### PR TITLE
Update pyyaml to 6.0.2

### DIFF
--- a/bin/yaml_edit.py
+++ b/bin/yaml_edit.py
@@ -88,7 +88,7 @@ def process_file(editor, filepath):
     yaml = YAML()
     yaml.preserve_quotes = True
     with open(filepath) as fobj:
-        data = yaml.load(fobj)
+        data = yaml.safe_load(fobj)
     try:
         data = editor.edit(data)
     except KeyError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">= 3.12"
 dependencies = [
     "ConfigArgParse == 0.14.0",
     "prometheus_client == 0.7.1",
-    "PyYAML == 5.1.2",
+    "PyYAML == 6.0.2",
     "pyaml == 19.4.1",
     "pinject == 0.14.1",
     "decorator < 5.0.0",  # 5.0.0 and later drops py2 support (transitive dep from pinject)


### PR DESCRIPTION
From the changelog[1] since 5.1.2 it looks like the most significant changes are dropping python 2 support and changing the signature of yaml.load. fiaas-deploy-daemon generally uses yaml.safe_load. I found a reference to yaml.load in `bin/yaml_edit.py` which is also changed to safe_load now.

[1]: https://github.com/yaml/pyyaml/blob/main/CHANGES