### PR TITLE
Statefulsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ spec:
   application: example
   image: nginx:1.13.0
   config:
-    version: 3
+    version: 4
     ingress:
       - host: example.com
     metrics:

--- a/docs/crd/examples/fiaas-deploy-daemon.yaml
+++ b/docs/crd/examples/fiaas-deploy-daemon.yaml
@@ -23,7 +23,7 @@ spec:
   application: fiaas-deploy-daemon
   image: fiaas/fiaas-deploy-daemon:20190812124040-967aba3
   config:
-    version: 3
+    version: 4
     admin_access: true
     replicas:
       maximum: 1

--- a/docs/crd/examples/nginx.yaml
+++ b/docs/crd/examples/nginx.yaml
@@ -28,7 +28,7 @@ spec:
       service_account:
         eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/iam_role
         abc: "test1"
-    version: 3
+    version: 4
     replicas:
       maximum: 2
       minimum: 1

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -45,7 +45,7 @@ This allows for a wide range of use-cases, some specific to a single site and ou
 
 Extensions in the cluster needs to be registered, by creating a FiaasExtension object, with details about how it integrates with the rest of the platform, a name and possibly other identifying details like maintainer and code repo.
 
-Extensions would typically require some configuration for each application. In the case of pure Operators, the configuration would most likely be in the form of custom annotations that are applied to objects as they are created, and then picked up by the Operator. This is supported in v3 of the fiaas.yml specification, with custom annotations propagated directly from the configuration to the objects.
+Extensions would typically require some configuration for each application. In the case of pure Operators, the configuration would most likely be in the form of custom annotations that are applied to objects as they are created, and then picked up by the Operator. This is supported in v4 of the fiaas.yml specification, with custom annotations propagated directly from the configuration to the objects.
 
 When an extension needs configuration that can't be applied as annotations on existing objects, we need a place to put that configuration. Configuration of an extension happens in a `extensions` section in the fiaas.yml file of a project (which is exposed in the cluster as a TPR). Each extension needs to register using a unique name, which would typically be the name of the FiaasExtension object. The extension would then find its configuration under `extensions.<name>` in the configuration. When linting, anything under `extensions` are ignored by the platform itself, except that we will issue warnings (or even errors?) if there is configuration for a non-existing extension.
 
@@ -125,4 +125,3 @@ This could be implemented as a custom ingress annotation that is parsed by the i
 ### Case 6: Monitoring Directives (SLA SLO SLI)
 
 This is a case for an extension that might be promoted to the root configuration, depending on where the company is moving. It could be implemented as a combination pre-create hook and operator, with a linting hook as an optional extra. The pre-create hook would read the configuration and modify the object in some way that allows the operator to set up extra monitoring. It might also be possible to do without the pre-create hook, because when the operator finds an object it needs to act on it can look up the configuration itself, from the TPR that belongs to the application.
-

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -43,7 +43,7 @@ Contains all the transforms from AppSpec internal representation to Kubernetes r
 Implements a synchronous signaling mechanism which is used to trigger actions between different parts of the application as parts of the process of deploying an application. This is mainly used to keep ApplicationStatus updated when a deployment completes, and to trigger usage reporting.
 
 - `fiaas_deploy_daemon/specs`
-Transforms of fiaas.yml to the internal AppSpec representation. Supports multiple versions by transforming older versions (v2) to the latest version (v3).
+Transforms of fiaas.yml to the internal AppSpec representation. Supports multiple versions by transforming older versions (v2/v3) to the latest version (v4).
 
 - `fiaas_deploy_daemon/usage_reporting`
 Trigger calls to a HTTP endpoint for different parts of the deployment lifecycle (start, success, failure).

--- a/docs/operator_guide.md
+++ b/docs/operator_guide.md
@@ -38,7 +38,7 @@ In order for FIAAS to function in a cluster, some basics needs to be in place
 
 In addition, some conventions might be useful to know about:
 
-* In fiaas.yml v3, the default paths for probes and metrics starts with `/_/`. As a cluster operator, it might be useful to configure your cluster to disallow public access to any path that starts with this prefix.
+* In fiaas.yml v3 and later, the default paths for probes and metrics starts with `/_/`. As a cluster operator, it might be useful to configure your cluster to disallow public access to any path that starts with this prefix.
 
 How to set configuration options
 --------------------------------
@@ -467,7 +467,7 @@ releaseChannelMetadata:
 # https://github.com/fiaas/releases/blob/master/fiaas-deploy-daemon/stable.json. Change it to suit your requirements
 # if necessary.
 releaseChannelMetadataSpecContentAsYAML: |-
-  version: 3
+  version: 4
   admin_access: true
   replicas:
     maximum: 1

--- a/docs/platform_contract.md
+++ b/docs/platform_contract.md
@@ -29,11 +29,12 @@ We are currently testing Kubernetes version 1.25.11 and above. FIAAS may work on
 
 | **FIAAS field** | **kubernetes entity** |
 |-----------------|-----------------------|
