### PR TITLE
Add support in PDBs to be able to set unhealthyPodEvictionPolicy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ limitations under the License.
 
 [![Build status](https://fiaas-svc.semaphoreci.com/badges/fiaas-deploy-daemon.svg?style=shields)](https://fiaas-svc.semaphoreci.com/projects/fiaas-deploy-daemon)
 
-You need Python 3.9+ and `pip`(7.x.x or higher)  on your `PATH` to work with fiaas-deploy-daemon.
+You need Python 3.12 and `pip`(7.x.x or higher)  on your `PATH` to work with fiaas-deploy-daemon.
 
 Supported use-cases
 -------------------

--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -211,6 +211,13 @@ This feature is disabled by default.
 
 By default, PDB will be set with maxUnavailable = 1 in case the deployment has more than 1 replica. This parameter allows to change that value either with another int value or with a string percentage (i.e. "20%"). Recommendation is some low value like 10% to avoid issues. Also in case of a number, something below min_replicas should be used to allow evictions.
 
+### pdb-unhealthy-pod-eviction-policy
+This option is useful for avoiding operational problems, with node rotations, when there exists deployments with only unhealthy pods. This can be useful in dev clusters which have deployment with only unhealthy pods or in production clusters where the applications tolerate unhealthy pods being disrupted, while new pods are being started.
+
+This option Controls when unhealthy running pods can be evicted. The default 'IfHealthyBudget' allows eviction only if enough healthy pods are available to maintain the desired count of healthy pods. 'AlwaysAllow' permits eviction of unhealthy running pods even if doing so would leave fewer pods than desired temporarily.
+
+[Kubernetes documentation is available here.](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy)
+
 ### disable-service-links
 
 By default, [enableServiceLinks](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#podspec-v1-core) is set to true, which means that environment variables are automatically created for each service in the same namespace. This parameter allows you to disable this feature by setting disable-service-links to true. This can be useful in scenarios where you have a large number of services and you want to reduce the number of environment variables that are automatically created. For new installations, it's recommended to disable this feature to streamline the environment setup. However, for existing installations, proceed with caution when disabling this feature. This is due to potential compatibility issues, as some services might rely on these automatically created environment variables for communication.

--- a/fiaas_deploy_daemon/config.py
+++ b/fiaas_deploy_daemon/config.py
@@ -328,6 +328,16 @@ class Configuration(Namespace):
             default="1",
             type=_int_or_unicode
         )
+        parser.add_argument(
+            "--pdb-unhealthy-pod-eviction-policy",
+            help=(
+                "The policy for unhealthy pods. IfHealthyBudget will only evict pods if the there "
+                "are enough healthy pods to maintain the budget. AlwaysAllow will allow "
+                "disruptions of unhealthy pods, even when the budget is not met."
+            ),
+            default="IfHealthyBudget",
+            choices=("IfHealthyBudget", "AlwaysAllow"),
+        )
         # Logic is inverted due to ConfigArgParse not supporting boolean flags with negation
         parser.add_argument(
             "--disable-service-links",

--- a/fiaas_deploy_daemon/deployer/kubernetes/pod_disruption_budget.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/pod_disruption_budget.py
@@ -34,6 +34,7 @@ class PodDisruptionBudgetDeployer(object):
         self._owner_references = owner_references
         self._extension_hook = extension_hook
         self.max_unavailable = config.pdb_max_unavailable
+        self.unhealthy_pod_eviction_policy = config.pdb_unhealthy_pod_eviction_policy
 
     @retry_on_upsert_conflict
     def deploy(self, app_spec: AppSpec, selector: dict[str, any], labels: dict[str, any]):
@@ -58,7 +59,8 @@ class PodDisruptionBudgetDeployer(object):
 
         spec = PodDisruptionBudgetSpec(
             selector=LabelSelector(matchLabels=selector),
-            maxUnavailable=max_unavailable
+            maxUnavailable=max_unavailable,
+            unhealthyPodEvictionPolicy=self.unhealthy_pod_eviction_policy
         )
 
         pdb = PodDisruptionBudget.get_or_create(metadata=metadata, spec=spec)


### PR DESCRIPTION
This PR introduces support for the unhealthyPodEvictionPolicy to provide more control over pod eviction behavior managed by PodDisruptionBudgets (PDBs). The policy can now be configured per FIAAS deployment daemon instance, allowing administrators to define how unhealthy pods are handled during voluntary disruptions like node maintenance.


**Default setting**: IfHealthyBudget, ensuring evictions only occur if they respect the PDB's disruption budget.
**Optional setting**: AlwaysAllow, can be useful for dev-environments where deployments may be broken or when the applications can tolerate the disruptions.

Documentation: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy
