### PR TITLE
Add node selector, affinity and toleration handling to the Helm chart

### DIFF
--- a/helm/fiaas-deploy-daemon/templates/deployment.yaml
+++ b/helm/fiaas-deploy-daemon/templates/deployment.yaml
@@ -83,18 +83,14 @@ spec:
             name: fiaas-deploy-daemon-config
             readOnly: true
       {{- if .Values.deployment.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+      nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.affinity }}
-      affinity:
-{{ toYaml .Values.deployment.affinity | indent 8 }}
+      affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.topologySpreadConstraints }}
-      topologySpreadConstraints:
-{{ toYaml .Values.deployment.topologySpreadConstraints | indent 8 }}
+      topologySpreadConstraints: {{ toYaml .Values.deployment.topologySpreadConstraints | nindent 8 }}
       {{- end }}
       {{- if .Values.deployment.tolerations }}
-      tolerations:
-{{ toYaml .Values.deployment.tolerations | indent 8 }}
+      tolerations: {{ toYaml .Values.deployment.tolerations | nindent 8 }}
       {{- end }}

--- a/helm/fiaas-deploy-daemon/templates/deployment.yaml
+++ b/helm/fiaas-deploy-daemon/templates/deployment.yaml
@@ -82,3 +82,19 @@ spec:
           - mountPath: /var/run/config/fiaas/
             name: fiaas-deploy-daemon-config
             readOnly: true
+      {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.deployment.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.affinity }}
+      affinity:
+{{ toYaml .Values.deployment.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.deployment.topologySpreadConstraints | indent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.tolerations }}
+      tolerations:
+{{ toYaml .Values.deployment.tolerations | indent 8 }}
+      {{- end }}

--- a/helm/fiaas-deploy-daemon/values.yaml.tpl
+++ b/helm/fiaas-deploy-daemon/values.yaml.tpl
@@ -117,3 +117,31 @@ deployment:
       prometheus.io/path: /internal-backstage/prometheus
       prometheus.io/port: "5000"
       prometheus.io/scrape: "true"
+
+  # Node labels for pod assignment
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  #
+  nodeSelector: {}
+
+  # Pod affinity: the pod's scheduling constraints for more fine-grained node selection logic and
+  # co-location rules with other pods.
+  #
+  affinity: {}
+
+  # Pod topology spread constraints
+  # You can use them to control how Pods are spread across your cluster among failure-domains such as
+  # regions, zones, nodes, and other user-defined topology domains. This can help to achieve high
+  # availability as well as efficient resource utilization.
+  # All topologySpreadConstraints are ANDed.
+  #
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
+
+  # Node tolerations for scheduling to nodes with taints
+  # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  #
+  tolerations: []
+    # - key: "key"
+    #   operator: "Equal|Exists"
+    #   value: "value"
+    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"


### PR DESCRIPTION
It's common to deploy non-user workloads such as the FIAAS daemon on centralized management nodes. By adding fields for node selectors and affinities (and tolerations), we can start using advanced scheduling logic such as required by the Cluster Autoscaler or Karpenter.