-| [replicas](/docs/v3_spec.md#replicas) | [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) if `max > min` |
-| [ingress](/docs/v3_spec.md#ingress) | [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) |
-| [healthchecks](/docs/v3_spec.md#healthchecks) | [pod live-/ready-ness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/) |
-| [resources](/docs/v3_spec.md#resources) | [pod resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) |
-| [metrics](/docs/v3_spec.md#metrics) | Resolves to annotations [example configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml) |
+| [replicas](/docs/v4_spec.md#replicas) | [HorizontalPodAutoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) if `max > min` |
+| [ingress](/docs/v4_spec.md#ingress) | [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) |
+| [healthchecks](/docs/v4_spec.md#healthchecks) | [pod live-/ready-ness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/) |
+| [resources](/docs/v4_spec.md#resources) | [pod resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) |
+| [metrics](/docs/v4_spec.md#metrics) | Resolves to annotations [example configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml) |
+| [statefulset](/docs/v4_spec.md#statefulset) | [StatefulSet with volumeClaimTemplates](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) |
 
 ## What applications can expect
 
@@ -75,7 +76,7 @@ Currently those are exposed both under the name given by the operator, but also 
 
 ## What FIAAS expects from the application
 
-In order to deploy an application, FIAAS needs three pieces of information: The name of the application, a container image, and a [FIAAS configuration](v3_spec.md).
+In order to deploy an application, FIAAS needs three pieces of information: The name of the application, a container image, and a [FIAAS configuration](v4_spec.md).
 
 Once deployed, the application is expected to send logs to stdout (as indicated by the `LOG_STDOUT` environment variable). It is expected to have a liveness check and a readiness check as defined in the configuration.
 

--- a/docs/v4_spec.md
+++ b/docs/v4_spec.md
@@ -1,0 +1,899 @@
+<!--
+Copyright 2017-2019 The FIAAS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# V4 Spec file reference
+
+This file represents how your application will be deployed into Kubernetes.
+
+
+## version
+
+| **Type** | **Required** |
+|----------|--------------|
+| int      | yes          |
+
+Which version of this spec to be used. This field must be set to `4` to use the features described below.
+Documentation for [version 3 can be found here](/docs/v3_spec.md) and [version 2 here](/docs/v2_spec.md).
+
+```yaml
+version: 4
+```
+
+
+## replicas
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Number of pods (instances) to run of the application. Based on the values of `minimum` and `maximum`, this object also
+controls whether the number of replicas should be automatically scaled based on load.
+
+If `minimum` and `maximum` are set to the same value, autoscaling will be disabled. 
+
+If `minimum` is higher than `maximum`, `minimum` will be set to `maximum` and autoscaling will be disabled as well.
+
+
+Default value:
+```yaml
+replicas:
+  minimum: 2
+  maximum: 5
+  cpu_threshold_percentage: 50
+  singleton: true
+```
+
+### minimum
+
+| **Type** | **Required** |
+|----------|--------------|
+| int      | no           |
+
+Minimum number of pods to run for the application.
+
+Default value:
+```yaml
+replicas:
+  minimum: 2
+```
+
+
+### maximum
+
+| **Type** | **Required** |
+|----------|--------------|
+| int      | no           |
+
+Maximum number of pods to run for the application.
+
+Default value:
+```yaml
+replicas:
+  maximum: 5
+```
+
+### cpu_threshold_percentage
+
+| **Type** | **Required** |
+|----------|--------------|
+| int      | no           |
+
+If `maximum` is greater than `minimum`, autoscaling is enabled for the application.
+
+Currently, the only supported metric for autoscaling is average cpu usage. If average cpu usage across all pods is
+greater than this value over some time period, the number of pods will be increased. If average cpu usage across all
+pods is less than this value, the number of pods will be decreased after some time period.
+
+Autoscaling is done by using a
+[`HorizontalPodAutoscaler`](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
+
+If autoscaling is disabled, this value is ignored.
+
+Default value:
+```yaml
+replicas:
+  cpu_threshold_percentage: 50
+```
+
+### singleton
+
+| **Type** | **Required** |
+|----------|--------------|
+| bool     | no           |
+
+Whether there should be a maximum of a single running replica at any one time. Only operational if maximum replicas is
+one. Set to false to have multiple replicas running during deployment, avoiding downtime.
+
+This flag is only relevant for single replica applications. If your app normally has more than one replica, the flag is
+ignored.
+
+For single replica apps, the `singleton` flag indicates if it is important for the application to never run more than
+one replica at a time. If `singleton` is `true` (the default), then the running replica will be shut down before a new
+replica is started. This leads to downtime during deploy, but allows for applications that require exclusive access
+to some resource.
+
+If you have an application that runs in a single replica, but can run in multiple replicas for short periods of time,
+changing this flag to `false` will allow deployments to start a new replica before the old one is shut down, allowing
+for zero downtime deployments.
+
+Default value:
+```yaml
+replicas:
+  singleton: true
+```
+
+## ingress
+
+| **Type** | **Required** |
+|----------|--------------|
+| list     | no           |
+
+This object configures path-based/layer 7 routing of requests to the application.
+It is a list of hosts which can each have a list of path and port combinations. Requests to the combination of host and
+path will be routed to the port specified on the path element. Setting annotations on an entry means a separate Ingress
+will be created, and will have metadata.annotations set accordingly.
+
+Default value:
+```yaml
+ingress:
+  - host: # no default value
+    paths:
+    - path: /
+      port: http
+    annotations: {}
+```
+
+All applications will get a set of default hosts, if the cluster operator has defined ingress suffixes.
+If you do not specify a host in your `ingress` configuration, these default hosts will be used.
+For example :
+1. `your-app.example1.com`
+2. `your-app.example2.com`
+
+When you expose a path on a host you get that one as well. For example :
+```yaml
+ingress:
+  - host: example.com
+    paths:
+    - path: /my-path
+```
+
+If you want to customize paths for default hosts as well, you can do it as :
+```yaml
+ingress:
+  - host: example.com
+    paths:
+    - path: /my-path
+  - paths:
+    - path: /some-other-path
+
+```
+
+This will make `/some-other-path` available on default hosts, but not on the host you provided in ingress.
+Remember, default hosts will also contain the paths from the ingress.
+
+### host
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The hostname part of a host + path combination where your application expects requests.
+
+If fiaas-deploy-daemon in the namespace you are deploying to is set up with one or more default ingress suffixes, all
+paths specified will be made available under these ingress suffixes.  E.g. if `foo.example.com` is the default ingress
+suffix, and your application is named `myapp`, your application will be available on `myapp.foo.example.com/`
+
+If the `host` field is set, the application will be available on `host` + any paths specified *in addition* to any
+default ingress suffixes.
+
+Example:
+```yaml
+ingress:
+  - host: your-app.example.com
+```
+
+If the operator of your cluster has configured host-rewrite rules they will be applied to the hostname given in this
+field. See [the operator guide](operator_guide.md#host-rewrite-rules) for details about how this feature works.
+
+In typical clusters, this value should be the host used by your application in production, and host-rewrite rules should
+be used to adapt the host to testing environments.
+
+### paths
+
+| **Type** | **Required** |
+|----------|--------------|
+| list     | no           |
+
+List of paths and port combinations.
+
+Example:
+```yaml
+ingress:
+  - host: your-app.example.com
+    paths:
+      - path: /foo
+      - path: /bar
+      - path: /metrics
+        port: metrics-port
+```
+
+In this example, requests to `your-app.example.com/foo` or `your-app.example.com/bar` will go to the port named
+`http`. Unless overridden, this is the default service port 80 which points to target port 8080 in the pod running
+your application. Requests to `your-app.example.com/metrics` will go to the port named metrics-port, which also has to
+be defined under the `ports` configuration structure. It is also possible to use a port number, but named ports are
+strongly recommended.
+
+### annotations
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+A map of annotations to add to the ingress.
+
+Each entry in the ingress list that contains a non-empty `annotations` value will cause a separate Ingress object to
+be created during the deployment. All items that have an empty value will have their hosts/paths merged into a single
+Ingress.
+
+Example:
+```yaml
+ingress:
+  - host: your-app.example.com
+    paths:
+      - path: /foo
+  - host: other.example.com
+    paths:
+      - path: /foo
+    annotations:
+      some/annotation: bar
+```
+
+In this example, the first ingress will be created for `your-app.example.com` (along with any default suffixes, if present) and
+a second will be created for `other.example.com` and this will be annotated with the provided values.
+
+Annotations defined within the `ingress.annotations` config will take precedence over any defined in the top-level `annotations`
+configuration.
+
+Example:
+```yaml
+ingress:
+  - host: app.example.com
+  - host: other.example.com
+    annotations:
+      some/annotation: foo
+
+annotations:
+  ingress:
+    some/annotation: bar
+```
+
+In this example, the ingress for `app.example.com` will have the annotation set with the value `bar`, while the ingress for
+`other.example.com` will have it set to `foo`.
+
+## healthchecks
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Application endpoints to be used by Kubernetes to determine [whether your application is up and/or ready to handle requests](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/).
+If `healthchecks.liveness` is specified and `healthchecks.readiness` is not specified, `healthchecks.liveness` will be used as the value for `healthchecks.readiness`.
+
+### liveness
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+
+Default value:
+```yaml
+healthchecks:
+  liveness:
+    execute:
+      command: # No default value
+    http:
+      path: /_/health
+      port: http
+      http_headers: {}
+    tcp:
+      port: # no default value
+    initial_delay_seconds: 10
+    period_seconds: 10
+    success_threshold: 1 # For liveness, 1 is the only valid value. For readiness, it can be higher
+    failure_threshold: 3
+    timeout_seconds: 1
+```
+
+You can only have one check, so specify only one of `execute`, `http`, or `tcp`. The default is a `http` check, which
+will send a HTTP request to the path and port configuration on the pod running the application. The health check will
+be considered good if the HTTP response has a status code in the 200 range. Otherwise it will be considered bad.
+
+An `execute` check can be used to execute a program inside the pod running the application. In this case, a exit
+status of 0 is considered a good health check, while any other exit status is considered bad.
+
+Example:
+```yaml
+healthchecks:
+  liveness:
+    execute:
+      command: /app/bin/check --foo
+```
+
+A `tcp` check can be used if the application's primary endpoint uses some other application layer protocol than
+HTTP. This type of check attempts to negotiate a TCP handshake on the specified port. If this succeeds, the health
+check is considered good, otherwise it is considered bad.
+
+Example:
+```yaml
+healthchecks:
+  liveness:
+    tcp:
+      port: 70
+```
+
+### readiness
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+`liveness` and `readiness` use the same structure for configuring the check itself. See the documentation for `liveness`.
+
+
+## resources
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+[Resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) required by the
+application.
+
+Default value:
+```yaml
+resources:
+  limits:
+    cpu: 400m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+```
+
+### limits
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Maximum amount of resources this application needs.
+
+#### memory
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The application will be OOM killed if exceeding these limits.
+
+#### cpu
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The application will have its CPU usage throttled if exceeding this limit.
+
+### requests
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Minimum amount of resources this application needs.
+
+#### memory
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The application will be scheduled on nodes with at least this amount of memory available.
+
+#### cpu
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The application will be scheduled on nodes with at least this amount of CPU available.
+
+Example:
+```yaml
+resources:
+  limits:
+    memory: 1G
+    cpu: 1
+  requests:
+    memory:  512M
+    cpu: 0.7
+```
+
+
+## metrics
+
+### prometheus
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Tells Prometheus where to find application metrics.
+
+Default value:
+```yaml
+metrics:
+  prometheus:
+    enabled: true
+    port: http
+    path: /_/metrics
+```
+
+#### enabled
+| **Type** | **Required** |
+|----------|--------------|
+| boolean  | no           |
+
+Whether or not the pods running the application will be scraped by Prometheus looking for metrics.
+
+#### port
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+Name of HTTP port Prometheus metrics are served on.
+
+#### path
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+HTTP endpoint where metrics are exposed.
+
+### datadog
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Configure datadog.
+
+Default value:
+```yaml
+metrics:
+  datadog:
+    enabled: false
+    tags: {}
+```
+
+#### enabled
+| **Type** | **Required** |
+|----------|--------------|
+| boolean  | no           |
+
+Attach a datadog sidecar for metrics collection. The sidecar will run DogStatsD, and your application should send metrics
+to `${STATSD_HOST}:${STATSD_PORT}` (in the current incarnation, this is set to `localhost:8125`, but your application
+should make use of the environment variables in order to be somewhat futureproof). In order for this to send metrics to the
+correct datadog account, a secret must be created in the namespace which contains the datadog API key. This key decides
+where the metrics end up.
+
+Creating the datadog secret can be done using `kubectl` directly:
+
+```
+kubectl -n "${NAMESPACE}" create secret generic datadog --from-literal apikey="${DD_API_KEY}"
+```
+
+Three additional tags are attached to the collected metrics automatically:
+
+- namespace name
+- application name
+- pod name
+
+#### tags
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Include the given tags for metrics exposed by the Datadog sidecar.
+These metrics will be added to the three metrics injected by default
+(namespace name, app name, pod name.)
+
+For example:
+
+```yaml
+metrics:
+  datadog:
+    enabled: true
+    tags:
+      tag1: value1
+      tag2: value2
+```
+
+Will add the following to the `DD_TAGS` environment variable in the
+Datadog sidecar:
+
+    tag1:value1,tag2:value2
+
+## ports
+
+| **Type** | **Required** |
+|----------|--------------|
+| list     | no           |
+
+List of ports the application listens for requests.
+
+Default value:
+```yaml
+ports:
+  - protocol: http
+    name: http
+    port: 80
+    target_port: 8080
+```
+
+### protocol
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no          |
+
+Protocol used by the application. It must be `http` or `tcp`.
+
+### name
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+A logical name for port discovery. Must be <= 63 characters and match `[a-z0-9]([-a-z0-9]*[a-z0-9])?`.
+
+### port
+| **Type** | **Required** |
+|----------|--------------|
+| int      | no          |
+
+Port number that will be exposed. For protocol equals TCP the available port range is (1024-32767) (may vary depending
+on the configuration of the underlying Kubernetes cluster).
+
+### target_port
+| **Type** | **Required** |
+|----------|--------------|
+| int      | no          |
+
+The port number which is exposed by the container and should receive traffic routed to `port`.
+
+
+## annotations
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+This configuration structure can be used to set custom annotations on the Kubernetes resources which are
+created or updated when deploying the application.
+
+Default value:
+```yaml
+annotations:
+  deployment: {}
+  horizontal_pod_autoscaler: {}
+  ingress: {}
+  service: {}
+  service_account: {}
+  pod: {}
+  pod_disruption_budget: {}
+  role_binding: {}
+```
+
+The annotations are organized under the Kubernetes resource they will be applied to. To specify custom anotations, set
+key-value pairs under the respective Kubernetes resource name. I.e. to set the label `foo=bar` on the Service
+object, you can do the following:
+
+```yaml
+annotations:
+  service:
+    foo: bar
+```
+
+Annotations are fundamentally different from labels in that labels are primarily used to organize and select
+resources, whereas annotations are more suitable for applying generic metadata to resources. This metadata can in turn
+be read and used by other systems running in the cluster. Refer to the
+[Kubernetes documentation on annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) for
+more information.
+
+
+## labels
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Default value:
+```yaml
+labels:
+  deployment: {}
+  horizontal_pod_autoscaler: {}
+  ingress: {}
+  service: {}
+  service_account: {}
+  pod: {}
+  pod_disruption_budget: {}
+  role_binding: {}
+```
+
+The labels are organized under the Kubernetes resource they will be applied to. To specify custom labels, set
+key-value pairs under the respective Kubernetes resource name. I.e. to set the label `layer=frontend` on the Service
+object, you can do the following:
+
+```yaml
+labels:
+  service:
+    layer: frontend
+```
+
+Labels have strict syntax requirements for both the key and value part. Refer to the [Kubernetes documentation on
+labels and selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) for details.
+
+
+## secrets_in_environment
+
+| **Type** | **Required** |
+|----------|--------------|
+| boolean  | no           |
+
+Any Kubernetes secret matching the application name will automatically be mounted under `/var/run/secrets/fiaas/`. If
+this setting is enabled, any key-value pairs from the same secret will also be available as environment variables in
+the application's environment.
+
+Default value:
+```yaml
+secrets_in_environment: false
+```
+
+
+## admin_access
+
+| **Type** | **Required** |
+|----------|--------------|
+| boolean  | no           |
+
+Controls whether or not Kubernetes apiserver tokens from the `default` `ServiceAccount` in the namespace the application
+is deployed to will be mounted inside the pods. This is only neccessary if the application requires access to the
+Kubernetes apiserver. If in doubt, leave this disabled.
+
+```yaml
+admin_access: False
+```
+
+
+## statefulset
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Controls whether FIAAS renders a Kubernetes `StatefulSet` instead of a `Deployment`. When `enabled` is `true` the
+application gains stable pod identities and persistent storage described in `volume_claims`. At least one
+`volume_claims` entry is required when stateful workloads are enabled.
+
+Default value:
+```yaml
+statefulset:
+  enabled: false
+  service_name:
+  pod_management_policy: OrderedReady
+  update_strategy:
+    type: RollingUpdate
+    rolling_update_partition:
+  volume_claims: []
+```
+
+### enabled
+
+| **Type** | **Required** |
+|----------|--------------|
+| boolean  | no           |
+
+When `true`, FIAAS deploys the workload as a `StatefulSet`.
+
+### service_name
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+Name of the headless service backing the `StatefulSet`. If omitted the application name is used. FIAAS ensures the
+generated service is headless by setting `clusterIP: None`.
+
+### pod_management_policy
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+Value propagated to `.spec.podManagementPolicy`. Valid options are `OrderedReady` (default) and `Parallel`.
+
+### update_strategy
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Controls how the `StatefulSet` rolls out updates. Supported fields:
+
+* `type`: Either `RollingUpdate` (default) or `OnDelete`.
+* `rolling_update_partition`: Optional integer used together with the `RollingUpdate` strategy.
+
+### volume_claims
+
+| **Type** | **Required** |
+|----------|--------------|
+| list     | yes, when `enabled` |
+
+List of persistent volume claim templates attached to each pod. Every entry must define `name`, `mount_path`, and
+`resources.requests.storage`.
+
+Each claim supports the following keys:
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | string | yes | Name of the claim template and `volumeMount`. |
+| `mount_path` | string | yes | Path where the claim is mounted inside the container. |
+| `storage_class_name` | string | no | Storage class to use. Defaults to the cluster default. |
+| `access_modes` | list | no | Defaults to `['ReadWriteOnce']`. |
+| `annotations` | object | no | Extra annotations added to the PVC metadata. |
+| `resources` | object | yes | Resource configuration; `requests.storage` must be set. |
+
+Example:
+```yaml
+statefulset:
+  enabled: true
+  volume_claims:
+    - name: data
+      mount_path: /var/lib/myapp
+      access_modes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi
+```
+
+
+## extensions
+
+### secrets
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Configuration for pulling secrets from arbitrary sources before application startup. The keys of this
+object should be the 'type' of secret init-container that has been registered in the cluster
+(using `--secret-init-containers`).
+The init-container can be configured using 'parameters', which will be available inside the container as
+Environment Variables; and/or 'annotations', which will be added to the annotations present in the pod.
+
+If no value is provided here, and a 'default' init-container is registered in the cluster it will be used
+for the application.
+
+The init-container should make secrets available as files under `/var/run/secrets/fiaas`. Any additional structure
+or convention will depend on the init-container being used.
+
+Example (Note: the specific structure of this will depend on the configuration of FIAAS in your cluster/namespace):
+```yaml
+extensions:
+  secrets:
+    parameter-store:
+      parameters:
+        AWS_REGION: eu-west-1
+        SECRET_ID: somesecret
+      annotations:
+        iam.amazonaws.com/role: arn:aws:iam::12345678:role/the-role-name
+```
+
+### strongbox
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+Configuration from pulling secrets from [Strongbox](https://schibsted.github.io/strongbox/) before application
+startup. Secrets will be made available as files under `/var/run/secrets/fiaas`, each secret in each secret group
+being stored under `/var/run/secrets/fiaas/$group_name/$secret_name`.
+
+Default values:
+```yaml
+extensions:
+  strongbox: # This is only enabled if fiaas-deploy-daemon runs with --strongbox-init-container-image set
+    iam_role: # AWS IAM role assumed before pulling secrets from Strongbox
+    aws_region: eu-west-1 # AWS region to get Strongbox secrets from
+    groups: [] # Strongbox secret groups. Will get all secrets present in each group
+```
+
+#### iam_role
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam) for the AWS IAM
+role which should be assumed before pulling secrets from Strongbox. This role will need read access to the secrets you
+want to get.
+
+Required to get secrets from Strongbox.
+
+#### aws_region
+
+| **Type** | **Required** |
+|----------|--------------|
+| string   | no           |
+
+The AWS region to pull Strongbox secrets from. Defaults to `eu-west-1`.
+
+#### groups
+
+| **Type** | **Required** |
+|----------|--------------|
+| list     | no           |
+
+List of Strongbox Secret Groups to pull secrets from. All secrets from each group will be pulled.
+
+Required to get secrets from Strongbox.
+
+
+Example:
+```yaml
+extensions:
+  strongbox:
+    iam_role: arn:aws:iam::12345678:role/the-role-name
+    aws_region: eu-west-1
+    groups:
+    - group-name-1
+    - group-name-2
+```
+
+### tls
+
+#### enabled
+
+| **Type** | **Required** |
+|----------|--------------|
+| object   | no           |
+
+If enabled, ingress objects will be extended to include annotations necessary for use with
+[cert-manager](https://github.com/jetstack/cert-manager)s [ingress-shim](https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html)
+to make use of automatic provisioning and management of TLS certificates.
+
+If certificate_issuer is set, generated ingress objects will be extended to include annotations specifying which certificate issuer to use with
+cert-manager.
+
+Example:
+```yaml
+extensions:
+  tls:
+    enabled: true
+    certificate_issuer: letsencrypt
+```
+
+Note generally fiaas operators will have already configured a default certificate issuer if applicable so the option to specify that explicitly
+is strictly here for allowing for overwriting of the default value and if omitted will use the configured default value.

--- a/docs/v4_whats_new.md
+++ b/docs/v4_whats_new.md
@@ -1,0 +1,50 @@
+<!--
+Copyright 2017-2024 The FIAAS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# What's new in FIAAS configuration format version 4
+
+Version 4 of the FIAAS application specification extends the workload options with first class support for
+stateful applications.
+
+## Stateful workloads
+
+The new top-level `statefulset` block lets you request a Kubernetes `StatefulSet` instead of the default
+`Deployment`. When `statefulset.enabled` is `true`, FIAAS will:
+
+* replace the generated `Deployment` with a `StatefulSet`
+* render a headless service and reuse it as the `StatefulSet`'s `serviceName`
+* create PVC templates from the items listed in `statefulset.volume_claims`
+* mount the claims into the main application container alongside the existing config and `/tmp` volumes
+* skip the HorizontalPodAutoscaler because the Kubernetes autoscaler does not support `StatefulSet`
+
+The minimal configuration looks like this:
+
+```yaml
+statefulset:
+  enabled: true
+  volume_claims:
+    - name: data
+      mount_path: /var/lib/app
+      resources:
+        requests:
+          storage: 10Gi
+```
+
+All other fields in the block are optional and default to behaviour compatible with Kubernetes defaults.
+
+## Version selection
+
+Remember to set `version: 4` at the top of your `fiaas.yml` to opt in to these features. Applications still targeting
+older configuration versions will continue to be transformed and deployed as before.

--- a/fiaas.yml
+++ b/fiaas.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-version: 3
+version: 4
 admin_access: true
 replicas:
   maximum: 1
@@ -30,3 +30,13 @@ healthchecks:
 metrics:
   prometheus:
     path: /internal-backstage/prometheus
+
+# Uncomment to deploy as a StatefulSet with a persistent volume
+#statefulset:
+#  enabled: true
+#  volume_claims:
+#    - name: data
+#      mount_path: /var/lib/app
+#      resources:
+#        requests:
+#          storage: 5Gi

--- a/fiaas_deploy_daemon/deployer/kubernetes/adapter.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/adapter.py
@@ -25,6 +25,7 @@ from ...specs.models import AppSpec, ResourcesSpec, ResourceRequirementSpec
 from .autoscaler import AutoscalerDeployer
 from .deployment import DeploymentDeployer
 from .ingress import IngressDeployer
+from .statefulset import StatefulSetDeployer
 from .service import ServiceDeployer
 from .service_account import ServiceAccountDeployer
 from .pod_disruption_budget import PodDisruptionBudgetDeployer
@@ -37,14 +38,22 @@ class K8s(object):
     """Adapt from an AppSpec to the necessary definitions for a kubernetes cluster"""
 
     def __init__(
-        self, config, service_deployer, deployment_deployer, ingress_deployer,
-        autoscaler, service_account_deployer, pod_disruption_budget_deployer,
-        role_binding_deployer
+        self,
+        config,
+        service_deployer,
+        deployment_deployer,
+        statefulset_deployer,
+        ingress_deployer,
+        autoscaler,
+        service_account_deployer,
+        pod_disruption_budget_deployer,
+        role_binding_deployer,
     ):
         self._version = config.version
         self._enable_service_account_per_app = config.enable_service_account_per_app
         self._service_deployer: ServiceDeployer = service_deployer
         self._deployment_deployer: DeploymentDeployer = deployment_deployer
+        self._statefulset_deployer: StatefulSetDeployer = statefulset_deployer
         self._ingress_deployer: IngressDeployer = ingress_deployer
         self._autoscaler_deployer: AutoscalerDeployer = autoscaler
         self._service_account_deployer: ServiceAccountDeployer = service_account_deployer
@@ -52,7 +61,8 @@ class K8s(object):
         self._role_binding_deployer: RoleBindingDeployer = role_binding_deployer
 
     def deploy(self, app_spec: AppSpec):
-        if _besteffort_qos_is_required(app_spec):
+        besteffort_required = _besteffort_qos_is_required(app_spec)
+        if besteffort_required:
             app_spec = _remove_resource_requirements(app_spec)
         selector = _make_selector(app_spec)
         labels = self._make_labels(app_spec)
@@ -61,7 +71,10 @@ class K8s(object):
             self._role_binding_deployer.deploy(app_spec, labels)
         self._service_deployer.deploy(app_spec, selector, labels)
         self._ingress_deployer.deploy(app_spec, labels)
-        self._deployment_deployer.deploy(app_spec, selector, labels, _besteffort_qos_is_required(app_spec))
+        if app_spec.statefulset.enabled:
+            self._statefulset_deployer.deploy(app_spec, selector, labels, besteffort_required)
+        else:
+            self._deployment_deployer.deploy(app_spec, selector, labels, besteffort_required)
         self._autoscaler_deployer.deploy(app_spec, labels)
         self._pod_disruption_budget_deployer.deploy(app_spec, selector, labels)
 

--- a/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/autoscaler.py
@@ -68,6 +68,8 @@ class AutoscalerDeployer(object):
 
 
 def should_have_autoscaler(app_spec):
+    if getattr(app_spec.statefulset, "enabled", False):
+        return False
     if not _autoscaler_enabled(app_spec.autoscaler):
         return False
     if not _enough_replicas_wanted(app_spec):

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/__init__.py
@@ -22,6 +22,7 @@ from .datadog import DataDog
 from .deployer import DeploymentDeployer
 from .prometheus import Prometheus
 from .secrets import Secrets, KubernetesSecrets, GenericInitSecrets
+from ..statefulset import StatefulSetDeployer
 
 
 class DeploymentBindings(pinject.BindingSpec):
@@ -32,3 +33,4 @@ class DeploymentBindings(pinject.BindingSpec):
         bind("generic_init_secrets", to_class=GenericInitSecrets)
         bind("deployment_secrets", to_class=Secrets)
         bind("deployment_deployer", to_class=DeploymentDeployer)
+        bind("statefulset_deployer", to_class=StatefulSetDeployer)

--- a/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/deployment/deployer.py
@@ -96,6 +96,13 @@ class DeploymentDeployer(object):
 
     @retry_on_upsert_conflict(max_value_seconds=5, max_tries=5)
     def deploy(self, app_spec, selector, labels, besteffort_qos_is_required):
+        if getattr(app_spec.statefulset, "enabled", False):
+            LOG.info("StatefulSet requested for %s; deleting existing deployment if present", app_spec.name)
+            try:
+                Deployment.delete(app_spec.name, app_spec.namespace)
+            except NotFound:
+                pass
+            return
         LOG.info("Creating new deployment for %s", app_spec.name)
         deployment_labels = merge_dicts(app_spec.labels.deployment, labels)
         metadata = ObjectMeta(

--- a/fiaas_deploy_daemon/deployer/kubernetes/service.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/service.py
@@ -63,7 +63,15 @@ class ServiceDeployer(object):
         metadata = ObjectMeta(
             name=service_name, namespace=app_spec.namespace, labels=custom_labels, annotations=custom_annotations
         )
-        spec = ServiceSpec(selector=selector, ports=ports, type=self._service_type)
+        service_type = "ClusterIP" if app_spec.statefulset.enabled else self._service_type
+        spec_args = {
+            "selector": selector,
+            "ports": ports,
+            "type": service_type,
+        }
+        if app_spec.statefulset.enabled:
+            spec_args["clusterIP"] = "None"
+        spec = ServiceSpec(**spec_args)
         svc = Service.get_or_create(metadata=metadata, spec=spec)
         self._owner_references.apply(svc, app_spec)
         self._extension_hook.apply(svc, app_spec)

--- a/fiaas_deploy_daemon/deployer/kubernetes/statefulset/__init__.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/statefulset/__init__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2024 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .deployer import StatefulSetDeployer  # NOQA

--- a/fiaas_deploy_daemon/deployer/kubernetes/statefulset/deployer.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/statefulset/deployer.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2024 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from fiaas_deploy_daemon.config import Configuration
+from fiaas_deploy_daemon.retry import retry_on_upsert_conflict
+from fiaas_deploy_daemon.tools import merge_dicts
+
+from k8s.client import NotFound
+from k8s.models.common import ObjectMeta
+from k8s.models.deployment import Deployment, LabelSelector
+
+from k8s.models.pod import (
+    ConfigMapEnvSource,
+    ConfigMapVolumeSource,
+    Container,
+    ContainerPort,
+    EmptyDirVolumeSource,
+    EnvFromSource,
+    EnvVar,
+    EnvVarSource,
+    ExecAction,
+    Handler,
+    Lifecycle,
+    ObjectFieldSelector,
+    PodDNSConfig,
+    PodSpec,
+    PodTemplateSpec,
+    ResourceFieldSelector,
+    ResourceRequirements,
+    Volume,
+    VolumeMount,
+)
+
+from fiaas_deploy_daemon.deployer.kubernetes.deployment.datadog import DataDog
+from fiaas_deploy_daemon.deployer.kubernetes.deployment.prometheus import Prometheus
+from fiaas_deploy_daemon.deployer.kubernetes.deployment.secrets import Secrets
+from fiaas_deploy_daemon.deployer.kubernetes.owner_references import OwnerReferences
+from fiaas_deploy_daemon.extension_hook_caller import ExtensionHookCaller
+from fiaas_deploy_daemon.deployer.kubernetes.deployment.deployer import (
+    _build_fiaas_env,
+    _build_global_env,
+    _add_status_label,
+    _make_probe,
+    _make_resource_requirements,
+)
+from .k8s_models import (
+    PersistentVolumeClaim,
+    PersistentVolumeClaimSpec,
+    StatefulSet,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategy,
+    RollingUpdateStatefulSetStrategy,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+class StatefulSetDeployer(object):
+    MINIMUM_GRACE_PERIOD = 30
+    DATADOG_PRE_STOP_DELAY = 5
+
+    def __init__(
+        self,
+        config: Configuration,
+        datadog,
+        prometheus,
+        deployment_secrets,
+        owner_references,
+        extension_hook,
+    ):
+        self._datadog: DataDog = datadog
+        self._prometheus: Prometheus = prometheus
+        self._secrets: Secrets = deployment_secrets
+        self._owner_references: OwnerReferences = owner_references
+        self._extension_hook: ExtensionHookCaller = extension_hook
+        self._pre_stop_delay = config.pre_stop_delay
+        self._legacy_fiaas_env = _build_fiaas_env(config)
+        self._global_env = _build_global_env(config.global_env)
+        self._lifecycle: Lifecycle | None = None
+        self._grace_period = self.MINIMUM_GRACE_PERIOD
+        self._use_in_memory_emptydirs = config.use_in_memory_emptydirs
+        if self._pre_stop_delay > 0:
+            self._lifecycle = Lifecycle(preStop=Handler(_exec=ExecAction(command=["sleep", str(self._pre_stop_delay)])))
+            self._grace_period += self._pre_stop_delay
+        self._disable_deprecated_managed_env_vars = config.disable_deprecated_managed_env_vars
+        self._enable_service_links = False if config.enable_service_links is False else None
+        self._dns_search_domains = config.dns_search_domains
+        self._enable_service_account_per_app = config.enable_service_account_per_app
+
+    @retry_on_upsert_conflict(max_value_seconds=5, max_tries=5)
+    def deploy(self, app_spec, selector, labels, besteffort_qos_is_required):
+        if not app_spec.statefulset.enabled:
+            self._delete(app_spec)
+            return
+
+        LOG.info("Creating new statefulset for %s", app_spec.name)
+
+        try:
+            Deployment.delete(app_spec.name, app_spec.namespace)
+        except NotFound:
+            pass
+
+        metadata = ObjectMeta(
+            name=app_spec.name,
+            namespace=app_spec.namespace,
+            labels=merge_dicts(app_spec.labels.deployment, labels),
+            annotations=app_spec.annotations.deployment,
+        )
+
+        container_ports = [
+            ContainerPort(name=port_spec.name, containerPort=port_spec.target_port) for port_spec in app_spec.ports
+        ]
+        env = self._make_env(app_spec)
+        pull_policy = "IfNotPresent" if (":" in app_spec.image and ":latest" not in app_spec.image) else "Always"
+        env_from = [EnvFromSource(configMapRef=ConfigMapEnvSource(name=app_spec.name, optional=True))]
+        containers = [
+            Container(
+                name=app_spec.name,
+                image=app_spec.image,
+                ports=container_ports,
+                env=env,
+                envFrom=env_from,
+                lifecycle=self._lifecycle,
+                livenessProbe=_make_probe(app_spec.health_checks.liveness),
+                readinessProbe=_make_probe(app_spec.health_checks.readiness),
+                imagePullPolicy=pull_policy,
+                volumeMounts=self._make_volume_mounts(app_spec),
+                resources=_make_resource_requirements(app_spec.resources),
+            )
+        ]
+
+        dns_config = None
+        if self._dns_search_domains:
+            dns_config = PodDNSConfig(searches=self._dns_search_domains)
+
+        service_account_name = app_spec.name if self._enable_service_account_per_app else "default"
+
+        pod_spec = PodSpec(
+            containers=containers,
+            initContainers=[],
+            volumes=self._make_volumes(app_spec),
+            serviceAccountName=service_account_name,
+            automountServiceAccountToken=app_spec.admin_access,
+            terminationGracePeriodSeconds=self._grace_period,
+            enableServiceLinks=self._enable_service_links,
+            dnsConfig=dns_config,
+        )
+
+        pod_metadata = ObjectMeta(
+            name=app_spec.name,
+            namespace=app_spec.namespace,
+            labels=merge_dicts(app_spec.labels.pod, _add_status_label(labels)),
+            annotations=app_spec.annotations.pod,
+        )
+        pod_template_spec = PodTemplateSpec(metadata=pod_metadata, spec=pod_spec)
+
+        spec = StatefulSetSpec(
+            serviceName=app_spec.statefulset.service_name or app_spec.name,
+            replicas=app_spec.autoscaler.min_replicas,
+            selector=LabelSelector(matchLabels=selector),
+            template=pod_template_spec,
+            updateStrategy=self._make_update_strategy(app_spec.statefulset.update_strategy),
+            podManagementPolicy=app_spec.statefulset.pod_management_policy,
+            volumeClaimTemplates=self._make_volume_claim_templates(app_spec),
+        )
+
+        statefulset = StatefulSet.get_or_create(metadata=metadata, spec=spec)
+        self._datadog.apply(
+            statefulset,
+            app_spec,
+            besteffort_qos_is_required,
+            self._pre_stop_delay + self.DATADOG_PRE_STOP_DELAY,
+        )
+        self._prometheus.apply(statefulset, app_spec)
+        self._secrets.apply(statefulset, app_spec)
+        self._owner_references.apply(statefulset, app_spec)
+        self._extension_hook.apply(statefulset, app_spec)
+        statefulset.save()
+
+    def _delete(self, app_spec):
+        try:
+            StatefulSet.delete(app_spec.name, app_spec.namespace)
+        except NotFound:
+            pass
+
+    def _make_volumes(self, app_spec):
+        volumes = [
+            Volume(
+                name="{}-config".format(app_spec.name),
+                configMap=ConfigMapVolumeSource(name=app_spec.name, optional=True),
+            )
+        ]
+        empty_dir_volume_source = EmptyDirVolumeSource(medium="Memory") if self._use_in_memory_emptydirs else EmptyDirVolumeSource()
+        volumes.append(Volume(name="tmp", emptyDir=empty_dir_volume_source))
+        return volumes
+
+    def _make_volume_mounts(self, app_spec):
+        mounts = [
+            VolumeMount(name="{}-config".format(app_spec.name), readOnly=True, mountPath="/var/run/config/fiaas/"),
+            VolumeMount(name="tmp", readOnly=False, mountPath="/tmp"),
+        ]
+        for claim in app_spec.statefulset.volume_claims:
+            mounts.append(VolumeMount(name=claim.name, readOnly=False, mountPath=claim.mount_path))
+        return mounts
+
+    def _make_volume_claim_templates(self, app_spec):
+        templates = []
+        for claim in app_spec.statefulset.volume_claims:
+            metadata = ObjectMeta(name=claim.name, annotations=claim.annotations)
+            limits = claim.resources.limits or None
+            resources = ResourceRequirements(requests=claim.resources.requests, limits=limits)
+            pvc_spec = PersistentVolumeClaimSpec(
+                accessModes=claim.access_modes,
+                resources=resources,
+                storageClassName=claim.storage_class_name,
+            )
+            templates.append(PersistentVolumeClaim(metadata=metadata, spec=pvc_spec))
+        return templates
+
+    @staticmethod
+    def _make_update_strategy(strategy_spec):
+        rolling_update = None
+        if strategy_spec.type == "RollingUpdate" and strategy_spec.rolling_update_partition is not None:
+            rolling_update = RollingUpdateStatefulSetStrategy(partition=strategy_spec.rolling_update_partition)
+        return StatefulSetUpdateStrategy(type=strategy_spec.type, rollingUpdate=rolling_update)
+
+    def _make_env(self, app_spec):
+        fiaas_managed_env = {
+            "FIAAS_ARTIFACT_NAME": app_spec.name,
+            "FIAAS_IMAGE": app_spec.image,
+            "FIAAS_VERSION": app_spec.version,
+        }
+        if not self._disable_deprecated_managed_env_vars:
+            fiaas_managed_env.update(
+                {
+                    "ARTIFACT_NAME": app_spec.name,
+                    "IMAGE": app_spec.image,
+                    "VERSION": app_spec.version,
+                }
+            )
+
+        static_env = merge_dicts(self._legacy_fiaas_env, self._global_env, fiaas_managed_env)
+        env = [EnvVar(name=name, value=value) for name, value in list(static_env.items())]
+        env.extend(
+            [
+                EnvVar(
+                    name="FIAAS_REQUESTS_CPU",
+                    valueFrom=EnvVarSource(resourceFieldRef=ResourceFieldSelector(resource="requests.cpu")),
+                ),
+                EnvVar(
+                    name="FIAAS_REQUESTS_MEMORY",
+                    valueFrom=EnvVarSource(resourceFieldRef=ResourceFieldSelector(resource="requests.memory")),
+                ),
+                EnvVar(
+                    name="FIAAS_LIMITS_CPU",
+                    valueFrom=EnvVarSource(resourceFieldRef=ResourceFieldSelector(resource="limits.cpu")),
+                ),
+                EnvVar(
+                    name="FIAAS_LIMITS_MEMORY",
+                    valueFrom=EnvVarSource(resourceFieldRef=ResourceFieldSelector(resource="limits.memory")),
+                ),
+                EnvVar(
+                    name="FIAAS_NAMESPACE",
+                    valueFrom=EnvVarSource(fieldRef=ObjectFieldSelector(fieldPath="metadata.namespace")),
+                ),
+                EnvVar(
+                    name="FIAAS_POD_NAME",
+                    valueFrom=EnvVarSource(fieldRef=ObjectFieldSelector(fieldPath="metadata.name")),
+                ),
+            ]
+        )
+        env.sort(key=lambda item: item.name)
+        return env

--- a/fiaas_deploy_daemon/deployer/kubernetes/statefulset/k8s_models.py
+++ b/fiaas_deploy_daemon/deployer/kubernetes/statefulset/k8s_models.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2024 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from k8s.base import Model
+from k8s.fields import Field, ListField
+from k8s.models.common import ObjectMeta, LabelSelector
+from k8s.models.deployment import PodTemplateSpec
+from k8s.models.pod import ResourceRequirements
+
+
+class RollingUpdateStatefulSetStrategy(Model):
+    partition = Field(int)
+
+
+class StatefulSetUpdateStrategy(Model):
+    type = Field(str, "RollingUpdate")
+    rollingUpdate = Field(RollingUpdateStatefulSetStrategy)
+
+
+class PersistentVolumeClaimSpec(Model):
+    accessModes = ListField(str)
+    resources = Field(ResourceRequirements)
+    storageClassName = Field(str)
+
+
+class PersistentVolumeClaim(Model):
+    metadata = Field(ObjectMeta)
+    spec = Field(PersistentVolumeClaimSpec)
+
+
+class StatefulSetSpec(Model):
+    serviceName = Field(str)
+    replicas = Field(int, 1)
+    selector = Field(LabelSelector)
+    template = Field(PodTemplateSpec)
+    updateStrategy = Field(StatefulSetUpdateStrategy)
+    podManagementPolicy = Field(str, "OrderedReady")
+    volumeClaimTemplates = ListField(PersistentVolumeClaim)
+
+
+class StatefulSet(Model):
+    class Meta:
+        list_url = "/apis/apps/v1/statefulsets"
+        url_template = "/apis/apps/v1/namespaces/{namespace}/statefulsets/{name}"
+
+    metadata = Field(ObjectMeta)
+    spec = Field(StatefulSetSpec)
+

--- a/fiaas_deploy_daemon/specs/__init__.py
+++ b/fiaas_deploy_daemon/specs/__init__.py
@@ -31,7 +31,7 @@ class SpecBindings(pinject.BindingSpec):
         bind("default_app_spec", to_class=DefaultAppSpec)
 
     def provide_factory(self):
-        from .v3 import Factory
+        from .v4 import Factory
 
         return Factory()
 

--- a/fiaas_deploy_daemon/specs/default.py
+++ b/fiaas_deploy_daemon/specs/default.py
@@ -5,7 +5,7 @@ LOG = logging.getLogger(__name__)
 
 class DefaultAppSpec(object):
     DEFAULT_APP_CONFIG = {
-        "version": 3,
+        "version": 4,
     }
 
     def __init__(self, spec_factory):

--- a/fiaas_deploy_daemon/specs/models.py
+++ b/fiaas_deploy_daemon/specs/models.py
@@ -43,6 +43,7 @@ class AppSpec(
             "singleton",
             "ingress_tls",
             "secrets",
+            "statefulset",
             "app_config",
         ],
     )
@@ -141,5 +142,32 @@ IngressTLSSpec = namedtuple(
     [
         "enabled",
         "certificate_issuer",
+    ],
+)
+
+StatefulSetUpdateStrategySpec = namedtuple("StatefulSetUpdateStrategySpec", ["type", "rolling_update_partition"])
+
+StatefulSetVolumeClaimResourcesSpec = namedtuple("StatefulSetVolumeClaimResourcesSpec", ["requests", "limits"])
+
+StatefulSetVolumeClaimSpec = namedtuple(
+    "StatefulSetVolumeClaimSpec",
+    [
+        "name",
+        "mount_path",
+        "storage_class_name",
+        "access_modes",
+        "annotations",
+        "resources",
+    ],
+)
+
+StatefulSetSpec = namedtuple(
+    "StatefulSetSpec",
+    [
+        "enabled",
+        "service_name",
+        "pod_management_policy",
+        "update_strategy",
+        "volume_claims",
     ],
 )

--- a/fiaas_deploy_daemon/specs/v2/transformer.py
+++ b/fiaas_deploy_daemon/specs/v2/transformer.py
@@ -37,6 +37,11 @@ This is unexpected behavior, so by setting the undefined fields to this value, t
 should leave the fields unset and not apply the defaults.
 """
 
+def _normalize_resource_value(value):
+    if value is RESOURCE_UNDEFINED_UGLYHACK or type(value) is object:
+        return None
+    return value
+
 
 class Transformer(BaseTransformer):
     COPY_MAPPING = {

--- a/fiaas_deploy_daemon/specs/v3/factory.py
+++ b/fiaas_deploy_daemon/specs/v3/factory.py
@@ -44,7 +44,7 @@ from ..models import (
     StatefulSetSpec,
     StatefulSetUpdateStrategySpec,
 )
-from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK
+from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK, _normalize_resource_value
 from ...tools import merge_dicts
 
 
@@ -129,8 +129,8 @@ class Factory(BaseFactory):
 
     @staticmethod
     def _resource_requirements_spec(resource_lookup):
-        cpu = None if resource_lookup["cpu"] == RESOURCE_UNDEFINED_UGLYHACK else resource_lookup["cpu"]
-        memory = None if resource_lookup["memory"] == RESOURCE_UNDEFINED_UGLYHACK else resource_lookup["memory"]
+        cpu = _normalize_resource_value(resource_lookup["cpu"])
+        memory = _normalize_resource_value(resource_lookup["memory"])
         return ResourceRequirementSpec(cpu=cpu, memory=memory)
 
     @staticmethod

--- a/fiaas_deploy_daemon/specs/v3/transformer.py
+++ b/fiaas_deploy_daemon/specs/v3/transformer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
 
-# Copyright 2017-2019 The FIAAS Authors
+# Copyright 2017-2024 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,5 +16,13 @@
 # limitations under the License.
 
 
-from .factory import Factory  # NOQA
-from .transformer import Transformer  # NOQA
+import copy
+
+from ..factory import BaseTransformer
+
+
+class Transformer(BaseTransformer):
+    def __call__(self, app_config, strip_defaults=False):
+        new_config = copy.deepcopy(app_config)
+        new_config["version"] = 4
+        return new_config

--- a/fiaas_deploy_daemon/specs/v4/__init__.py
+++ b/fiaas_deploy_daemon/specs/v4/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
 
-# Copyright 2017-2019 The FIAAS Authors
+# Copyright 2017-2024 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,3 @@
 
 
 from .factory import Factory  # NOQA
-from .transformer import Transformer  # NOQA

--- a/fiaas_deploy_daemon/specs/v4/defaults.yml
+++ b/fiaas_deploy_daemon/specs/v4/defaults.yml
@@ -1,0 +1,113 @@
+
+# Copyright 2017-2024 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+version: 4
+replicas:
+  minimum: 2
+  maximum: 5
+  cpu_threshold_percentage: 50
+  singleton: true
+ingress:
+  - host:
+    paths:
+    - path: /
+      port: http
+    annotations: {}
+healthchecks:
+  liveness:
+    execute:
+      command:
+    http:
+      path: /_/health
+      port: http
+      http_headers: {}
+    tcp:
+      port:
+    initial_delay_seconds: 10
+    period_seconds: 10
+    success_threshold: 1
+    failure_threshold: 3
+    timeout_seconds: 1
+  readiness:
+    execute:
+      command:
+    http:
+      path: /_/ready
+      port: http
+      http_headers: {}
+    tcp:
+      port:
+    initial_delay_seconds: 10
+    period_seconds: 10
+    success_threshold: 1
+    failure_threshold: 3
+    timeout_seconds: 1
+resources:
+  limits:
+    cpu: 400m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+metrics:
+  prometheus:
+    enabled: true
+    port: http
+    path: /_/metrics
+  datadog:
+    enabled: false
+    tags: {}
+ports:
+  - protocol: http
+    name: http
+    port: 80
+    target_port: 8080
+annotations:
+  deployment: {}
+  horizontal_pod_autoscaler: {}
+  service_account: {}
+  ingress: {}
+  service: {}
+  pod: {}
+  pod_disruption_budget: {}
+  role_binding: {}
+labels:
+  deployment: {}
+  horizontal_pod_autoscaler: {}
+  service_account: {}
+  ingress: {}
+  service: {}
+  pod: {}
+  pod_disruption_budget: {}
+  role_binding: {}
+secrets_in_environment: false
+admin_access: false
+statefulset:
+  enabled: false
+  service_name:
+  pod_management_policy: OrderedReady
+  update_strategy:
+    type: RollingUpdate
+    rolling_update_partition:
+  volume_claims: []
+extensions:
+  strongbox:
+    iam_role:
+    aws_region: eu-west-1
+    groups: []
+  tls:
+    enabled: false
+    certificate_issuer:
+  secrets: {}

--- a/fiaas_deploy_daemon/specs/v4/factory.py
+++ b/fiaas_deploy_daemon/specs/v4/factory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8
 
-# Copyright 2017-2019 The FIAAS Authors
+# Copyright 2017-2024 The FIAAS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,16 +43,18 @@ from ..models import (
     SecretsSpec,
     StatefulSetSpec,
     StatefulSetUpdateStrategySpec,
+    StatefulSetVolumeClaimSpec,
+    StatefulSetVolumeClaimResourcesSpec,
 )
 from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK
 from ...tools import merge_dicts
 
 
 class Factory(BaseFactory):
-    version = 3
+    version = 4
 
     def __init__(self, config=None):
-        self._defaults = yaml.safe_load(pkgutil.get_data("fiaas_deploy_daemon.specs.v3", "defaults.yml"))
+        self._defaults = yaml.safe_load(pkgutil.get_data("fiaas_deploy_daemon.specs.v4", "defaults.yml"))
         # Overwrite default value based on config flag for ingress_tls
         self._defaults["extensions"]["tls"]["enabled"] = config and config.use_ingress_tls == "default_on"
 
@@ -102,7 +104,7 @@ class Factory(BaseFactory):
                 certificate_issuer=lookup["extensions"]["tls"]["certificate_issuer"],
             ),
             secrets=self._secrets_specs(lookup["extensions"]["secrets"]),
-            statefulset=self._statefulset_spec(),
+            statefulset=self._statefulset_spec(lookup["statefulset"]),
             app_config=app_config,
         )
         return app_spec
@@ -139,15 +141,77 @@ class Factory(BaseFactory):
             enabled=prometheus_lookup["enabled"], port=prometheus_lookup["port"], path=prometheus_lookup["path"]
         )
 
-    @staticmethod
-    def _statefulset_spec():
-        return StatefulSetSpec(
-            enabled=False,
-            service_name=None,
-            pod_management_policy="OrderedReady",
-            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
-            volume_claims=[],
+    def _statefulset_spec(self, statefulset_lookup):
+        enabled = statefulset_lookup["enabled"]
+        service_name = self._optional_string(statefulset_lookup.get_config_value("service_name"))
+        pod_management_policy = statefulset_lookup["pod_management_policy"]
+        update_strategy_lookup = statefulset_lookup["update_strategy"]
+        update_strategy = StatefulSetUpdateStrategySpec(
+            type=update_strategy_lookup["type"],
+            rolling_update_partition=update_strategy_lookup["rolling_update_partition"],
         )
+        volume_claims = self._statefulset_volume_claims(statefulset_lookup["volume_claims"])
+        if enabled and not volume_claims:
+            raise InvalidConfiguration("statefulset.enabled requires at least one volume_claim")
+        return StatefulSetSpec(
+            enabled=enabled,
+            service_name=service_name,
+            pod_management_policy=pod_management_policy,
+            update_strategy=update_strategy,
+            volume_claims=volume_claims,
+        )
+
+    def _statefulset_volume_claims(self, volume_claims_lookup):
+        claims = []
+        for idx in range(len(volume_claims_lookup)):
+            claim_lookup = volume_claims_lookup[idx]
+            claims.append(self._volume_claim_spec(claim_lookup))
+        return claims
+
+    def _volume_claim_spec(self, claim_lookup):
+        if not isinstance(claim_lookup, dict):
+            claim_lookup = claim_lookup.raw()
+        name = claim_lookup.get("name")
+        mount_path = claim_lookup.get("mount_path")
+        if not name:
+            raise InvalidConfiguration("statefulset.volume_claims entries must define name")
+        if not mount_path:
+            raise InvalidConfiguration("statefulset.volume_claims {} must define mount_path".format(name))
+
+        resources_lookup = claim_lookup.get("resources") or {}
+        resources = self._statefulset_volume_resources(name, resources_lookup)
+
+        storage_class_name = self._optional_string(claim_lookup.get("storage_class_name"))
+        access_modes = claim_lookup.get("access_modes") or ["ReadWriteOnce"]
+        annotations = claim_lookup.get("annotations") or {}
+        return StatefulSetVolumeClaimSpec(
+            name=name,
+            mount_path=mount_path,
+            storage_class_name=storage_class_name,
+            access_modes=list(access_modes),
+            annotations=dict(annotations),
+            resources=resources,
+        )
+
+    @staticmethod
+    def _statefulset_volume_resources(name, resources_lookup):
+        requests = dict(resources_lookup.get("requests") or {})
+        if "storage" not in requests or not requests["storage"]:
+            raise InvalidConfiguration(
+                "statefulset.volume_claims {} must define resources.requests.storage".format(name)
+            )
+        limits = resources_lookup.get("limits")
+        limits = dict(limits) if limits else None
+        return StatefulSetVolumeClaimResourcesSpec(requests=requests, limits=limits)
+
+    @staticmethod
+    def _optional_string(value):
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return value
+        value = value.strip()
+        return value if value else None
 
     @staticmethod
     def _datadog_spec(datadog_lookup):

--- a/fiaas_deploy_daemon/specs/v4/factory.py
+++ b/fiaas_deploy_daemon/specs/v4/factory.py
@@ -46,7 +46,7 @@ from ..models import (
     StatefulSetVolumeClaimSpec,
     StatefulSetVolumeClaimResourcesSpec,
 )
-from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK
+from ..v2.transformer import RESOURCE_UNDEFINED_UGLYHACK, _normalize_resource_value
 from ...tools import merge_dicts
 
 
@@ -131,8 +131,8 @@ class Factory(BaseFactory):
 
     @staticmethod
     def _resource_requirements_spec(resource_lookup):
-        cpu = None if resource_lookup["cpu"] == RESOURCE_UNDEFINED_UGLYHACK else resource_lookup["cpu"]
-        memory = None if resource_lookup["memory"] == RESOURCE_UNDEFINED_UGLYHACK else resource_lookup["memory"]
+        cpu = _normalize_resource_value(resource_lookup["cpu"])
+        memory = _normalize_resource_value(resource_lookup["memory"])
         return ResourceRequirementSpec(cpu=cpu, memory=memory)
 
     @staticmethod

--- a/fiaas_deploy_daemon/web/__init__.py
+++ b/fiaas_deploy_daemon/web/__init__.py
@@ -73,7 +73,7 @@ def metrics():
 @web.route("/defaults")
 @defaults_histogram.time()
 def defaults():
-    return _render_defaults("fiaas_deploy_daemon.specs.v3", "defaults.yml")
+    return _render_defaults(_latest_defaults_module(), "defaults.yml")
 
 
 @web.route("/defaults/<int:version>")
@@ -125,6 +125,25 @@ def _render_defaults(*args):
         return resp
     else:
         abort(404)
+
+
+def _latest_defaults_module():
+    import importlib
+
+    from fiaas_deploy_daemon import specs
+
+    latest = None
+    for module_info in pkgutil.iter_modules(specs.__path__):
+        if module_info.ispkg and module_info.name.startswith("v"):
+            version = int(module_info.name[1:])
+            if latest is None or version > latest[0]:
+                latest = (version, module_info.name)
+
+    if latest is None:
+        raise RuntimeError("No spec versions available")
+
+    importlib.import_module(f"{specs.__name__}.{latest[1]}")
+    return f"{specs.__name__}.{latest[1]}"
 
 
 class WebBindings(pinject.BindingSpec):

--- a/tests/fiaas_deploy_daemon/conftest.py
+++ b/tests/fiaas_deploy_daemon/conftest.py
@@ -37,6 +37,8 @@ from fiaas_deploy_daemon.specs.models import (
     IngressPathMappingSpec,
     StrongboxSpec,
     IngressTLSSpec,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
 )
 
 PROMETHEUS_SPEC = PrometheusSpec(enabled=True, port="http", path="/internal-backstage/prometheus")
@@ -100,6 +102,13 @@ def app_spec():
         singleton=False,
         ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
         secrets=[],
+        statefulset=StatefulSetSpec(
+            enabled=False,
+            service_name=None,
+            pod_management_policy="OrderedReady",
+            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+            volume_claims=[],
+        ),
         app_config={},
     )
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/statefulset/test_deployer.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/statefulset/test_deployer.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+
+# Copyright 2017-2024 The FIAAS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+from fiaas_deploy_daemon.config import Configuration
+from fiaas_deploy_daemon.deployer.kubernetes.statefulset.deployer import StatefulSetDeployer
+from fiaas_deploy_daemon.specs.models import (
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
+    StatefulSetVolumeClaimResourcesSpec,
+    StatefulSetVolumeClaimSpec,
+)
+
+
+@pytest.fixture
+def config():
+    cfg = mock.create_autospec(Configuration([]), spec_set=True)
+    cfg.pre_stop_delay = 0
+    cfg.global_env = {}
+    cfg.use_in_memory_emptydirs = False
+    cfg.disable_deprecated_managed_env_vars = False
+    cfg.enable_service_links = None
+    cfg.dns_search_domains = []
+    cfg.enable_service_account_per_app = False
+    cfg.infrastructure = None
+    cfg.log_format = "json"
+    cfg.environment = None
+    return cfg
+
+
+def _stateful_app_spec(app_spec):
+    claim = StatefulSetVolumeClaimSpec(
+        name="data",
+        mount_path="/data",
+        storage_class_name=None,
+        access_modes=["ReadWriteOnce"],
+        annotations={},
+        resources=StatefulSetVolumeClaimResourcesSpec(requests={"storage": "1Gi"}, limits=None),
+    )
+    statefulset_spec = StatefulSetSpec(
+        enabled=True,
+        service_name=None,
+        pod_management_policy="OrderedReady",
+        update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+        volume_claims=[claim],
+    )
+    return app_spec._replace(statefulset=statefulset_spec)
+
+
+@mock.patch("fiaas_deploy_daemon.deployer.kubernetes.statefulset.deployer.StatefulSet")
+@mock.patch("fiaas_deploy_daemon.deployer.kubernetes.statefulset.deployer.Deployment")
+def test_creates_statefulset_and_deletes_deployment(mock_deployment, mock_statefulset, config, app_spec):
+    app_spec = _stateful_app_spec(app_spec)
+    mock_statefulset.get_or_create.return_value = mock.Mock(save=mock.Mock())
+
+    deployer = StatefulSetDeployer(
+        config,
+        datadog=mock.Mock(),
+        prometheus=mock.Mock(),
+        deployment_secrets=mock.Mock(),
+        owner_references=mock.Mock(),
+        extension_hook=mock.Mock(),
+    )
+
+    deployer.deploy(app_spec, selector={"app": app_spec.name}, labels={"app": app_spec.name}, besteffort_qos_is_required=False)
+
+    mock_deployment.delete.assert_called_with(app_spec.name, app_spec.namespace)
+    mock_statefulset.get_or_create.assert_called_once()
+    mock_statefulset.get_or_create.return_value.save.assert_called_once()
+
+
+@mock.patch("fiaas_deploy_daemon.deployer.kubernetes.statefulset.deployer.StatefulSet")
+def test_delete_called_when_statefulset_disabled(mock_statefulset, config, app_spec):
+    deployer = StatefulSetDeployer(
+        config,
+        datadog=mock.Mock(),
+        prometheus=mock.Mock(),
+        deployment_secrets=mock.Mock(),
+        owner_references=mock.Mock(),
+        extension_hook=mock.Mock(),
+    )
+
+    deployer.deploy(app_spec, selector={"app": app_spec.name}, labels={}, besteffort_qos_is_required=False)
+
+    mock_statefulset.delete.assert_called_with(app_spec.name, app_spec.namespace)
+    mock_statefulset.get_or_create.assert_not_called()

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_adapter.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_adapter.py
@@ -21,11 +21,19 @@ from fiaas_deploy_daemon.deployer.kubernetes.adapter import K8s, _make_selector
 from fiaas_deploy_daemon.deployer.kubernetes.autoscaler import AutoscalerDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.deployment import DeploymentDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.ingress import IngressDeployer
+from fiaas_deploy_daemon.deployer.kubernetes.statefulset import StatefulSetDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.service import ServiceDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.service_account import ServiceAccountDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.pod_disruption_budget import PodDisruptionBudgetDeployer
 from fiaas_deploy_daemon.deployer.kubernetes.role_binding import RoleBindingDeployer
-from fiaas_deploy_daemon.specs.models import ResourcesSpec, ResourceRequirementSpec
+from fiaas_deploy_daemon.specs.models import (
+    ResourcesSpec,
+    ResourceRequirementSpec,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
+    StatefulSetVolumeClaimResourcesSpec,
+    StatefulSetVolumeClaimSpec,
+)
 
 FIAAS_VERSION = "1"
 TEAMS = "foo"
@@ -44,6 +52,10 @@ class TestK8s(object):
     @pytest.fixture(autouse=True)
     def deployment_deployer(self):
         return mock.create_autospec(DeploymentDeployer)
+
+    @pytest.fixture(autouse=True)
+    def statefulset_deployer(self):
+        return mock.create_autospec(StatefulSetDeployer)
 
     @pytest.fixture(autouse=True)
     def ingress_deployer(self):
@@ -69,16 +81,24 @@ class TestK8s(object):
 
     @pytest.fixture
     def k8s(
-        self, service_deployer, deployment_deployer, ingress_deployer,
-        autoscaler_deployer, service_account_deployer,
-        pod_disruption_budget_deployer, role_binding_deployer
+        self,
+        service_deployer,
+        deployment_deployer,
+        statefulset_deployer,
+        ingress_deployer,
+        autoscaler_deployer,
+        service_account_deployer,
+        pod_disruption_budget_deployer,
+        role_binding_deployer,
     ):
         config = mock.create_autospec(Configuration([]), spec_set=True)
         config.version = FIAAS_VERSION
+        config.enable_service_account_per_app = False
         return K8s(
             config,
             service_deployer,
             deployment_deployer,
+            statefulset_deployer,
             ingress_deployer,
             autoscaler_deployer,
             service_account_deployer,
@@ -138,6 +158,7 @@ class TestK8s(object):
         app_spec,
         k8s,
         deployment_deployer,
+        statefulset_deployer,
         resource_quota_list,
         resource_quota_specs,
         expect_strip_resources,
@@ -172,6 +193,7 @@ class TestK8s(object):
         pytest.helpers.assert_any_call(
             deployment_deployer.deploy, expected_app_spec, selector, labels, expect_strip_resources
         )
+        statefulset_deployer.deploy.assert_not_called()
 
     def test_pass_to_ingress(self, app_spec, k8s, ingress_deployer, resource_quota_list):
         labels = k8s._make_labels(app_spec)
@@ -179,6 +201,39 @@ class TestK8s(object):
         k8s.deploy(app_spec)
 
         pytest.helpers.assert_any_call(ingress_deployer.deploy, app_spec, labels)
+
+    def test_pass_to_statefulset(
+        self,
+        app_spec,
+        k8s,
+        deployment_deployer,
+        statefulset_deployer,
+        resource_quota_list,
+    ):
+        claim = StatefulSetVolumeClaimSpec(
+            name="data",
+            mount_path="/data",
+            storage_class_name=None,
+            access_modes=["ReadWriteOnce"],
+            annotations={},
+            resources=StatefulSetVolumeClaimResourcesSpec(requests={"storage": "1Gi"}, limits=None),
+        )
+        statefulset_spec = StatefulSetSpec(
+            enabled=True,
+            service_name=None,
+            pod_management_policy="OrderedReady",
+            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+            volume_claims=[claim],
+        )
+        app_spec = app_spec._replace(statefulset=statefulset_spec)
+
+        selector = _make_selector(app_spec)
+        labels = k8s._make_labels(app_spec)
+
+        k8s.deploy(app_spec)
+
+        deployment_deployer.deploy.assert_not_called()
+        pytest.helpers.assert_any_call(statefulset_deployer.deploy, app_spec, selector, labels, False)
 
     def test_pass_to_service(self, app_spec, k8s, service_deployer, resource_quota_list):
         selector = _make_selector(app_spec)
@@ -204,6 +259,7 @@ class TestK8s(object):
         service_deployer,
         resource_quota_list,
         deployment_deployer,
+        statefulset_deployer,
         ingress_deployer,
         autoscaler_deployer,
         service_account_deployer,
@@ -219,6 +275,7 @@ class TestK8s(object):
             config,
             service_deployer,
             deployment_deployer,
+            statefulset_deployer,
             ingress_deployer,
             autoscaler_deployer,
             service_account_deployer,
@@ -243,6 +300,7 @@ class TestK8s(object):
         service_deployer,
         resource_quota_list,
         deployment_deployer,
+        statefulset_deployer,
         ingress_deployer,
         autoscaler_deployer,
         service_account_deployer,
@@ -258,6 +316,7 @@ class TestK8s(object):
             config,
             service_deployer,
             deployment_deployer,
+            statefulset_deployer,
             ingress_deployer,
             autoscaler_deployer,
             service_account_deployer,

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_deployment_deploy.py
@@ -37,6 +37,10 @@ from fiaas_deploy_daemon.specs.models import (
     ExecCheckSpec,
     HealthCheckSpec,
     LabelAndAnnotationSpec,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
+    StatefulSetVolumeClaimResourcesSpec,
+    StatefulSetVolumeClaimSpec,
 )
 from fiaas_deploy_daemon.tools import merge_dicts
 
@@ -329,6 +333,42 @@ class TestDeploymentDeployer(object):
         secrets.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
         owner_references.apply.assert_called_with(TypeMatcher(Deployment), app_spec)
         extension_hook.apply.assert_called_once_with(TypeMatcher(Deployment), app_spec)
+
+    @mock.patch("fiaas_deploy_daemon.deployer.kubernetes.deployment.deployer.Deployment")
+    def test_deployment_deleted_when_statefulset_enabled(
+        self,
+        mock_deployment,
+        config,
+        app_spec,
+        datadog,
+        prometheus,
+        secrets,
+        owner_references,
+        extension_hook,
+    ):
+        statefulset_spec = StatefulSetSpec(
+            enabled=True,
+            service_name=None,
+            pod_management_policy="OrderedReady",
+            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+            volume_claims=[
+                StatefulSetVolumeClaimSpec(
+                    name="data",
+                    mount_path="/data",
+                    storage_class_name=None,
+                    access_modes=["ReadWriteOnce"],
+                    annotations={},
+                    resources=StatefulSetVolumeClaimResourcesSpec(requests={"storage": "1Gi"}, limits=None),
+                )
+            ],
+        )
+        app_spec = app_spec._replace(statefulset=statefulset_spec)
+
+        deployer = DeploymentDeployer(config, datadog, prometheus, secrets, owner_references, extension_hook)
+        deployer.deploy(app_spec, SELECTOR, LABELS, False)
+
+        mock_deployment.delete.assert_called_with(app_spec.name, app_spec.namespace)
+        mock_deployment.get_or_create.assert_not_called()
 
     @pytest.mark.parametrize(
         "enable_service_links, expected_result",

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_ingress_deploy.py
@@ -41,9 +41,11 @@ from fiaas_deploy_daemon.specs.models import (
     AutoscalerSpec,
     LabelAndAnnotationSpec,
     IngressItemSpec,
-    IngressPathMappingSpec,
+   IngressPathMappingSpec,
     StrongboxSpec,
     IngressTLSSpec,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
 )
 
 from utils import TypeMatcher
@@ -109,6 +111,13 @@ def app_spec(**kwargs):
         singleton=False,
         ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
         secrets=[],
+        statefulset=StatefulSetSpec(
+            enabled=False,
+            service_name=None,
+            pod_management_policy="OrderedReady",
+            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+            volume_claims=[],
+        ),
         app_config={},
     )
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_networking_v1_ingress.py
@@ -42,6 +42,8 @@ from fiaas_deploy_daemon.specs.models import (
     IngressPathMappingSpec,
     StrongboxSpec,
     IngressTLSSpec,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
 )
 
 from utils import TypeMatcher
@@ -107,6 +109,13 @@ def app_spec(**kwargs):
         singleton=False,
         ingress_tls=IngressTLSSpec(enabled=False, certificate_issuer=None),
         secrets=[],
+        statefulset=StatefulSetSpec(
+            enabled=False,
+            service_name=None,
+            pod_management_policy="OrderedReady",
+            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+            volume_claims=[],
+        ),
         app_config={},
     )
 

--- a/tests/fiaas_deploy_daemon/deployer/kubernetes/test_service_deploy.py
+++ b/tests/fiaas_deploy_daemon/deployer/kubernetes/test_service_deploy.py
@@ -23,7 +23,13 @@ from k8s.models.service import Service
 from fiaas_deploy_daemon import ExtensionHookCaller
 from fiaas_deploy_daemon.config import Configuration
 from fiaas_deploy_daemon.deployer.kubernetes.service import ServiceDeployer
-from fiaas_deploy_daemon.specs.models import LabelAndAnnotationSpec
+from fiaas_deploy_daemon.specs.models import (
+    LabelAndAnnotationSpec,
+    StatefulSetSpec,
+    StatefulSetUpdateStrategySpec,
+    StatefulSetVolumeClaimResourcesSpec,
+    StatefulSetVolumeClaimSpec,
+)
 
 from utils import TypeMatcher
 
@@ -167,6 +173,44 @@ class TestServiceDeployer(object):
         post.return_value = mock_response
 
         deployer.deploy(app_spec_multiple_thrift_ports, SELECTOR, LABELS)
+
+        pytest.helpers.assert_any_call(post, SERVICES_URI, expected_service)
+
+    @pytest.mark.usefixtures("get")
+    def test_headless_service_for_statefulset(self, deployer, post, app_spec):
+        claim = StatefulSetVolumeClaimSpec(
+            name="data",
+            mount_path="/data",
+            storage_class_name=None,
+            access_modes=["ReadWriteOnce"],
+            annotations={},
+            resources=StatefulSetVolumeClaimResourcesSpec(requests={"storage": "1Gi"}, limits=None),
+        )
+        statefulset_spec = StatefulSetSpec(
+            enabled=True,
+            service_name=None,
+            pod_management_policy="OrderedReady",
+            update_strategy=StatefulSetUpdateStrategySpec(type="RollingUpdate", rolling_update_partition=None),
+            volume_claims=[claim],
+        )
+        app_spec = app_spec._replace(statefulset=statefulset_spec)
+
+        expected_service = {
+            "spec": {
+                "selector": SELECTOR,
+                "type": "ClusterIP",
+                "loadBalancerSourceRanges": [],
+                "ports": [{"protocol": "TCP", "targetPort": 8080, "name": "http", "port": 80}],
+                "sessionAffinity": "None",
+                "clusterIP": "None",
+            },
+            "metadata": pytest.helpers.create_metadata("testapp", labels=LABELS),
+        }
+        mock_response = create_autospec(Response)
+        mock_response.json.return_value = expected_service
+        post.return_value = mock_response
+
+        deployer.deploy(app_spec, SELECTOR, LABELS)
 
         pytest.helpers.assert_any_call(post, SERVICES_URI, expected_service)
 

--- a/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
+++ b/tests/fiaas_deploy_daemon/specs/test_spec_factory.py
@@ -39,12 +39,16 @@ class TestSpecFactory(object):
         return create_autospec(BaseTransformer, spec_set=True, return_value={"version": 3})
 
     @pytest.fixture
-    def v3(self, app_spec):
-        return create_autospec(BaseFactory, spec_set=True, version=3, return_value=app_spec)
+    def v3(self):
+        return create_autospec(BaseTransformer, spec_set=True, return_value={"version": 4})
 
     @pytest.fixture
-    def transformers(self, v1, v2):
-        return {1: v1, 2: v2}
+    def v4(self, app_spec):
+        return create_autospec(BaseFactory, spec_set=True, version=4, return_value=app_spec)
+
+    @pytest.fixture
+    def transformers(self, v1, v2, v3):
+        return {1: v1, 2: v2, 3: v3}
 
     @pytest.fixture
     def config(self):
@@ -53,8 +57,8 @@ class TestSpecFactory(object):
         return config
 
     @pytest.fixture
-    def factory(self, v3, transformers, config):
-        return SpecFactory(v3, transformers, config)
+    def factory(self, v4, transformers, config):
+        return SpecFactory(v4, transformers, config)
 
     @pytest.mark.parametrize(
         "version,mock_to_call",
@@ -62,6 +66,7 @@ class TestSpecFactory(object):
             (None, "v1"),
             (1, "v1"),
             (2, "v2"),
+            (3, "v3"),
         ],
     )
     def test_dispatch_to_correct_transformer(self, request, factory, version, mock_to_call):
@@ -72,31 +77,31 @@ class TestSpecFactory(object):
         mock_factory = request.getfixturevalue(mock_to_call)
         mock_factory.assert_called_with(minimal_config, strip_defaults=False)
 
-    @pytest.mark.parametrize("version", [1, 2, 3])
-    def test_parsed_by_current_version(self, factory, version, v3):
+    @pytest.mark.parametrize("version", [1, 2, 3, 4])
+    def test_parsed_by_current_version(self, factory, version, v4):
         factory(UID, NAME, IMAGE, {"version": version}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
-        v3.assert_called_with(UID, NAME, IMAGE, TEAMS, TAGS, ANY, DEPLOYMENT_ID, NAMESPACE, None, None)
+        v4.assert_called_with(UID, NAME, IMAGE, TEAMS, TAGS, ANY, DEPLOYMENT_ID, NAMESPACE, None, None)
 
     def test_raise_invalid_config_if_version_not_supported(self, factory):
         with pytest.raises(InvalidConfiguration):
             factory(UID, NAME, IMAGE, {"version": 999}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
 
-    def test_raise_invalid_config_if_datadog_undefined_and_requested(self, factory, v3, app_spec):
+    def test_raise_invalid_config_if_datadog_undefined_and_requested(self, factory, v4, app_spec):
         datadog_spec = app_spec.datadog._replace(enabled=True, tags={})
-        v3.return_value = app_spec._replace(datadog=datadog_spec)
+        v4.return_value = app_spec._replace(datadog=datadog_spec)
         with pytest.raises(InvalidConfiguration):
-            factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+            factory(UID, NAME, IMAGE, {"version": 4}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
 
-    def test_accept_config_if_datadog_defined_and_requested(self, factory, v3, app_spec, config):
+    def test_accept_config_if_datadog_defined_and_requested(self, factory, v4, app_spec, config):
         config.datadog_container_image = "datadog"
         datadog_spec = app_spec.datadog._replace(enabled=True, tags={})
         expected = app_spec._replace(datadog=datadog_spec)
-        v3.return_value = expected
-        actual = factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+        v4.return_value = expected
+        actual = factory(UID, NAME, IMAGE, {"version": 4}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
         assert actual == expected
 
     @pytest.mark.parametrize("exception", (AttributeError, KeyError, IndexError, ValueError, TypeError, NameError))
-    def test_parse_errors_raises_invalid_config(self, factory, v3, exception):
-        v3.side_effect = exception
+    def test_parse_errors_raises_invalid_config(self, factory, v4, exception):
+        v4.side_effect = exception
         with pytest.raises(InvalidConfiguration):
-            factory(UID, NAME, IMAGE, {"version": 3}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)
+            factory(UID, NAME, IMAGE, {"version": 4}, TEAMS, TAGS, DEPLOYMENT_ID, NAMESPACE, None, None)

--- a/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
+++ b/tests/fiaas_deploy_daemon/specs/v3/test_v3factory.py
@@ -91,6 +91,12 @@ TEST_DATA = {
         "strongbox.iam_role": None,
         "strongbox.groups": None,
         "strongbox.aws_region": "eu-west-1",
+        "statefulset.enabled": False,
+        "statefulset.service_name": None,
+        "statefulset.pod_management_policy": "OrderedReady",
+        "statefulset.update_strategy.type": "RollingUpdate",
+        "statefulset.update_strategy.rolling_update_partition": None,
+        "statefulset.volume_claims": [],
     },
     "autoscaling_disabled": {
         "autoscaler.enabled": False,

--- a/tests/fiaas_deploy_daemon/web/test_web.py
+++ b/tests/fiaas_deploy_daemon/web/test_web.py
@@ -52,14 +52,14 @@ class TestEndpoints:
             assert metric_name in resp.data
 
     def test_defaults(self, client):
-        defaults_raw = pkgutil.get_data("fiaas_deploy_daemon.specs.v3", "defaults.yml")
+        defaults_raw = pkgutil.get_data("fiaas_deploy_daemon.specs.v4", "defaults.yml")
 
         resp = client.get("/defaults")
 
         assert resp.status_code == 200
         assert resp.data == defaults_raw
 
-    @pytest.mark.parametrize("version", ("2", "3"))
+    @pytest.mark.parametrize("version", ("2", "3", "4"))
     def test_defaults_versioned(self, client, version):
         defaults_raw = pkgutil.get_data(f"fiaas_deploy_daemon.specs.v{version}", "defaults.yml")
 
@@ -89,9 +89,9 @@ class TestEndpoints:
 
     def test_transform_post(self, spec_factory, client):
         app_config = "version: 2"
-        expected_response = b"version: 3\n"
+        expected_response = b"version: 4\n"
 
-        spec_factory.transform.return_value = {"version": 3}
+        spec_factory.transform.return_value = {"version": 4}
 
         resp = client.post("/transform", data=app_config)
 


### PR DESCRIPTION
## Summary

- Introduces FIAAS spec v4 with a new statefulset configuration block, defaults, and transformer/validation so v1–v3 configs continue to upgrade seamlessly.
- Adds end-to-end runtime support for stateful workloads: a StatefulSetDeployer, PVC template generation, headless service handling, autoscaler gating, and integration into the existing Kubernetes adapter.
- Updates documentation, sample manifests, and web defaults to describe v4/statefulset usage and provides a “What’s new” guide for adopters.
