### PR TITLE
Add fiaas_log_records metric

### DIFF
--- a/fiaas_deploy_daemon/log_metrics.py
+++ b/fiaas_deploy_daemon/log_metrics.py
@@ -1,0 +1,17 @@
+import logging
+
+from prometheus_client import Counter
+
+fiaas_log_records = Counter(
+    "fiaas_log_records",
+    "Number of records logged by the application, by level",
+    ["level"],
+)
+
+
+class MetricsHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+
+    def emit(self, record: logging.LogRecord):
+        fiaas_log_records.labels(level=record.levelname).inc()

--- a/fiaas_deploy_daemon/logsetup.py
+++ b/fiaas_deploy_daemon/logsetup.py
@@ -23,6 +23,7 @@ import sys
 
 from fiaas_deploy_daemon.log_extras import StatusHandler
 from .log_extras import ExtraFilter, StatusErrorHandler
+from .log_metrics import MetricsHandler
 from .config import Configuration
 
 
@@ -105,6 +106,7 @@ def init_logging(config: Configuration):
     root.addHandler(_create_default_handler(config))
     root.addHandler(StatusHandler())
     root.addHandler(StatusErrorHandler())
+    root.addHandler(MetricsHandler())
     _set_special_levels()
 
 

--- a/tests/fiaas_deploy_daemon/test_log_metrics.py
+++ b/tests/fiaas_deploy_daemon/test_log_metrics.py
@@ -1,0 +1,32 @@
+import logging
+
+from fiaas_deploy_daemon.log_metrics import MetricsHandler, fiaas_log_records
+
+
+def test_metrics_handler():
+    log = logging.getLogger("test_metrics_handler")
+    log.addHandler(MetricsHandler())
+    log.setLevel(logging.DEBUG)
+
+    log.debug("debug")
+    log.info("info")
+    log.warning("warning")
+    log.error("error")
+    try:
+        raise RuntimeError("exception")
+    except RuntimeError:
+        log.exception("exception")
+
+    expected = {
+        "DEBUG": 1.0,
+        "INFO": 1.0,
+        "WARNING": 1.0,
+        "ERROR": 2.0,
+    }
+
+    [metric] = fiaas_log_records.collect()
+    for level, value in expected.items():
+        assert any(
+            sample.name == "fiaas_log_records_total" and sample.labels == {"level": level} and sample.value == value
+            for sample in metric.samples
+        ), f"fiaas_log_records_total with labels level={level} and value={value} was not in the collected samples"

--- a/tests/fiaas_deploy_daemon/test_logsetup.py
+++ b/tests/fiaas_deploy_daemon/test_logsetup.py
@@ -24,6 +24,7 @@ import pytest
 from callee import InstanceOf, Attrs, List
 
 from fiaas_deploy_daemon.log_extras import StatusHandler, ExtraFilter, set_extras
+from fiaas_deploy_daemon.log_metrics import MetricsHandler
 from fiaas_deploy_daemon.logsetup import init_logging, FiaasFormatter, _create_default_handler
 
 TEST_MESSAGE = "This is a test log message"
@@ -58,7 +59,11 @@ class TestLogSetup(object):
         init_logging(_FakeConfig())
 
         root_logger.addHandler.assert_has_calls(
-            (mock.call(self._describe_stream_handler(logging.Formatter)), mock.call(self._describe_status_handler())),
+            (
+                mock.call(self._describe_stream_handler(logging.Formatter)),
+                mock.call(self._describe_status_handler()),
+                mock.call(InstanceOf(MetricsHandler)),
+            ),
             any_order=True,
         )
         root_logger.setLevel.assert_called_with(logging.INFO)
@@ -66,7 +71,11 @@ class TestLogSetup(object):
     def test_output_json(self, root_logger):
         init_logging(_FakeConfig("json"))
         root_logger.addHandler.assert_has_calls(
-            (mock.call(self._describe_stream_handler(FiaasFormatter)), mock.call(self._describe_status_handler())),
+            (
+                mock.call(self._describe_stream_handler(FiaasFormatter)),
+                mock.call(self._describe_status_handler()),
+                mock.call(InstanceOf(MetricsHandler)),
+            ),
             any_order=True,
         )
 


### PR DESCRIPTION
Add metric to track the number of logged records. The primary use case is to enable monitoring the number of error logs.